### PR TITLE
Add 'updated' Column to Queue Table for Enhanced Feature Support

### DIFF
--- a/src/PgQueuer/cli.py
+++ b/src/PgQueuer/cli.py
@@ -179,6 +179,19 @@ def cliparser() -> argparse.Namespace:
         ),
     )
 
+    subparsers.add_parser(
+        "upgrade",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        parents=[common_arguments],
+    ).add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Prints the SQL statements that would be executed without "
+            "actually applying any changes to the database."
+        ),
+    )
+
     dashboardparser = subparsers.add_parser(
         "dashboard",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -252,6 +265,10 @@ async def main() -> None:
                 print(QueryBuilder().create_uninstall_query())
                 if not parsed.dry_run:
                     await queries.uninstall()
+            case "upgrade":
+                print("\n".join(QueryBuilder().create_upgrade_queries()))
+                if not parsed.dry_run:
+                    await queries.upgrade()
             case "dashboard":
                 await fetch_and_display(
                     queries,

--- a/src/PgQueuer/qm.py
+++ b/src/PgQueuer/qm.py
@@ -115,6 +115,13 @@ class QueueManager:
         Continuously listens for events and dispatches jobs. Manages connections and
         tasks, logs timeouts, and resets connections upon termination.
         """
+
+        if not (await self.queries.has_updated_column()):
+            logger.warning(
+                f"The {self.queries.qb.settings.queue_table} table is missing the "
+                "updated column, please run 'python3 -m PgQueuer upgrade'"
+            )
+
         async with (
             self.pool.acquire() as connection,
             TaskManager() as tm,


### PR DESCRIPTION
The update introduces an 'updated' column to the queue table, which will be used for future features like retry and rate limiting. Key changes include:

- Addition of the 'upgrade' command in the CLI to handle schema updates.
- New upgrade logic in `QueueManager` to check for the 'updated' column and log a warning if missing.
- Updates to the table creation and query logic to incorporate the 'updated' column.