### PR TITLE
Add support for --factory in dashboard cli command.

### DIFF
--- a/pgqueuer/cli.py
+++ b/pgqueuer/cli.py
@@ -5,6 +5,7 @@ import contextlib
 import os
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Awaitable, Callable
 
 import typer
 from tabulate import tabulate
@@ -231,12 +232,12 @@ def upgrade(
     asyncio.run(run())
 
 
-def create_default_queries_factory(ctx: Context):
+def create_default_queries_factory(ctx: Context) -> Callable[..., Awaitable[queries.Queries]]:
     """
     This is the default implementation of a factory that returns an instance of Queries.
     """
 
-    async def factory():
+    async def factory() -> queries.Queries:
         config: AppConfig = ctx.obj
         return await query_adapter(config.dsn)
 

--- a/pgqueuer/factories.py
+++ b/pgqueuer/factories.py
@@ -1,0 +1,60 @@
+import importlib
+import os
+import sys
+import warnings
+from contextlib import AbstractAsyncContextManager, AbstractContextManager, asynccontextmanager
+from typing import Any, AsyncGenerator, Awaitable, TypeVar
+
+
+def load_factory(factory_path: str) -> Any:
+    """
+    Load factory function from a given module path or factory-style path.
+
+    Args:
+        factory_path (str): Module path to the factory function or factory-style path.
+
+    Returns: A callable
+    """
+    sys.path.insert(0, os.getcwd())
+
+    if ":" in factory_path:
+        module_name, factory_name = factory_path.split(":", 1)
+    else:
+        # Backward compatibility for module.function style
+        warnings.warn(
+            (
+                "The use of 'module.function' syntax for specifying the factory path is "
+                "deprecated and will be removed in a future version. Please use "
+                "'module:factory' syntax instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        module_name, factory_name = factory_path.rsplit(".", 1)
+
+    module = importlib.import_module(module_name)
+    return getattr(module, factory_name)
+
+
+T = TypeVar("T")
+
+
+@asynccontextmanager
+async def run_factory(
+    factory_result: Awaitable[T] | AbstractAsyncContextManager[T],
+) -> AsyncGenerator[T, None]:
+    """
+    Converts the result of a factory function in a async context manager
+    """
+
+    # Check if it's an async context manager
+    if isinstance(factory_result, AbstractAsyncContextManager):
+        async with factory_result as value:
+            yield value
+    # Check if it's a synchronous context manager
+    elif isinstance(factory_result, AbstractContextManager):
+        with factory_result as value:
+            yield value
+    # Otherwise, assume it's an awaitable and return the result
+    else:
+        yield await factory_result

--- a/pgqueuer/factories.py
+++ b/pgqueuer/factories.py
@@ -5,6 +5,8 @@ import warnings
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, asynccontextmanager
 from typing import Any, AsyncGenerator, Awaitable, TypeVar
 
+T = TypeVar("T")
+
 
 def load_factory(factory_path: str) -> Any:
     """
@@ -34,9 +36,6 @@ def load_factory(factory_path: str) -> Any:
 
     module = importlib.import_module(module_name)
     return getattr(module, factory_name)
-
-
-T = TypeVar("T")
 
 
 @asynccontextmanager

--- a/pgqueuer/supervisor.py
+++ b/pgqueuer/supervisor.py
@@ -9,13 +9,11 @@ using configurable factory paths.
 from __future__ import annotations
 
 import asyncio
-import importlib
-import os
 import signal
-import sys
-import warnings
 from datetime import timedelta
 from typing import Awaitable, Callable, TypeAlias
+
+from pgqueuer.factories import load_factory
 
 from . import applications, logconfig, qm, sm
 
@@ -36,25 +34,7 @@ def load_manager_factory(factory_path: str) -> FactoryType:
     Returns:
         A callable that creates an instance of QueueManager, SchedulerManager, or PgQueuer.
     """
-    sys.path.insert(0, os.getcwd())
-
-    if ":" in factory_path:
-        module_name, factory_name = factory_path.split(":", 1)
-    else:
-        # Backward compatibility for module.function style
-        warnings.warn(
-            (
-                "The use of 'module.function' syntax for specifying the factory path is "
-                "deprecated and will be removed in a future version. Please use "
-                "'module:factory' syntax instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        module_name, factory_name = factory_path.rsplit(".", 1)
-
-    module = importlib.import_module(module_name)
-    return getattr(module, factory_name)
+    return load_factory(factory_path)
 
 
 async def runit(


### PR DESCRIPTION
This adds support for a --factory argument when running `pgq dashboard`. The argument must refer to a function that either returns, or yeild's (as part of an async context manager) an instance of Queries.

Changes include:

1. Moving the reference (i.e. a.b:c) loading logic to a common file
2. A default factory that generates the Queries from the cli context.

Closes #259 