### PR TITLE
fix: add a missing call to AsyncpgPoolDriver._lock before handling _listener_connection

### DIFF
--- a/pgqueuer/db.py
+++ b/pgqueuer/db.py
@@ -272,9 +272,11 @@ class AsyncpgPoolDriver(Driver):
         return self
 
     async def __aexit__(self, *_: object) -> None:
-        if self._listener_connection is not None:
-            await self._listener_connection.reset()
-            await self._pool.release(self._listener_connection)
+        async with self._lock:
+            if self._listener_connection is not None:
+                await self._listener_connection.reset()
+                await self._pool.release(self._listener_connection)
+                self._listener_connection = None
 
 
 @functools.cache


### PR DESCRIPTION
This resolves #282, where the `AsyncpgPoolDriver` didn't call _lock before resetting the _listener_connection, and didn't set it to `None` after releasing it back to the pool. This caused it to raise an exception when multiple coroutines would try to reset the listener connection concurrently.