### PR TITLE
Exponential backoff with jitter for deadlock mitigation

### DIFF
--- a/pgqueuer/helpers.py
+++ b/pgqueuer/helpers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import random
 import time
 from datetime import datetime, timedelta, timezone
 
@@ -88,3 +89,25 @@ def retry_timer_buffer_timeout(
         return min(dt for dt in dts if dt > _t0)
     except ValueError:
         return _default
+
+
+def timeout_with_jitter(
+    timeout: timedelta,
+    delay_multiplier: float,
+    jitter_span: tuple[float, float] = (0.8, 1.2),
+) -> timedelta:
+    """
+    Calculate a delay with a jitter applied.
+
+    Args:
+        base_timeout (timedelta): The base timeout as a timedelta object.
+        delay_multiplier (float): The multiplier to scale the base timeout.
+        jitter_span (tuple[float, float]): A tuple representing the lower and upper
+            bounds of the jitter range.
+
+    Returns:
+        float: The calculated delay with jitter applied, in seconds.
+        The jitter will be in the specified range of the base delay.
+    """
+    jitter = random.uniform(*jitter_span)
+    return timedelta(seconds=timeout.total_seconds() * delay_multiplier * jitter)

--- a/pgqueuer/qm.py
+++ b/pgqueuer/qm.py
@@ -282,12 +282,12 @@ class QueueManager:
             buffers.JobStatusLogBuffer(
                 max_size=batch_size,
                 timeout=job_status_log_buffer_timeout,
-                flush_callable=self.queries.log_jobs,
+                callback=self.queries.log_jobs,
             ) as jbuff,
             buffers.HeartbeatBuffer(
                 max_size=sys.maxsize,
-                timeout=heartbeat_buffer_timeout,
-                flush_callable=self.queries.notify_activity,
+                timeout=heartbeat_buffer_timeout / 2,
+                callback=self.queries.notify_activity,
             ) as hbuff,
             tm.TaskManager() as task_manager,
             self.connection,
@@ -393,7 +393,7 @@ class QueueManager:
         async with (
             heartbeat.Heartbeat(
                 job.id,
-                executor.retry_timer / 2,
+                executor.retry_timer,
                 hbuff,
             ),
             self.entrypoint_statistics[job.entrypoint].concurrency_limiter,

--- a/test/test_buffers.py
+++ b/test/test_buffers.py
@@ -1,6 +1,6 @@
 import asyncio
-import random
 from datetime import timedelta
+from itertools import count
 
 import pytest
 
@@ -9,10 +9,10 @@ from pgqueuer.helpers import perf_counter_dt
 from pgqueuer.models import Job
 
 
-def job_faker() -> Job:
+def job_faker(cnt: count = count()) -> Job:
     dt = perf_counter_dt()
     return Job(
-        id=random.choice(range(1_000_000_000)),
+        id=next(cnt),
         priority=0,
         created=dt,
         heartbeat=dt,
@@ -32,14 +32,16 @@ async def test_job_buffer_max_size(max_size: int) -> None:
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=100),
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
         for _ in range(max_size - 1):
             await buffer.add((job_faker(), "successful"))
             assert len(helper_buffer) == 0
 
         await buffer.add((job_faker(), "successful"))
-        assert len(helper_buffer) == max_size
+
+    # On ctx-mangner exit flush is forced.
+    assert len(helper_buffer) == max_size
 
 
 @pytest.mark.parametrize("N", (5, 64))
@@ -56,7 +58,7 @@ async def test_job_buffer_timeout(
     async with JobStatusLogBuffer(
         max_size=N * 2,
         timeout=timeout,
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
         for _ in range(N):
             await buffer.add((job_faker(), "successful"))
@@ -65,9 +67,6 @@ async def test_job_buffer_timeout(
         await asyncio.sleep(timeout.total_seconds() * 1.1)
 
     assert len(helper_buffer) == N
-
-
-# ### Additional Tests ###
 
 
 @pytest.mark.parametrize("max_size", (2, 3, 5, 64))  # Adjusted to max_size >=2
@@ -84,7 +83,7 @@ async def test_job_buffer_flush_on_exit(max_size: int) -> None:
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=100),
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
         for _ in range(max_size - 2):
             await buffer.add((job_faker(), "successful"))
@@ -95,36 +94,35 @@ async def test_job_buffer_flush_on_exit(max_size: int) -> None:
 
 
 @pytest.mark.parametrize("max_size", (1, 2, 3, 5, 64))
-async def test_job_buffer_multiple_flushes(max_size: int) -> None:
+@pytest.mark.parametrize("flushes", (1, 2, 3, 5, 64))
+async def test_job_buffer_multiple_flushes(max_size: int, flushes: int) -> None:
     """
     Test that the buffer can handle multiple flushes when more items than max_size are added.
     """
     helper_buffer = []
-    flush_call_count = 0
 
     async def helper(x: list) -> None:
-        nonlocal flush_call_count
-        flush_call_count += 1
-        helper_buffer.extend(x)
+        helper_buffer.append(x)
 
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=100),
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
-        total_items = max_size * 3  # Add three times the max_size
-        for _ in range(total_items):
-            await buffer.add((job_faker(), "successful"))
+        for _ in range(flushes):
+            for _ in range(max_size):
+                await buffer.add((job_faker(), "successful"))
+            buffer.next_flush = perf_counter_dt()
+            await buffer.flush()
 
     # Verify that the buffer flushed three times
-    assert flush_call_count == 3
-    assert len(helper_buffer) == total_items
+    assert len(helper_buffer) == flushes
 
 
 @pytest.mark.parametrize("max_size", (1, 2, 3, 5, 64))
 async def test_job_buffer_flush_on_exception(max_size: int) -> None:
     """
-    Test that the buffer handles exceptions in the flush_callable gracefully and retries.
+    Test that the buffer handles exceptions in the callback gracefully and retries.
     """
     helper_buffer = []
     flush_call_count = 0
@@ -139,7 +137,7 @@ async def test_job_buffer_flush_on_exception(max_size: int) -> None:
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=0.01),
-        flush_callable=faulty_helper,
+        callback=faulty_helper,
     ) as buffer:
         for _ in range(max_size):
             await buffer.add((job_faker(), "successful"))
@@ -165,40 +163,13 @@ async def test_job_buffer_flush_order(max_size: int) -> None:
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=100),
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
         items = [(job_faker(), "successful") for _ in range(max_size)]
         for item in items:
             await buffer.add(item)  # type: ignore[arg-type]
 
     assert helper_buffer == items
-
-
-@pytest.mark.parametrize("max_size", (1, 2, 3, 5, 64))
-async def test_job_buffer_no_flush_before_timeout(max_size: int) -> None:
-    """
-    Test that the buffer does not flush before the timeout if max_size is not reached.
-    """
-    helper_buffer = []
-
-    async def helper(x: list) -> None:
-        helper_buffer.extend(x)
-
-    async with JobStatusLogBuffer(
-        max_size=max_size,
-        timeout=timedelta(seconds=0.1),
-        flush_callable=helper,
-    ) as buffer:
-        for _ in range(max_size - 1):
-            await buffer.add((job_faker(), "successful"))
-            assert len(helper_buffer) == 0
-
-        # Wait less than the timeout
-        await asyncio.sleep(0.05)
-        assert len(helper_buffer) == 0
-
-    # After exiting, buffer should flush
-    assert len(helper_buffer) == max_size - 1
 
 
 @pytest.mark.parametrize("max_size", (1, 2, 3, 5, 64))
@@ -214,7 +185,7 @@ async def test_job_buffer_concurrent_adds(max_size: int) -> None:
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=100),
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
 
         async def add_items(n: int) -> None:
@@ -241,7 +212,7 @@ async def test_job_buffer_empty_flush() -> None:
     async with JobStatusLogBuffer(
         max_size=10,
         timeout=timedelta(seconds=0.1),
-        flush_callable=helper,
+        callback=helper,
     ):
         # Do not add any items and let the buffer flush on exit
         pass
@@ -262,11 +233,13 @@ async def test_job_buffer_reuse_after_flush(max_size: int) -> None:
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=100),
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
         # First flush
         for _ in range(max_size):
             await buffer.add((job_faker(), "successful"))
+        buffer.next_flush = perf_counter_dt()
+        await buffer.flush()
         assert len(helper_buffer) == max_size
 
         # Reset helper_buffer for the second flush
@@ -275,6 +248,8 @@ async def test_job_buffer_reuse_after_flush(max_size: int) -> None:
         # Second flush
         for _ in range(max_size):
             await buffer.add((job_faker(), "successful"))
+        buffer.next_flush = perf_counter_dt()
+        await buffer.flush()
         assert len(helper_buffer) == max_size
 
 
@@ -296,7 +271,7 @@ async def test_job_buffer_exception_during_flush(max_size: int) -> None:
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=0.01),
-        flush_callable=faulty_helper,
+        callback=faulty_helper,
     ) as buffer:
         for _ in range(max_size):
             await buffer.add((job_faker(), "successful"))
@@ -310,10 +285,11 @@ async def test_job_buffer_exception_during_flush(max_size: int) -> None:
 
 
 @pytest.mark.parametrize("max_size", (1, 2, 3, 5, 64))
-async def test_job_buffer_flush_callable_called_correctly(max_size: int) -> None:
+async def test_job_buffer_callback_called_correctly(max_size: int) -> None:
     """
-    Test that the flush_callable is called with the correct items.
+    Test that the callback is called with the correct items.
     """
+    items = [(job_faker(), "successful") for _ in range(max_size)]
     received_items = []
 
     async def helper(x: list) -> None:
@@ -322,9 +298,8 @@ async def test_job_buffer_flush_callable_called_correctly(max_size: int) -> None
     async with JobStatusLogBuffer(
         max_size=max_size,
         timeout=timedelta(seconds=100),
-        flush_callable=helper,
+        callback=helper,
     ) as buffer:
-        items = [(job_faker(), "successful") for _ in range(max_size)]
         for item in items:
             await buffer.add(item)  # type: ignore[arg-type]
 

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -240,6 +240,8 @@ Enqueue Batch Size:     {args.enqueue_batch_size}
     print("Queue size:")
     for status, items in groupby(sorted(qsize, key=lambda x: x.status), key=lambda x: x.status):
         print(f"  {status} {sum(x.count for x in items)}")
+    if not qsize:
+        print("  0")
 
     if tqdm_format_dict and args.output_json:
         with open(args.output_json, "w") as f:


### PR DESCRIPTION
Resolves #170 

This PR updates the buffer flushing mechanism by introducing an exponential backoff with jitter to reduce the occurrence of deadlocks during concurrent insert/update operations. The changes aim to make the flush process more resilient when multiple workers try to access the same rows, ultimately reducing contention and improving system reliability.

**Key Changes:**
- Replaced `flush_callable` with `callback` for clarity.
- Added `delay_multiplier` to implement an exponential backoff for retry attempts.
- Added `timeout_with_jitter` to introduce a randomized jitter in retry delays to prevent synchronized retries.
- Modified buffer flush logic to support periodic flushing with improved handling for shutdown and retry scenarios.
- Updated relevant tests to accommodate the new buffer behavior.

These changes will help alleviate deadlocks by ensuring retries are distributed over time, reducing simultaneous access to the same resources.

