### PR TITLE
Normalize line endings when building test docker image

### DIFF
--- a/test/db/Dockerfile
+++ b/test/db/Dockerfile
@@ -12,7 +12,7 @@ ENV PGPORT=5432
 # Install Python and Pip
 ENV VIRTUAL_ENV=/opt/venv
 RUN apt-get update && \
-    apt-get install -y python3-pip python3-full git && \
+    apt-get install -y python3-pip python3-full git dos2unix && \
     rm -rf /var/lib/apt/lists/*  && \
     python3 -m venv $VIRTUAL_ENV
 
@@ -24,3 +24,4 @@ RUN cd src && pip install -e ".[asyncpg]"
 
 # # Copy the combined database setup script into the container
 COPY --chmod=0755 test/db/init_db.sh /docker-entrypoint-initdb.d/init_db.sh
+RUN dos2unix /docker-entrypoint-initdb.d/init_db.sh


### PR DESCRIPTION
This was a small quality-of-life issue that I ran into when setting up development on a windows machine. Git checks out the `init_db.sh` script with CRLF line endings, which causes issues for the docker image. 