### PR TITLE
BREAKING; Implement `AsyncPGDriver` for Database Operations in PgQueuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,28 @@ Here's how you can use PgQueuer in a typical scenario processing incoming data m
 import asyncio
 
 import asyncpg
+from PgQueuer.db import AsyncPGDriver
 from PgQueuer.models import Job
 from PgQueuer.qm import QueueManager
 
 
 async def main() -> None:
-    pool = await asyncpg.create_pool(min_size=2)
-    qm = QueueManager(pool)
+    connection = await asyncpg.connect()
+    driver = AsyncPGDriver(connection)
+    qm = QueueManager(driver)
 
-    N = 1_000
-    # Enqueue messages.
-    for n in range(N):
-        await qm.queries.enqueue("fetch", f"this is from me: {n}".encode())
-
+    # Setup the 'fetch' entrypoint
     @qm.entrypoint("fetch")
     async def process_message(job: Job) -> None:
         print(f"Processed message: {job}")
+
+    N = 1_000
+    # Enqueue jobs.
+    await qm.queries.enqueue(
+        ["fetch"] * N,
+        [f"this is from me: {n}".encode() for n in range(N)],
+        [0] * N,
+    )
 
     await qm.run()
 

--- a/src/PgQueuer/cli.py
+++ b/src/PgQueuer/cli.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 import asyncpg
 from tabulate import tabulate, tabulate_formats
 
-from PgQueuer.db import AsyncPGDriver, Driver
+from PgQueuer.db import AsyncpgDriver, Driver
 from PgQueuer.listeners import initialize_event_listener
 from PgQueuer.models import LogStatistics, PGChannel
 from PgQueuer.queries import DBSettings, Queries, QueryBuilder
@@ -253,7 +253,7 @@ async def main() -> None:
         user=parsed.pg_user,
         host=parsed.pg_host,
     )
-    driver = AsyncPGDriver(connection)
+    driver = AsyncpgDriver(connection)
     queries = Queries(driver)
 
     match parsed.command:

--- a/src/PgQueuer/cli.py
+++ b/src/PgQueuer/cli.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 import asyncpg
 from tabulate import tabulate, tabulate_formats
 
+from PgQueuer.db import Driver
 from PgQueuer.listeners import initialize_event_listener
 from PgQueuer.models import LogStatistics, PGChannel
 from PgQueuer.queries import DBSettings, Queries, QueryBuilder
@@ -44,16 +45,15 @@ async def display_stats(
 
 
 async def display_pg_channel(
-    pool: asyncpg.Pool,
+    connection: Driver,
     channel: PGChannel,
 ) -> None:
-    async with pool.acquire() as connection:
-        listener = await initialize_event_listener(
-            connection,  # type: ignore[arg-type]
-            channel,
-        )
-        while True:
-            print(repr(await listener.get()))
+    listener = await initialize_event_listener(
+        connection,
+        channel,
+    )
+    while True:
+        print(repr(await listener.get()))
 
 
 async def fetch_and_display(

--- a/src/PgQueuer/db.py
+++ b/src/PgQueuer/db.py
@@ -1,3 +1,9 @@
+"""Database Abstraction Layer for PgQueuer.
+
+This module provides database driver abstractions and a specific implementation
+for AsyncPG to handle database operations asynchronously.
+"""
+
 import asyncio
 from typing import Any, Callable, Protocol, Sequence
 
@@ -5,74 +11,64 @@ import asyncpg
 
 
 class Driver(Protocol):
-    async def fetch(
-        self,
-        query: str,
-        *args: Any,
-    ) -> list[Any]: ...
-    async def execute(
-        self,
-        query: str,
-        *args: Any,
-    ) -> str: ...
-    async def executemany(
-        self,
-        query: str,
-        *args: Sequence,
-    ) -> None: ...
+    """
+    Defines a protocol for database drivers with essential database operations.
+    """
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        """Fetch multiple records from the database."""
+
+    async def execute(self, query: str, *args: Any) -> str:
+        """Execute a single query and return a status message."""
+
+    async def executemany(self, query: str, *args: Sequence) -> None:
+        """Execute a query multiple times with a list of parameters."""
+
     async def add_listener(
-        self,
-        channal: str,
-        callback: Callable[[str | bytes | bytearray], None],
-    ) -> None: ...
-    async def fetchval(
-        self,
-        query: str,
-        *args: Any,
-    ) -> Any: ...
+        self, channel: str, callback: Callable[[str | bytes | bytearray], None]
+    ) -> None:
+        """Add a listener for a specific PostgreSQL NOTIFY channel."""
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        """Fetch a single value from the database."""
 
 
 class AsyncPGDriver(Driver):
+    """
+    Implements the Driver protocol using AsyncPG for PostgreSQL database operations.
+    """
+
     def __init__(self, connection: asyncpg.Connection) -> None:
-        super().__init__()
+        """Initialize the driver with an AsyncPG connection."""
         self.lock = asyncio.Lock()
         self.connection = connection
 
-    async def fetch(
-        self,
-        query: str,
-        *args: Any,
-    ) -> list:
+    async def fetch(self, query: str, *args: Any) -> list:
+        """Fetch records with query locking to ensure thread safety."""
         async with self.lock:
             return await self.connection.fetch(query, *args)
 
-    async def execute(
-        self,
-        query: str,
-        *args: Any,
-    ) -> str:
+    async def execute(self, query: str, *args: Any) -> str:
+        """Execute a query with locking to avoid concurrent access issues."""
         async with self.lock:
             return await self.connection.execute(query, *args)
 
-    async def executemany(
-        self,
-        query: str,
-        *args: Sequence,
-    ) -> None:
+    async def executemany(self, query: str, *args: Sequence) -> None:
+        """Execute a query multiple times, protected by a lock."""
         async with self.lock:
             return await self.connection.executemany(query, *args)
 
     async def fetchval(self, query: str, *args: Any) -> Any:
+        """Fetch a single value with concurrency protection."""
         async with self.lock:
             return await self.connection.fetchval(query, *args)
 
     async def add_listener(
-        self,
-        channal: str,
-        callback: Callable[[str | bytes | bytearray], None],
+        self, channel: str, callback: Callable[[str | bytes | bytearray], None]
     ) -> None:
+        """Add a database listener with locking to manage concurrency."""
         async with self.lock:
             await self.connection.add_listener(
-                channal,
+                channel,
                 lambda *x: callback(x[-1]),
             )

--- a/src/PgQueuer/db.py
+++ b/src/PgQueuer/db.py
@@ -1,0 +1,78 @@
+import asyncio
+from typing import Any, Callable, Protocol, Sequence
+
+import asyncpg
+
+
+class Driver(Protocol):
+    async def fetch(
+        self,
+        query: str,
+        *args: Any,
+    ) -> list[Any]: ...
+    async def execute(
+        self,
+        query: str,
+        *args: Any,
+    ) -> str: ...
+    async def executemany(
+        self,
+        query: str,
+        *args: Sequence,
+    ) -> None: ...
+    async def add_listener(
+        self,
+        channal: str,
+        callback: Callable[[str | bytes | bytearray], None],
+    ) -> None: ...
+    async def fetchval(
+        self,
+        query: str,
+        *args: Any,
+    ) -> Any: ...
+
+
+class AsyncPGDriver(Driver):
+    def __init__(self, connection: asyncpg.Connection) -> None:
+        super().__init__()
+        self.lock = asyncio.Lock()
+        self.connection = connection
+
+    async def fetch(
+        self,
+        query: str,
+        *args: Any,
+    ) -> list:
+        async with self.lock:
+            return await self.connection.fetch(query, *args)
+
+    async def execute(
+        self,
+        query: str,
+        *args: Any,
+    ) -> str:
+        async with self.lock:
+            return await self.connection.execute(query, *args)
+
+    async def executemany(
+        self,
+        query: str,
+        *args: Sequence,
+    ) -> None:
+        async with self.lock:
+            return await self.connection.executemany(query, *args)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        async with self.lock:
+            return await self.connection.fetchval(query, *args)
+
+    async def add_listener(
+        self,
+        channal: str,
+        callback: Callable[[str | bytes | bytearray], None],
+    ) -> None:
+        async with self.lock:
+            await self.connection.add_listener(
+                channal,
+                lambda x: callback(x[-1]),
+            )

--- a/src/PgQueuer/db.py
+++ b/src/PgQueuer/db.py
@@ -74,5 +74,5 @@ class AsyncPGDriver(Driver):
         async with self.lock:
             await self.connection.add_listener(
                 channal,
-                lambda x: callback(x[-1]),
+                lambda *x: callback(x[-1]),
             )

--- a/src/PgQueuer/db.py
+++ b/src/PgQueuer/db.py
@@ -33,7 +33,7 @@ class Driver(Protocol):
         """Fetch a single value from the database."""
 
 
-class AsyncPGDriver(Driver):
+class AsyncpgDriver(Driver):
     """
     Implements the Driver protocol using AsyncPG for PostgreSQL database operations.
     """

--- a/src/PgQueuer/listeners.py
+++ b/src/PgQueuer/listeners.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import asyncio
 
-import asyncpg
-
 from . import models
+from .db import Driver
 from .logconfig import logger
 
 
@@ -23,7 +22,7 @@ class PGEventListener(asyncio.Queue[models.Event]):
 
 
 async def initialize_event_listener(
-    pg_connection: asyncpg.Connection,
+    pg_connection: Driver,
     pg_channel: models.PGChannel,
 ) -> PGEventListener:
     """
@@ -58,5 +57,5 @@ async def initialize_event_listener(
     await pg_connection.add_listener(
         pg_channel, lambda *x: parse_and_queue(x[-1], listener)
     )
-    pg_connection.add_termination_listener(_critical_termination_listener)
+    # pg_connection.add_termination_listener(_critical_termination_listener)
     return listener

--- a/src/PgQueuer/listeners.py
+++ b/src/PgQueuer/listeners.py
@@ -22,8 +22,8 @@ class PGEventListener(asyncio.Queue[models.Event]):
 
 
 async def initialize_event_listener(
-    pg_connection: Driver,
-    pg_channel: models.PGChannel,
+    connection: Driver,
+    channel: models.PGChannel,
 ) -> PGEventListener:
     """
     This method establishes a listener on a PostgreSQL channel using
@@ -54,8 +54,6 @@ async def initialize_event_listener(
             )
 
     listener = PGEventListener()
-    await pg_connection.add_listener(
-        pg_channel, lambda *x: parse_and_queue(x[-1], listener)
-    )
+    await connection.add_listener(channel, lambda *x: parse_and_queue(x[-1], listener))
     # pg_connection.add_termination_listener(_critical_termination_listener)
     return listener

--- a/src/PgQueuer/listeners.py
+++ b/src/PgQueuer/listeners.py
@@ -7,13 +7,6 @@ from .db import Driver
 from .logconfig import logger
 
 
-def _critical_termination_listener(*_: object, **__: object) -> None:
-    # Must be defined in the global namespace, as ayncpg keeps
-    # a set of functions to call. This this will now happen once as
-    # all instance will point to the same function.
-    logger.critical("Connection is closed / terminated.")
-
-
 class PGEventListener(asyncio.Queue[models.Event]):
     """
     A PostgreSQL event queue that listens to a specified
@@ -55,5 +48,4 @@ async def initialize_event_listener(
 
     listener = PGEventListener()
     await connection.add_listener(channel, lambda *x: parse_and_queue(x[-1], listener))
-    # pg_connection.add_termination_listener(_critical_termination_listener)
     return listener

--- a/src/PgQueuer/qm.py
+++ b/src/PgQueuer/qm.py
@@ -134,7 +134,7 @@ class QueueManager:
             )
 
         async with TaskManager() as tm:
-            listener = await initialize_event_listener(self.connection, self.channel)  # type: ignore[arg-type]
+            listener = await initialize_event_listener(self.connection, self.channel)
 
             while self.alive:
                 while self.alive and (

--- a/src/PgQueuer/qm.py
+++ b/src/PgQueuer/qm.py
@@ -159,9 +159,6 @@ class QueueManager:
                         dequeue_timeout,
                     )
 
-            ## connection.remove_termination_listener(_critical_termination_listener)
-            ## await connection.reset()
-
     async def _dispatch(self, job: Job) -> None:
         """
         Handles asynchronous job dispatch. Logs exceptions, updates job status,

--- a/src/PgQueuer/qm.py
+++ b/src/PgQueuer/qm.py
@@ -17,10 +17,9 @@ from typing import (
 
 import anyio
 import anyio.to_thread
-import asyncpg
 
 from .db import Driver
-from .listeners import _critical_termination_listener, initialize_event_listener
+from .listeners import initialize_event_listener
 from .logconfig import logger
 from .models import Job, PGChannel
 from .queries import DBSettings, Queries

--- a/src/PgQueuer/queries.py
+++ b/src/PgQueuer/queries.py
@@ -460,11 +460,13 @@ class Queries:
 
         await self.pool.executemany(
             self.qb.create_enqueue_query(),
-            zip(
-                normed_priority,
-                normed_entrypoint,
-                normed_payload,
-                strict=True,
+            list(
+                zip(
+                    normed_priority,
+                    normed_entrypoint,
+                    normed_payload,
+                    strict=True,
+                )
             ),
         )
 
@@ -525,9 +527,7 @@ class Queries:
         ]
 
     async def upgrade(self) -> None:
-        async with self.pool.acquire() as conn, conn.transaction():
-            for query in self.qb.create_upgrade_queries():
-                await conn.execute(query)
+        await self.pool.execute("\n\n".join(self.qb.create_upgrade_queries()))
 
     async def has_updated_column(self) -> bool:
         return await self.pool.fetchval(

--- a/src/PgQueuer/queries.py
+++ b/src/PgQueuer/queries.py
@@ -385,7 +385,7 @@ class Queries:
     enqueueing, dequeueing, and querying the size of the queue.
     """
 
-    pool: db.Driver
+    driver: db.Driver
     qb: QueryBuilder = dataclasses.field(default_factory=QueryBuilder)
 
     async def install(self) -> None:
@@ -394,14 +394,14 @@ class Queries:
         tables, and triggers for job queuing and logging.
         """
 
-        await self.pool.execute(self.qb.create_install_query())
+        await self.driver.execute(self.qb.create_install_query())
 
     async def uninstall(self) -> None:
         """
         Drops all database structures related to job queuing
         and logging that were created by the install method.
         """
-        await self.pool.execute(self.qb.create_uninstall_query())
+        await self.driver.execute(self.qb.create_uninstall_query())
 
     async def dequeue(
         self,
@@ -427,7 +427,7 @@ class Queries:
         if retry_timer and retry_timer < timedelta(seconds=0):
             raise ValueError("Retry timer must be a non-negative timedelta")
 
-        rows = await self.pool.fetch(
+        rows = await self.driver.fetch(
             self.qb.create_dequeue_query(),
             batch_size,
             entrypoints,
@@ -456,7 +456,7 @@ class Queries:
         normed_payload = payload if isinstance(payload, list) else [payload]
         normed_priority = priority if isinstance(priority, list) else [priority]
 
-        await self.pool.executemany(
+        await self.driver.executemany(
             self.qb.create_enqueue_query(),
             list(
                 zip(
@@ -473,12 +473,12 @@ class Queries:
         Clears jobs from the queue, optionally filtering by entrypoint if specified.
         """
         await (
-            self.pool.execute(
+            self.driver.execute(
                 self.qb.create_delete_from_queue_query(),
                 [entrypoint] if isinstance(entrypoint, str) else entrypoint,
             )
             if entrypoint
-            else self.pool.execute(self.qb.create_truncate_queue_query())
+            else self.driver.execute(self.qb.create_truncate_queue_query())
         )
 
     async def queue_size(self) -> list[models.QueueStatistics]:
@@ -487,7 +487,7 @@ class Queries:
         """
         return [
             models.QueueStatistics.model_validate(dict(x))
-            for x in await self.pool.fetch(self.qb.create_queue_size_query())
+            for x in await self.driver.fetch(self.qb.create_queue_size_query())
         ]
 
     async def log_job(self, job: models.Job, status: models.STATUS_LOG) -> None:
@@ -495,7 +495,7 @@ class Queries:
         Moves a completed or failed job from the queue table to the log
         table, recording its final status and duration.
         """
-        await self.pool.execute(
+        await self.driver.execute(
             self.qb.create_log_job_query(),
             job.id,
             job.priority,
@@ -510,25 +510,27 @@ class Queries:
         by entrypoint if specified.
         """
         await (
-            self.pool.execute(
+            self.driver.execute(
                 self.qb.create_delete_from_log_query(),
                 [entrypoint] if isinstance(entrypoint, str) else entrypoint,
             )
             if entrypoint
-            else self.pool.execute(self.qb.create_truncate_log_query())
+            else self.driver.execute(self.qb.create_truncate_log_query())
         )
 
     async def log_statistics(self, tail: int) -> list[models.LogStatistics]:
         return [
             models.LogStatistics.model_validate(dict(x))
-            for x in await self.pool.fetch(self.qb.create_log_statistics_query(), tail)
+            for x in await self.driver.fetch(
+                self.qb.create_log_statistics_query(), tail
+            )
         ]
 
     async def upgrade(self) -> None:
-        await self.pool.execute("\n\n".join(self.qb.create_upgrade_queries()))
+        await self.driver.execute("\n\n".join(self.qb.create_upgrade_queries()))
 
     async def has_updated_column(self) -> bool:
-        return await self.pool.fetchval(
+        return await self.driver.fetchval(
             self.qb.create_has_column_query(),
             self.qb.settings.queue_table,
             "updated",

--- a/src/PgQueuer/queries.py
+++ b/src/PgQueuer/queries.py
@@ -7,7 +7,7 @@ from typing import Final, Generator
 
 import asyncpg
 
-from . import models
+from . import db, models
 
 
 def add_prefix(string: str) -> str:
@@ -387,7 +387,7 @@ class Queries:
     enqueueing, dequeueing, and querying the size of the queue.
     """
 
-    pool: asyncpg.Pool
+    pool: db.Driver
     qb: QueryBuilder = dataclasses.field(default_factory=QueryBuilder)
 
     async def install(self) -> None:

--- a/src/PgQueuer/queries.py
+++ b/src/PgQueuer/queries.py
@@ -5,8 +5,6 @@ import os
 from datetime import timedelta
 from typing import Final, Generator
 
-import asyncpg
-
 from . import db, models
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator
 
 import asyncpg
 import pytest
-from PgQueuer.db import AsyncPGDriver, Driver
+from PgQueuer.db import AsyncpgDriver, Driver
 
 
 def dsn(
@@ -29,7 +29,7 @@ async def pgdriver() -> AsyncGenerator[Driver, None]:
     conn_a = await asyncpg.connect(dsn=dsn(database="postgres"))
     async with create_test_database(database, conn_a):
         conn_b = await asyncpg.connect(dsn=dsn(database=database))
-        yield AsyncPGDriver(conn_b)
+        yield AsyncpgDriver(conn_b)
     await asyncio.gather(conn_a.close(), conn_b.close())
 
 

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -2,8 +2,8 @@ import asyncio
 import time
 from contextlib import suppress
 
-import asyncpg
 import pytest
+from PgQueuer import db
 from PgQueuer.models import Job
 from PgQueuer.qm import QueueManager
 from PgQueuer.queries import Queries
@@ -11,7 +11,7 @@ from PgQueuer.queries import Queries
 
 @pytest.mark.parametrize("N", (1, 2, 32))
 async def test_job_queing(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
 ) -> None:
     c = QueueManager(pgdriver)
@@ -41,7 +41,7 @@ async def test_job_queing(
 @pytest.mark.parametrize("N", (1, 2, 32))
 @pytest.mark.parametrize("concurrency", (1, 2, 3, 4))
 async def test_job_fetch(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
     concurrency: int,
 ) -> None:
@@ -79,7 +79,7 @@ async def test_job_fetch(
 @pytest.mark.parametrize("N", (1, 2, 32))
 @pytest.mark.parametrize("concurrency", (1, 2, 3, 4))
 async def test_sync_entrypoint(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
     concurrency: int,
 ) -> None:
@@ -116,7 +116,7 @@ async def test_sync_entrypoint(
 
 
 async def test_pick_local_entrypoints(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
 ) -> None:
     q = Queries(pgdriver)
     qm = QueueManager(pgdriver)

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -11,10 +11,10 @@ from PgQueuer.queries import Queries
 
 @pytest.mark.parametrize("N", (1, 2, 32))
 async def test_job_queing(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
 ) -> None:
-    c = QueueManager(pgpool)
+    c = QueueManager(pgdriver)
     seen = list[int]()
 
     @c.entrypoint("fetch")
@@ -41,12 +41,12 @@ async def test_job_queing(
 @pytest.mark.parametrize("N", (1, 2, 32))
 @pytest.mark.parametrize("concurrency", (1, 2, 3, 4))
 async def test_job_fetch(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
     concurrency: int,
 ) -> None:
-    q = Queries(pgpool)
-    qmpool = [QueueManager(pgpool) for _ in range(concurrency)]
+    q = Queries(pgdriver)
+    qmpool = [QueueManager(pgdriver) for _ in range(concurrency)]
     seen = list[int]()
 
     for qm in qmpool:
@@ -79,12 +79,12 @@ async def test_job_fetch(
 @pytest.mark.parametrize("N", (1, 2, 32))
 @pytest.mark.parametrize("concurrency", (1, 2, 3, 4))
 async def test_sync_entrypoint(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
     concurrency: int,
 ) -> None:
-    q = Queries(pgpool)
-    qmpool = [QueueManager(pgpool) for _ in range(concurrency)]
+    q = Queries(pgdriver)
+    qmpool = [QueueManager(pgdriver) for _ in range(concurrency)]
     seen = list[int]()
 
     for qm in qmpool:
@@ -116,10 +116,10 @@ async def test_sync_entrypoint(
 
 
 async def test_pick_local_entrypoints(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
 ) -> None:
-    q = Queries(pgpool)
-    qm = QueueManager(pgpool)
+    q = Queries(pgdriver)
+    qm = QueueManager(pgdriver)
 
     @qm.entrypoint("to_be_picked")
     async def to_be_picked(job: Job) -> None:

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -1,13 +1,12 @@
 import asyncio
 from datetime import timedelta
 
-import asyncpg
 import pytest
-from PgQueuer import models, queries
+from PgQueuer import db, models, queries
 
 
 @pytest.mark.parametrize("N", (1, 2, 64))
-async def test_queries_put(pgdriver: asyncpg.Pool, N: int) -> None:
+async def test_queries_put(pgdriver: db.Driver, N: int) -> None:
     q = queries.Queries(pgdriver)
 
     assert sum(x.count for x in await q.queue_size()) == 0
@@ -20,7 +19,7 @@ async def test_queries_put(pgdriver: asyncpg.Pool, N: int) -> None:
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queries_next_jobs(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
 ) -> None:
     q = queries.Queries(pgdriver)
@@ -45,7 +44,7 @@ async def test_queries_next_jobs(
 @pytest.mark.parametrize("N", (1, 2, 64))
 @pytest.mark.parametrize("concurrency", (1, 2, 4, 16))
 async def test_queries_next_jobs_concurrent(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
     concurrency: int,
 ) -> None:
@@ -78,7 +77,7 @@ async def test_queries_next_jobs_concurrent(
     assert sorted(seen) == list(range(N))
 
 
-async def test_queries_clear(pgdriver: asyncpg.Pool) -> None:
+async def test_queries_clear(pgdriver: db.Driver) -> None:
     q = queries.Queries(pgdriver)
     await q.clear_queue()
     assert sum(x.count for x in await q.queue_size()) == 0
@@ -92,7 +91,7 @@ async def test_queries_clear(pgdriver: asyncpg.Pool) -> None:
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_move_job_log(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
 ) -> None:
     q = queries.Queries(pgdriver)
@@ -115,7 +114,7 @@ async def test_move_job_log(
 
 @pytest.mark.parametrize("N", (1, 2, 5))
 async def test_clear_queue(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
 ) -> None:
     q = queries.Queries(pgdriver)
@@ -159,7 +158,7 @@ async def test_clear_queue(
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_priority(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
 ) -> None:
     q = queries.Queries(pgdriver)
@@ -184,7 +183,7 @@ async def test_queue_priority(
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_retry_timer(
-    pgdriver: asyncpg.Pool,
+    pgdriver: db.Driver,
     N: int,
     retry_timer: timedelta = timedelta(seconds=0.1),
 ) -> None:
@@ -216,7 +215,7 @@ async def test_queue_retry_timer(
     assert len(jobs) == N
 
 
-async def test_queue_retry_timer_negative_raises(pgdriver: asyncpg.Pool) -> None:
+async def test_queue_retry_timer_negative_raises(pgdriver: db.Driver) -> None:
     with pytest.raises(ValueError):
         await queries.Queries(pgdriver).dequeue(
             entrypoints={"placeholder"},

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -49,7 +49,6 @@ async def test_queries_next_jobs_concurrent(
     N: int,
     concurrency: int,
 ) -> None:
-    assert pgpool.get_max_size() >= concurrency
     q = queries.Queries(pgpool)
 
     await q.enqueue(

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -7,8 +7,8 @@ from PgQueuer import models, queries
 
 
 @pytest.mark.parametrize("N", (1, 2, 64))
-async def test_queries_put(pgpool: asyncpg.Pool, N: int) -> None:
-    q = queries.Queries(pgpool)
+async def test_queries_put(pgdriver: asyncpg.Pool, N: int) -> None:
+    q = queries.Queries(pgdriver)
 
     assert sum(x.count for x in await q.queue_size()) == 0
 
@@ -20,10 +20,10 @@ async def test_queries_put(pgpool: asyncpg.Pool, N: int) -> None:
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queries_next_jobs(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
 ) -> None:
-    q = queries.Queries(pgpool)
+    q = queries.Queries(pgdriver)
 
     await q.enqueue(
         ["placeholder"] * N,
@@ -45,11 +45,11 @@ async def test_queries_next_jobs(
 @pytest.mark.parametrize("N", (1, 2, 64))
 @pytest.mark.parametrize("concurrency", (1, 2, 4, 16))
 async def test_queries_next_jobs_concurrent(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
     concurrency: int,
 ) -> None:
-    q = queries.Queries(pgpool)
+    q = queries.Queries(pgdriver)
 
     await q.enqueue(
         ["placeholder"] * N,
@@ -78,8 +78,8 @@ async def test_queries_next_jobs_concurrent(
     assert sorted(seen) == list(range(N))
 
 
-async def test_queries_clear(pgpool: asyncpg.Pool) -> None:
-    q = queries.Queries(pgpool)
+async def test_queries_clear(pgdriver: asyncpg.Pool) -> None:
+    q = queries.Queries(pgdriver)
     await q.clear_queue()
     assert sum(x.count for x in await q.queue_size()) == 0
 
@@ -92,10 +92,10 @@ async def test_queries_clear(pgpool: asyncpg.Pool) -> None:
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_move_job_log(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
 ) -> None:
-    q = queries.Queries(pgpool)
+    q = queries.Queries(pgdriver)
 
     await q.enqueue(
         ["placeholder"] * N,
@@ -115,10 +115,10 @@ async def test_move_job_log(
 
 @pytest.mark.parametrize("N", (1, 2, 5))
 async def test_clear_queue(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
 ) -> None:
-    q = queries.Queries(pgpool)
+    q = queries.Queries(pgdriver)
 
     # Test delete all by listing all
     await q.enqueue(
@@ -159,10 +159,10 @@ async def test_clear_queue(
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_priority(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
 ) -> None:
-    q = queries.Queries(pgpool)
+    q = queries.Queries(pgdriver)
     jobs = list[models.Job]()
 
     await q.enqueue(
@@ -184,11 +184,11 @@ async def test_queue_priority(
 
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_retry_timer(
-    pgpool: asyncpg.Pool,
+    pgdriver: asyncpg.Pool,
     N: int,
     retry_timer: timedelta = timedelta(seconds=0.1),
 ) -> None:
-    q = queries.Queries(pgpool)
+    q = queries.Queries(pgdriver)
     jobs = list[models.Job]()
 
     await q.enqueue(
@@ -216,16 +216,16 @@ async def test_queue_retry_timer(
     assert len(jobs) == N
 
 
-async def test_queue_retry_timer_negative_raises(pgpool: asyncpg.Pool) -> None:
+async def test_queue_retry_timer_negative_raises(pgdriver: asyncpg.Pool) -> None:
     with pytest.raises(ValueError):
-        await queries.Queries(pgpool).dequeue(
+        await queries.Queries(pgdriver).dequeue(
             entrypoints={"placeholder"},
             batch_size=10,
             retry_timer=-timedelta(seconds=0.001),
         )
 
     with pytest.raises(ValueError):
-        await queries.Queries(pgpool).dequeue(
+        await queries.Queries(pgdriver).dequeue(
             entrypoints={"placeholder"},
             batch_size=10,
             retry_timer=timedelta(seconds=-0.001),

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -8,7 +8,7 @@ from itertools import count
 from typing import Callable, Generator
 
 import asyncpg
-from PgQueuer.db import AsyncPGDriver
+from PgQueuer.db import AsyncpgDriver
 from PgQueuer.models import Job
 from PgQueuer.qm import QueueManager
 from PgQueuer.queries import Queries
@@ -114,7 +114,7 @@ Enqueue:                {args.enqueue}
 Enqueue Batch Size:     {args.enqueue_batch_size}
 """)
 
-    util_driver = AsyncPGDriver(await asyncpg.connect())
+    util_driver = AsyncpgDriver(await asyncpg.connect())
 
     util_queries = Queries(util_driver)
 
@@ -127,20 +127,20 @@ Enqueue Batch Size:     {args.enqueue_batch_size}
         cnt = count()
         bs = int(args.enqueue_batch_size)
 
-        queries = list[tuple[AsyncPGDriver, Queries]]()
+        queries = list[tuple[AsyncpgDriver, Queries]]()
 
         for _ in range(bs):
-            driver = AsyncPGDriver(await asyncpg.connect())
+            driver = AsyncpgDriver(await asyncpg.connect())
             queries.append((driver, Queries(driver)))
 
         await asyncio.gather(*[producer(alive, q, bs, cnt) for _, q in queries])
 
     async def dequeue() -> list[float]:
         bs = int(args.dequeue_batch_size)
-        queries = list[tuple[AsyncPGDriver, Queries]]()
+        queries = list[tuple[AsyncpgDriver, Queries]]()
 
         for _ in range(bs):
-            driver = AsyncPGDriver(await asyncpg.connect())
+            driver = AsyncpgDriver(await asyncpg.connect())
             queries.append((driver, Queries(driver)))
 
         qms = [QueueManager(d) for d, _ in queries]

--- a/tools/ex.py
+++ b/tools/ex.py
@@ -1,14 +1,14 @@
 import asyncio
 
 import asyncpg
-from PgQueuer.db import AsyncPGDriver
+from PgQueuer.db import AsyncpgDriver
 from PgQueuer.models import Job
 from PgQueuer.qm import QueueManager
 
 
 async def main() -> None:
     connection = await asyncpg.connect()
-    driver = AsyncPGDriver(connection)
+    driver = AsyncpgDriver(connection)
     qm = QueueManager(driver)
 
     # Setup the 'fetch' entrypoint

--- a/tools/ex.py
+++ b/tools/ex.py
@@ -1,17 +1,15 @@
 import asyncio
 
 import asyncpg
+from PgQueuer.db import AsyncPGDriver
 from PgQueuer.models import Job
 from PgQueuer.qm import QueueManager
 
 
 async def main() -> None:
-    pool = await asyncpg.create_pool(min_size=2)
-
-    # mypy wtf?
-    assert isinstance(pool, asyncpg.Pool)
-
-    qm = QueueManager(pool)
+    connection = await asyncpg.connect()
+    driver = AsyncPGDriver(connection)
+    qm = QueueManager(driver)
 
     # Setup the 'fetch' entrypoint
     @qm.entrypoint("fetch")


### PR DESCRIPTION
This PR replaces direct `asyncpg` usage with `AsyncPGDriver` across PgQueuer. The new driver centralizes database interactions, improving code modularity and simplifying future enhancements.

**Major Changes:**
- Introduced `AsyncPGDriver` in `db.py`, implementing database operations.
- Refactored `QueueManager`, CLI tools, and tests to use the new driver.

This update streamlines database handling and enhances the maintainability of the codebase.

NOTE; Major performance drop(6k -> 1.5k), a followup PR with batched queries is needed (Have a poc showing 6k -> ~13k job per second)