### PR TITLE
Add support for context manager factories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+.envrc
 .env
 .venv
 env/

--- a/examples/consumer.py
+++ b/examples/consumer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import datetime
+from typing import AsyncGenerator
 
 import asyncpg
 
@@ -24,3 +26,11 @@ async def main() -> PgQueuer:
         print(f"Executed every minute {schedule!r} {datetime.now()!r}")
 
     return pgq
+
+
+@asynccontextmanager
+async def context() -> AsyncGenerator[PgQueuer]:
+    # startup
+    pgq = await main()
+    yield pgq
+    # teardown

--- a/pgqueuer/factories.py
+++ b/pgqueuer/factories.py
@@ -5,6 +5,8 @@ import warnings
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, asynccontextmanager
 from typing import Any, AsyncGenerator, Awaitable, TypeVar
 
+from . import logconfig
+
 T = TypeVar("T")
 
 
@@ -48,12 +50,15 @@ async def run_factory(
 
     # Check if it's an async context manager
     if isinstance(factory_result, AbstractAsyncContextManager):
+        logconfig.logger.debug("factory is an async context manager. running.")
         async with factory_result as value:
             yield value
     # Check if it's a synchronous context manager
     elif isinstance(factory_result, AbstractContextManager):
+        logconfig.logger.debug("factory is an context manager. running.")
         with factory_result as value:
             yield value
     # Otherwise, assume it's an awaitable and return the result
     else:
+        logconfig.logger.debug("factory is an coroutine. running.")
         yield await factory_result

--- a/pgqueuer/supervisor.py
+++ b/pgqueuer/supervisor.py
@@ -82,9 +82,12 @@ async def runit(
                         "not recognized as a valid QueueManager, SchedulerManager, or PgQueuer."
                     )
 
-                logconfig.logger.debug("running instance: %s", type(instance).__name__)
                 try:
+                    logconfig.logger.debug("running instance: %s", type(instance).__name__)
                     await run_instance(instance, dequeue_timeout, batch_size)
+                    logconfig.logger.debug(
+                        "instance %s finished running. cleaning up", type(instance).__name__
+                    )
                 except Exception as exc:
                     if not restart_on_failure:
                         raise


### PR DESCRIPTION
This explores how a context manager might be used with a factory to handle lifecycle tasks that need to be run on shutdown. 

For example: 

```python
async def main() -> PgQueuer:
    connection = await asyncpg.connect()
    driver = AsyncpgDriver(connection)
    pgq = PgQueuer(driver)

    # Setup the 'fetch' entrypoint
    @pgq.entrypoint("fetch")
    async def process_message(job: Job) -> None:
        print(f"Processed message: {job!r}")

    @pgq.schedule("scheduled_every_minute", "* * * * *")
    async def scheduled_every_minute(schedule: Schedule) -> None:
        print(f"Executed every minute {schedule!r} {datetime.now()!r}")

    return pgq


@asynccontextmanager
async def context() -> AsyncGenerator[PgQueuer]:
    # startup (i.e. open app database connection pool)
    pgq = await main()
    yield pgq
    # teardown (i.e. close app database connection pool)
```

This would close #265 