### PR TITLE
Correct various typos in documentation, tests, and scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ First off, thank you for considering contributing to PGQueuer.
 
 There are many ways you can contribute to PGQueuer, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or writing code which can be incorporated into PGQueuer itself.
 
-Below you will find a set of guidelines to follow when contributing. These are mostly guidelines, not rules, so use your best judgment and feel free to propose changes to this document.
+Below you will find a set of guidelines to follow when contributing. These are mostly guidelines, not rules, so use your best judgement and feel free to propose changes to this document.
 
 ### Reporting Bugs
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ async def main() -> PgQueuer:
     driver = AsyncpgDriver(connection)
     pgq = PgQueuer(driver)
 
-    # Entrypoint for jobs whos entrypoint is named 'fetch'.
+    # Entrypoint for jobs whose entrypoint is named 'fetch'.
     @pgq.entrypoint("fetch")
     async def process_message(job: Job) -> None:
         print(f"Processed message: {job!r}")

--- a/pgqueuer/applications.py
+++ b/pgqueuer/applications.py
@@ -70,7 +70,7 @@ class PgQueuer:
         handle job processing and scheduling.
         """
 
-        # The task manager waits for all tasks for complite before
+        # The task manager waits for all tasks for compile before
         # exit.
         async with TaskManager() as tm:
             tm.add(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,7 +18,7 @@ async def apgdriver() -> AsyncGenerator[AsyncpgDriver, None]:
 
 
 @pytest.fixture(scope="function", autouse=True)
-async def trucate_tables(apgdriver: Driver) -> None:
+async def truncate_tables(apgdriver: Driver) -> None:
     await asyncio.gather(
         Queries(apgdriver).clear_log(),
         Queries(apgdriver).clear_queue(),

--- a/test/test_pgqueuer.py
+++ b/test/test_pgqueuer.py
@@ -22,7 +22,7 @@ async def wait_until_empty_queue(q: Queries, pgqs: list[PgQueuer]) -> None:
 
 
 @pytest.mark.parametrize("N", (1, 2, 32))
-async def test_pgqueuer_job_queing(apgdriver: db.Driver, N: int) -> None:
+async def test_pgqueuer_job_queuing(apgdriver: db.Driver, N: int) -> None:
     pgq = PgQueuer(apgdriver)
     seen = list[int]()
 
@@ -208,11 +208,11 @@ async def test_scheduler_runs_tasks(scheduler: PgQueuer, mocker: Mock) -> None:
         "pgqueuer.helpers.utc_now",
         return_value=datetime.now(timezone.utc) + timedelta(hours=1),
     )
-    exectued = False
+    executed = False
 
     async def sample_task(schedule: Schedule) -> None:
-        nonlocal exectued
-        exectued = True
+        nonlocal executed
+        executed = True
 
     scheduler.schedule("sample_task", "* * * * *")(sample_task)
 
@@ -223,7 +223,7 @@ async def test_scheduler_runs_tasks(scheduler: PgQueuer, mocker: Mock) -> None:
         ],
     )
 
-    assert exectued
+    assert executed
 
 
 @pytest.mark.asyncio
@@ -260,11 +260,11 @@ async def test_schedule_storage_and_retrieval(
     )
     expression = "* * * * *"
     entrypoint = "db_task"
-    recived: CronExpressionEntrypoint | None = None
+    received: CronExpressionEntrypoint | None = None
 
     async def db_task(schedule: Schedule) -> None:
-        nonlocal recived
-        recived = CronExpressionEntrypoint(
+        nonlocal received
+        received = CronExpressionEntrypoint(
             entrypoint=schedule.entrypoint,
             expression=schedule.expression,
         )
@@ -277,6 +277,6 @@ async def test_schedule_storage_and_retrieval(
         ],
     )
 
-    assert recived is not None
-    assert recived.entrypoint == entrypoint
-    assert recived.expression == expression
+    assert received is not None
+    assert received.entrypoint == entrypoint
+    assert received.expression == expression

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -23,7 +23,7 @@ async def wait_until_empty_queue(
 
 
 @pytest.mark.parametrize("N", (1, 2, 32))
-async def test_job_queing(
+async def test_job_queuing(
     apgdriver: db.Driver,
     N: int,
 ) -> None:

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -64,11 +64,11 @@ async def test_scheduler_runs_tasks(scheduler: SchedulerManager, mocker: Mock) -
         "pgqueuer.helpers.utc_now",
         return_value=datetime.now(timezone.utc) + timedelta(hours=1),
     )
-    exectued = False
+    executed = False
 
     async def sample_task(schedule: Schedule) -> None:
-        nonlocal exectued
-        exectued = True
+        nonlocal executed
+        executed = True
 
     scheduler.schedule("sample_task", "* * * * *")(sample_task)
 
@@ -79,7 +79,7 @@ async def test_scheduler_runs_tasks(scheduler: SchedulerManager, mocker: Mock) -
         ],
     )
 
-    assert exectued
+    assert executed
 
 
 @pytest.mark.asyncio
@@ -116,11 +116,11 @@ async def test_schedule_storage_and_retrieval(
     )
     expression = "* * * * *"
     entrypoint = "db_task"
-    recived: CronExpressionEntrypoint | None = None
+    received: CronExpressionEntrypoint | None = None
 
     async def db_task(schedule: Schedule) -> None:
-        nonlocal recived
-        recived = CronExpressionEntrypoint(
+        nonlocal received
+        received = CronExpressionEntrypoint(
             entrypoint=schedule.entrypoint,
             expression=schedule.expression,
         )
@@ -133,6 +133,6 @@ async def test_schedule_storage_and_retrieval(
         ],
     )
 
-    assert recived is not None
-    assert recived.entrypoint == entrypoint
-    assert recived.expression == expression
+    assert received is not None
+    assert received.entrypoint == entrypoint
+    assert received.expression == expression

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -130,14 +130,14 @@ def cli_parser() -> argparse.Namespace:
         "--requests-per-second",
         nargs="+",
         default=[float("inf"), float("inf")],
-        help="RPS for endporints given as a list, defautl is 'inf'.",
+        help="RPS for endporints given as a list, default is 'inf'.",
     )
     parser.add_argument(
         "-ci",
         "--concurrency-limit",
         nargs="+",
         default=[sys.maxsize, sys.maxsize],
-        help=f"Concurrency limit for endporints given as a list, defautl is '{sys.maxsize}'.",
+        help=f"Concurrency limit for endporints given as a list, default is '{sys.maxsize}'.",
     )
     parser.add_argument(
         "-o",


### PR DESCRIPTION
Found via `typos --hidden --format brief` and `codespell -H`