### PR TITLE
Add durability policy with explicit logging modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 	docker compose -f $(COMPOSE_FILE) build
 
 up:
-	docker compose -f $(COMPOSE_FILE) up -d db
+	docker compose -f $(COMPOSE_FILE) up db
 
 db:
 	docker compose -f $(COMPOSE_FILE) up db populate

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,23 +1,54 @@
 CLI Module for PGQueuer
 =======================
 
-The pgq CLI provides a command-line interface for managing various aspects of the PGQueuer system. The CLI can be invoked via the alias `pgq` or the traditional method `python3 -m pgqueuer`. Both methods are fully supported and provide identical functionality.
-
-Functionality
--------------
-
-The CLI offers several commands to install, uninstall, upgrade, and manage the job queue system. Additionally, it allows for real-time monitoring through a dashboard and specific PostgreSQL NOTIFY channels.
+The pgq CLI provides a command-line interface for managing various aspects of the PGQueuer system. The CLI can be invoked via the alias `pgq` or the traditional method `python3 -m pgqueuer`. Both methods are fully supported and provide identical functionality. The CLI offers several commands to install, uninstall, upgrade, and manage the job queue system. Additionally, it allows for real-time monitoring through a dashboard and specific PostgreSQL NOTIFY channels.
 
 Key Commands
 ------------
 
 - ``install``: Set up the necessary database schema for PGQueuer.
+    - Supports the ``--durability`` option to define the durability level for tables. Possible values are:
+        - ``volatile``: All tables are unlogged, prioritizing maximum performance over durability.
+        - ``balanced``: Critical tables (e.g., `pgqueuer` and `pgqueuer_schedules``) are logged, while auxiliary tables are unlogged for improved performance.
+        - ``durable``: All tables are logged to ensure maximum durability.
+        - **Default**: ``durable``.
+
+    Example:
+
+    ```bash
+    pgq install --durability balanced
+    ```
+
 - ``uninstall``: Remove the PGQueuer schema from the database.
+
 - ``upgrade``: Apply database schema upgrades to PGQueuer.
+    - Also supports the ``--durability`` option, similar to ``install``, allowing you to adjust the durability level during the upgrade process.
+
+    Example:
+
+    ```bash
+    pgq upgrade --durability durable
+    ```
+
+- ``alter-durability``: Change the durability level of existing PGQueuer tables without data loss.
+    - Arguments:
+        - ``durability`` (required): The desired durability mode (`volatile`, `balanced`, or `durable``).
+        - ``--dry-run`` (optional): Print SQL commands without executing them.
+
+    Example:
+
+    ```bash
+    pgq alter-durability durable
+    ```
+
 - ``dashboard``: Display a live dashboard showing job statistics.
+
 - ``listen``: Listen to PostgreSQL NOTIFY channels for debugging.
+
 - ``run``: Start a QueueManager that manages job queues and processes.
+
 - ``schedules``: Manage schedules within the PGQueuer system. You can display all schedules or remove specific ones by ID or name.
+
 
 Why Use the ``run`` Option
 --------------------------
@@ -42,3 +73,27 @@ To use the CLI, invoke it with the desired command and options. You can use eith
 This command initializes the QueueManager using the factory function provided, setting up signal handling automatically to manage job processing interruptions gracefully.
 
 The new `pgq` alias makes it more convenient to work with the CLI, while maintaining full compatibility with the traditional approach for those who prefer it.
+
+
+Durability Explained
+--------------------
+
+Durability in PGQueuer determines the logging behavior of the database tables, which directly affects performance and data safety. PGQueuer offers three durability levels:
+
+- **volatile**:
+  - All tables are unlogged, prioritizing maximum performance.
+  - Data in unlogged tables is not written to the PostgreSQL Write-Ahead Log (WAL), making operations faster but at the cost of data safety.
+  - If the database crashes, all data in unlogged tables is lost.
+  - Suitable for temporary or ephemeral workloads where data loss is acceptable.
+
+- **balanced**:
+  - Critical tables (e.g., `pgqueuer` and `pgqueuer_schedules`) are logged to ensure durability, while auxiliary tables (e.g., `pgqueuer_log` and `pgqueuer_statistics`) are unlogged for improved performance.
+  - This provides a middle ground between performance and data safety.
+  - Suitable for use cases where durability is important for critical data, but non-critical logs and statistics can be sacrificed for performance.
+
+- **durable** (default):
+  - All tables are logged, ensuring maximum data durability.
+  - Data is written to the WAL, providing full recovery in case of a crash.
+  - This is ideal for production environments where data integrity is critical, but it comes with a performance cost due to the overhead of logging.
+
+Choosing a durability level involves trade-offs between performance and data safety. The **volatile** level maximizes performance but risks data loss during crashes. The **balanced** level offers a compromise, with critical data protected while auxiliary data is optimized for speed. The **durable** level ensures full data safety at the expense of performance.

--- a/pgqueuer/queries.py
+++ b/pgqueuer/queries.py
@@ -101,6 +101,12 @@ class Queries:
         """
         await self.driver.execute("\n\n".join(self.qbe.build_upgrade_queries()))
 
+    async def alter_durability(self) -> None:
+        """
+        Alter the durability level of the tables in PGQueuer without data loss
+        """
+        await self.driver.execute("\n\n".join(self.qbe.build_alter_durability_query()))
+
     async def table_has_column(self, table: str, column: str) -> bool:
         """
         Check if the column exists in table.

--- a/test/test_durability.py
+++ b/test/test_durability.py
@@ -1,0 +1,95 @@
+import pytest
+
+from pgqueuer.qb import Durability, DurabilityPolicy
+
+
+@pytest.mark.parametrize(
+    "durability,expected_policy",
+    [
+        (
+            Durability.volatile,
+            DurabilityPolicy(
+                queue_table="UNLOGGED",
+                queue_log_table="UNLOGGED",
+                statistics_table="UNLOGGED",
+                schedules_table="UNLOGGED",
+            ),
+        ),
+        (
+            Durability.balanced,
+            DurabilityPolicy(
+                queue_table="",
+                queue_log_table="UNLOGGED",
+                statistics_table="UNLOGGED",
+                schedules_table="",
+            ),
+        ),
+        (
+            Durability.durable,
+            DurabilityPolicy(
+                queue_table="",
+                queue_log_table="",
+                statistics_table="",
+                schedules_table="",
+            ),
+        ),
+    ],
+)
+def test_durability_policy(durability: Durability, expected_policy: DurabilityPolicy) -> None:
+    """
+    Test that the `config` property of each `Durability` level correctly returns
+    the expected `DurabilityPolicy`.
+    """
+    assert durability.config == expected_policy
+
+
+@pytest.mark.parametrize(
+    "policy,expected_logged",
+    [
+        (
+            DurabilityPolicy(
+                queue_table="",
+                queue_log_table="UNLOGGED",
+                statistics_table="UNLOGGED",
+                schedules_table="",
+            ),
+            {
+                "pgqueuer": True,
+                "pgqueuer_log": False,
+                "pgqueuer_statistics": False,
+                "pgqueuer_schedules": True,
+            },
+        ),
+        (
+            DurabilityPolicy(
+                queue_table="UNLOGGED",
+                queue_log_table="UNLOGGED",
+                statistics_table="UNLOGGED",
+                schedules_table="UNLOGGED",
+            ),
+            {
+                "pgqueuer": False,
+                "pgqueuer_log": False,
+                "pgqueuer_statistics": False,
+                "pgqueuer_schedules": False,
+            },
+        ),
+    ],
+)
+def test_policy_attributes(policy: DurabilityPolicy, expected_logged: dict[str, bool]) -> None:
+    """
+    Test that individual attributes in `DurabilityPolicy` correctly indicate whether they
+    are logged or unlogged.
+    """
+    assert (policy.queue_table == "") == expected_logged["pgqueuer"]
+    assert (policy.queue_log_table == "") == expected_logged["pgqueuer_log"]
+    assert (policy.statistics_table == "") == expected_logged["pgqueuer_statistics"]
+    assert (policy.schedules_table == "") == expected_logged["pgqueuer_schedules"]
+
+
+def test_invalid_durability_level() -> None:
+    """
+    Test that accessing an unknown durability level raises a ValueError.
+    """
+    with pytest.raises(ValueError, match="'nonexistent' is not a valid Durability"):
+        Durability("nonexistent")


### PR DESCRIPTION
Introduces the DurabilityPolicy class, which defines table logging configurations as explicit values ('' for logged and 'unlogged' for unlogged). It updates the Durability enum to provide configurations dynamically and ensures pgqueuer_schedules aligns with pgqueuer. Includes unit tests for DurabilityPolicy and Durability to validate the behavior.