### PR TITLE
Implement AsyncpgReconnectionMixin with connection.add_termination_listener

### DIFF
--- a/pgqueuer/db.py
+++ b/pgqueuer/db.py
@@ -13,12 +13,11 @@ import functools
 import os
 import re
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Callable, Dict, Protocol, Set
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 from typing_extensions import Self
 
 from . import logconfig, tm
-import contextlib
 
 if TYPE_CHECKING:
     import asyncpg

--- a/pgqueuer/db.py
+++ b/pgqueuer/db.py
@@ -216,7 +216,6 @@ class AsyncpgDriver(AsyncpgReconnectionMixin, Driver):
         AsyncpgReconnectionMixin.__init__(self)
         self._shutdown = asyncio.Event()
         self._connection = connection
-        logconfig.logger.info(connection.get_settings())
         self._dsn = dsn
         self._lock = asyncio.Lock()
 
@@ -289,7 +288,6 @@ class AsyncpgPoolDriver(AsyncpgReconnectionMixin, Driver):
         """
         Initialize the AsyncpgPoolDriver with a connection pool.
         """
-        Driver.__init__(self)
         AsyncpgReconnectionMixin.__init__(self)
         self._shutdown = asyncio.Event()
         self._pool = pool


### PR DESCRIPTION
I've tested this with manually stopping and restarting Postgres in Docker, both with `AsyncpgPoolDriver` and `AsyncpgDriver`.

I haven't figured out yet how to write unit tests, but also wanted to check first if the approach makes sense.

For some reason if the database is stopped for more than a minute the logs show that the reconnection was successful, but the listener doesn't get notified any more. I've asked about it [here](https://github.com/MagicStack/asyncpg/issues/519#issuecomment-2560194204).

This is an example what to expect:

```
...
WARNING:pgqueuer:Listener connection lost
INFO:pgqueuer:Trying to reconnect listener (attempt 1)...
ERROR:pgqueuer:Failed to reconnect on attempt 1 due to error: the database system is shutting down; waiting 0:00:01 before trying again...
INFO:pgqueuer:Trying to reconnect listener (attempt 2)...
ERROR:pgqueuer:Failed to reconnect on attempt 2 due to error: [Errno 61] Connection refused; waiting 0:00:02 before trying again...
INFO:pgqueuer:Trying to reconnect listener (attempt 3)...
INFO:pgqueuer:Successfully restored listener, resuming operation
INFO: Executing job: 164
...
```