### PR TITLE
Add configuration arguments to CLI run subcommand

### DIFF
--- a/pgqueuer/cli.py
+++ b/pgqueuer/cli.py
@@ -245,6 +245,32 @@ def cliparser() -> argparse.Namespace:
         parents=[common_arguments],
     )
     wm_parser.add_argument(
+        "--dequeue-timeout",
+        help=(
+            "Specifies timeout (in seconds) to wait to dequeue jobs "
+            "(see the 'dequeue_timeout' argument of 'QueueManager.run')"
+        ),
+        type=lambda s: timedelta(seconds=float(s)),
+        default=timedelta(seconds=30.0),
+    )
+    wm_parser.add_argument(
+        "--batch-size",
+        help=(
+            "Specifies the number of jobs to dequeue in each batch "
+            "(see the 'batch_size' argument of 'QueueManager.run')"
+        ),
+        type=int,
+        default=10,
+    )
+    wm_parser.add_argument(
+        "--retry-timer",
+        help=(
+            "Specifies time to wait (in seconds) before retrying jobs "
+            "(see the 'retry_timer' argument of 'QueueManager.run')"
+        ),
+        type=lambda s: timedelta(seconds=float(s)),
+    )
+    wm_parser.add_argument(
         "qm_factory",
         help=("Path to the QueueManager factory function, e.g., " '"myapp.create_queue_manager"'),
     )
@@ -319,4 +345,9 @@ async def main() -> None:  # noqa: C901
                 PGChannel(parsed.channel),
             )
         case "run":
-            await supervisor.runit(parsed.qm_factory)
+            await supervisor.runit(
+                parsed.qm_factory,
+                dequeue_timeout=parsed.dequeue_timeout,
+                batch_size=parsed.batch_size,
+                retry_timer=parsed.retry_timer,
+            )

--- a/pgqueuer/supervisor.py
+++ b/pgqueuer/supervisor.py
@@ -18,9 +18,13 @@ def load_queue_manager_factory(factory_path: str) -> QM_FACTORY:
     return getattr(module, factory_name)
 
 
-async def runit(factory_fn: str) -> None:
+async def runit(factory_fn: str, **kwargs) -> None:
     """
     Main function to instantiate and manage the lifecycle of a QueueManager.
+
+    Parameters:
+        - factory_fn: module and function path to a function returning a QueueManager
+        - **kwargs: keyword arguments passed through to QueueManager.run
     """
     qm_factory = load_queue_manager_factory(factory_fn)
     qm = await qm_factory()  # Create the QueueManager instance
@@ -36,4 +40,4 @@ async def runit(factory_fn: str) -> None:
     signal.signal(signal.SIGINT, graceful_shutdown)  # Handle Ctrl-C
     signal.signal(signal.SIGTERM, graceful_shutdown)  # Handle termination request
 
-    await qm.run()  # Start the QueueManager's operation
+    await qm.run(**kwargs)  # Start the QueueManager's operation

--- a/pgqueuer/supervisor.py
+++ b/pgqueuer/supervisor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 import importlib
 import signal
 from typing import Awaitable, Callable, TypeAlias
@@ -18,7 +19,9 @@ def load_queue_manager_factory(factory_path: str) -> QM_FACTORY:
     return getattr(module, factory_name)
 
 
-async def runit(factory_fn: str, **kwargs) -> None:
+async def runit(
+    factory_fn: str, dequeue_timeout: timedelta, batch_size: int, retry_timer: timedelta | None
+) -> None:
     """
     Main function to instantiate and manage the lifecycle of a QueueManager.
 
@@ -40,4 +43,5 @@ async def runit(factory_fn: str, **kwargs) -> None:
     signal.signal(signal.SIGINT, graceful_shutdown)  # Handle Ctrl-C
     signal.signal(signal.SIGTERM, graceful_shutdown)  # Handle termination request
 
-    await qm.run(**kwargs)  # Start the QueueManager's operation
+    # Start the QueueManager's operation
+    await qm.run(dequeue_timeout=dequeue_timeout, batch_size=batch_size, retry_timer=retry_timer)

--- a/pgqueuer/supervisor.py
+++ b/pgqueuer/supervisor.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import timedelta
 import importlib
 import signal
+from datetime import timedelta
 from typing import Awaitable, Callable, TypeAlias
 
 from .qm import QueueManager


### PR DESCRIPTION
Adds arguments to the CLI which mirror those of `QueueManager.run`. This allows you to use non-default configurations while using the supervisor.