### PR TITLE
show timezone in dashboard header

### DIFF
--- a/pgqueuer/cli.py
+++ b/pgqueuer/cli.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Literal
 
 from tabulate import tabulate, tabulate_formats
 
 from . import db, listeners, models, queries, supervisor
+
+__local_tz = datetime.now().astimezone().strftime("%z")
 
 
 async def display_stats(
@@ -19,7 +21,7 @@ async def display_stats(
         tabulate(
             [
                 (
-                    stat.created.astimezone(),
+                    stat.created.astimezone().strftime("%Y-%m-%d %H:%M:%S"),
                     stat.count,
                     stat.entrypoint,
                     stat.time_in_queue,
@@ -29,7 +31,7 @@ async def display_stats(
                 for stat in log_stats
             ],
             headers=[
-                "Created",
+                f"Created ({__local_tz})",
                 "Count",
                 "Entrypoint",
                 "Time in Queue (HH:MM:SS)",

--- a/pgqueuer/cli.py
+++ b/pgqueuer/cli.py
@@ -10,7 +10,6 @@ from tabulate import tabulate, tabulate_formats
 
 from . import db, listeners, models, queries, supervisor
 
-__local_tz = datetime.now().astimezone().strftime("%z")
 
 
 async def display_stats(
@@ -31,7 +30,7 @@ async def display_stats(
                 for stat in log_stats
             ],
             headers=[
-                f"Created ({__local_tz})",
+                f"Created ({datetime.now().astimezone().strftime("%Z")})",
                 "Count",
                 "Entrypoint",
                 "Time in Queue (HH:MM:SS)",


### PR DESCRIPTION
~~Currently it use `%z` as timezone, not sure how this works with Daylight Time.~~

change it to `%Z` for tz name

![image](https://github.com/user-attachments/assets/efbb759e-0261-48cf-9076-46e898994a0b)