### PR TITLE
BREAKING; Consolidate queue_status_type and statistics_table_status_type into a unified enum

### DIFF
--- a/pgqueuer/qm.py
+++ b/pgqueuer/qm.py
@@ -362,7 +362,7 @@ class QueueManager:
                     f"Please run 'pgq upgrade' to ensure all schema changes are applied."
                 )
 
-        for key, enum in (("canceled", self.queries.qbe.settings.statistics_table_status_type),):
+        for key, enum in (("canceled", self.queries.qbe.settings.queue_status_type),):
             if not (await self.queries.has_user_defined_enum(key, enum)):
                 raise RuntimeError(
                     f"The {enum} is missing the '{key}' type, please run 'pgq upgrade'"

--- a/pgqueuer/types.py
+++ b/pgqueuer/types.py
@@ -5,12 +5,18 @@ from typing import Literal, NewType
 ###### Events ######
 PGChannel = NewType("PGChannel", str)
 OPERATIONS = Literal["insert", "update", "delete", "truncate"]
-STATUS = Literal["queued", "picked"]
 EVENT_TYPES = Literal["table_changed_event", "requests_per_second_event", "cancellation_event"]
 
 
 ###### Jobs ######
 JobId = NewType("JobId", int)
+STATUS = Literal[
+    "queued",
+    "picked",
+    "successful",
+    "exception",
+    "canceled",
+]
 
 
 ###### Schedules ######


### PR DESCRIPTION
This PR consolidates the `queue_status_type` and `statistics_table_status_type` into a single, unified ENUM type to simplify and standardize status handling across PGQueuer. Key updates include:

- **Unified ENUM Type**: Expanded `queue_status_type` to include all possible statuses (`queued`, `picked`, `successful`, `exception`, `canceled`) and removed the separate `statistics_table_status_type`.
- **Schema Changes**:
  - Updated the statistics table to use `queue_status_type` for the `status` column.
  - Dynamically added any missing ENUM values during upgrades to maintain backward compatibility.
- **Code Refactoring**:
  - Adjusted queries and logic to reference the unified `queue_status_type`.
  - Updated validation logic in `QueueManager` to reflect the consolidated ENUM.
- **Typed Literals**:
  - Expanded the `STATUS` literal in `types.py` to include all status options.

### Upgrade Instructions
Run `pgq upgrade` post-deployment to apply the schema changes and ensure all ENUM values are correctly updated.