### PR TITLE
Refactor CLI to Support User-Provided Query Factories

### DIFF
--- a/pgqueuer/cli.py
+++ b/pgqueuer/cli.py
@@ -10,6 +10,7 @@ from typing import Awaitable, Callable
 import typer
 from tabulate import tabulate
 from typer import Context
+from typing_extensions import AsyncGenerator
 
 from . import db, factories, helpers, listeners, models, qb, queries, supervisor
 
@@ -17,7 +18,6 @@ try:
     from uvloop import run as asyncio_run
 except ImportError:
     from asyncio import run as asyncio_run  # type: ignore[assignment]
-
 
 app = typer.Typer(
     help=(
@@ -42,6 +42,7 @@ class AppConfig:
     pg_database: str = ""
     pg_password: str = ""
     pg_schema: str = ""
+    factory_fn_ref: str | None = None
 
     def setup_env(self) -> None:
         if self.prefix:
@@ -72,7 +73,11 @@ def main(
     pg_database: str = typer.Option(None, help="Database name.", envvar="PGDATABASE"),
     pg_password: str = typer.Option(None, help="Database password.", envvar="PGPASSWORD"),
     pg_schema: str = typer.Option(None, help="Database schema.", envvar="PGSCHEMA"),
+    factory_fn_ref: str | None = typer.Option(
+        None, "--factory", help="A reference to a function that returns an instance of Queries"
+    ),
 ) -> None:
+    """Main Typer callback to set up shared configuration."""
     config = AppConfig(
         prefix=prefix,
         pg_dsn=pg_dsn,
@@ -82,48 +87,83 @@ def main(
         pg_database=pg_database,
         pg_password=pg_password,
         pg_schema=pg_schema,
+        factory_fn_ref=factory_fn_ref,
     )
     config.setup_env()
     ctx.obj = config
+
+
+def create_default_queries_factory(
+    config: AppConfig, settings: qb.DBSettings
+) -> Callable[..., Awaitable[queries.Queries]]:
+    """
+    This is the default implementation of a factory that returns an instance of Queries.
+    It attempts asyncpg first, then psycopg.
+    """
+
+    async def factory() -> queries.Queries:
+        with contextlib.suppress(ImportError):
+            import asyncpg
+
+            return queries.Queries(
+                db.AsyncpgDriver(await asyncpg.connect(dsn=config.dsn)),
+                qbe=qb.QueryBuilderEnvironment(settings),
+                qbq=qb.QueryQueueBuilder(settings),
+                qbs=qb.QuerySchedulerBuilder(settings),
+            )
+        with contextlib.suppress(ImportError):
+            import psycopg
+
+            return queries.Queries(
+                db.PsycopgDriver(
+                    await psycopg.AsyncConnection.connect(config.dsn, autocommit=True)
+                ),
+                qbe=qb.QueryBuilderEnvironment(settings),
+                qbq=qb.QueryQueueBuilder(settings),
+                qbs=qb.QuerySchedulerBuilder(settings),
+            )
+        raise RuntimeError("Neither asyncpg nor psycopg could be imported.")
+
+    return factory
+
+
+@contextlib.asynccontextmanager
+async def yield_queries(
+    ctx: Context,
+    settings: qb.DBSettings = qb.DBSettings(),
+) -> AsyncGenerator[queries.Queries, None]:
+    """
+    Async context manager that yields a Queries instance from either a user-supplied
+    factory function or the default factory.
+    """
+    config: AppConfig = ctx.obj
+    if config.factory_fn_ref:
+        factory_fn = factories.load_factory(config.factory_fn_ref)
+    else:
+        factory_fn = create_default_queries_factory(config, settings)
+    async with factories.run_factory(factory_fn()) as q:
+        yield q
 
 
 async def display_stats(log_stats: list[models.LogStatistics]) -> None:
     print(
         tabulate(
             [
-                (
-                    stat.created.astimezone(),
-                    stat.count,
-                    stat.entrypoint,
-                    stat.status,
-                    stat.priority,
-                )
+                (stat.created.astimezone(), stat.count, stat.entrypoint, stat.status, stat.priority)
                 for stat in log_stats
             ],
-            headers=[
-                "Created",
-                "Count",
-                "Entrypoint",
-                "Status",
-                "Priority",
-            ],
+            headers=["Created", "Count", "Entrypoint", "Status", "Priority"],
             tablefmt=os.environ.get(qb.add_prefix("TABLEFMT"), "pretty"),
         )
     )
 
 
-async def display_pg_channel(
-    connection: db.Driver,
-    channel: models.Channel,
-) -> None:
+async def display_pg_channel(connection: db.Driver, channel: models.Channel) -> None:
     queue = asyncio.Queue[models.AnyEvent]()
-    await listeners.initialize_notice_event_listener(
-        connection,
-        channel,
-        queue.put_nowait,
-    )
+    await listeners.initialize_notice_event_listener(connection, channel, queue.put_nowait)
     while True:
-        print(repr((await queue.get()).root))
+        event = await queue.get()
+        print(repr(event.root))
 
 
 async def display_schedule(schedules: list[models.Schedule]) -> None:
@@ -159,46 +199,14 @@ async def display_schedule(schedules: list[models.Schedule]) -> None:
     )
 
 
-async def fetch_and_display(
-    queries_obj: queries.Queries,
-    interval: timedelta | None,
-    tail: int,
-) -> None:
+async def fetch_and_display(q: queries.Queries, interval: timedelta | None, tail: int) -> None:
     clear_and_home = "\033[2J\033[H"
     while True:
         print(clear_and_home, end="")
-        await display_stats(await queries_obj.log_statistics(tail))
+        await display_stats(await q.log_statistics(tail))
         if interval is None:
             return
         await asyncio.sleep(interval.total_seconds())
-
-
-async def query_adapter(
-    conninfo: str,
-    settings: qb.DBSettings,
-) -> queries.Queries:
-    with contextlib.suppress(ImportError):
-        import asyncpg
-
-        return queries.Queries(
-            db.AsyncpgDriver(await asyncpg.connect(dsn=conninfo)),
-            qbe=qb.QueryBuilderEnvironment(settings),
-            qbq=qb.QueryQueueBuilder(settings),
-            qbs=qb.QuerySchedulerBuilder(settings),
-        )
-
-    with contextlib.suppress(ImportError):
-        import psycopg
-
-        return queries.Queries(
-            db.PsycopgDriver(
-                await psycopg.AsyncConnection.connect(conninfo=conninfo, autocommit=True)
-            ),
-            qbe=qb.QueryBuilderEnvironment(settings),
-            qbq=qb.QueryQueueBuilder(settings),
-            qbs=qb.QuerySchedulerBuilder(settings),
-        )
-    raise RuntimeError("Neither asyncpg nor psycopg could be imported.")
 
 
 @app.command(help="Install the necessary database schema for PGQueuer.")
@@ -209,36 +217,26 @@ def install(
         qb.Durability.durable.value,
         "--durability",
         "-d",
-        help=(
-            "Durability level for tables: 'volatile' (all unlogged), "
-            "'balanced' (main table logged, others unlogged), 'durable' (all logged)."
-        ),
+        help="Durability level for tables.",
     ),
 ) -> None:
-    config: AppConfig = ctx.obj
-    print(
-        queries.qb.QueryBuilderEnvironment(
-            qb.DBSettings(durability=durability)
-        ).build_install_query()
-    )
+    print(qb.QueryBuilderEnvironment(qb.DBSettings(durability=durability)).build_install_query())
 
     async def run() -> None:
-        await (await query_adapter(config.dsn, qb.DBSettings(durability=durability))).install()
+        async with yield_queries(ctx, qb.DBSettings(durability=durability)) as q:
+            await q.install()
 
     if not dry_run:
         asyncio_run(run())
 
 
 @app.command(help="Remove the PGQueuer schema from the database.")
-def uninstall(
-    ctx: Context,
-    dry_run: bool = typer.Option(False, help="Print SQL only."),
-) -> None:
-    config: AppConfig = ctx.obj
-    print(queries.qb.QueryBuilderEnvironment().build_uninstall_query())
+def uninstall(ctx: Context, dry_run: bool = typer.Option(False, help="Print SQL only.")) -> None:
+    print(qb.QueryBuilderEnvironment().build_uninstall_query())
 
     async def run() -> None:
-        await (await query_adapter(config.dsn, qb.DBSettings())).uninstall()
+        async with yield_queries(ctx) as q:
+            await q.uninstall()
 
     if not dry_run:
         asyncio_run(run())
@@ -249,60 +247,30 @@ def upgrade(
     ctx: Context,
     dry_run: bool = typer.Option(False, help="Print SQL only."),
     durability: qb.Durability = typer.Option(
-        qb.Durability.durable.value,
-        "--durability",
-        "-d",
-        help=(
-            "Durability level for tables: 'volatile' (all unlogged), "
-            "'balanced' (main table logged, others unlogged), 'durable' (all logged)."
-        ),
+        qb.Durability.durable.value, "--durability", "-d", help="Durability level for tables."
     ),
 ) -> None:
-    config: AppConfig = ctx.obj
-    print(f"\n{'-' * 50}\n".join(queries.qb.QueryBuilderEnvironment().build_upgrade_queries()))
+    print(f"\n{'-' * 50}\n".join(qb.QueryBuilderEnvironment().build_upgrade_queries()))
 
     async def run() -> None:
-        await (await query_adapter(config.dsn, qb.DBSettings(durability=durability))).upgrade()
+        async with yield_queries(ctx, qb.DBSettings(durability=durability)) as q:
+            await q.upgrade()
 
     if not dry_run:
         asyncio_run(run())
 
 
-def create_default_queries_factory(
-    ctx: Context,
-) -> Callable[..., Awaitable[queries.Queries]]:
-    """
-    This is the default implementation of a factory that returns an instance of Queries.
-    """
-
-    async def factory() -> queries.Queries:
-        config: AppConfig = ctx.obj
-        return await query_adapter(config.dsn, qb.DBSettings())
-
-    return factory
-
-
 @app.command(help="Display a live dashboard showing job statistics.")
 def dashboard(
     ctx: Context,
-    factory_fn_ref: str | None = typer.Option(
-        None,
-        "--factory",
-        help="A reference to a function that returns an instance of Queries",
-    ),
     interval: float | None = typer.Option(None, "-i", "--interval"),
     tail: int = typer.Option(25, "-n", "--tail"),
 ) -> None:
     interval_td = timedelta(seconds=interval) if interval is not None else None
 
     async def run() -> None:
-        factory_fn = (
-            factories.load_factory(factory_fn_ref)
-            if factory_fn_ref
-            else create_default_queries_factory(ctx)
-        )
-        async with factories.run_factory(factory_fn()) as queries:
-            await fetch_and_display(queries, interval_td, tail)
+        async with yield_queries(ctx) as q:
+            await fetch_and_display(q, interval_td, tail)
 
     asyncio_run(run())
 
@@ -312,25 +280,32 @@ def listen(
     ctx: Context,
     channel: str = typer.Option(qb.DBSettings().channel, "--channel"),
 ) -> None:
-    config: AppConfig = ctx.obj
-
     async def run() -> None:
-        await display_pg_channel(
-            (await query_adapter(config.dsn, qb.DBSettings())).driver,
-            models.Channel(channel),
-        )
+        async with yield_queries(ctx) as q:
+            await display_pg_channel(q.driver, models.Channel(channel))
 
     asyncio_run(run())
 
 
 @app.command(help="Start a QueueManager to manage and process jobs.")
 def run(
-    factory_fn: str = typer.Argument(...),
-    dequeue_timeout: float = typer.Option(30.0, "--dequeue-timeout"),
-    batch_size: int = typer.Option(10, "--batch-size"),
-    restart_delay: float = typer.Option(5.0, "--restart-delay"),
-    restart_on_failure: bool = typer.Option(False, "--restart-on-failure"),
+    factory_fn: str = typer.Argument(..., help="Path to a function returning a Queries instance."),
+    dequeue_timeout: float = typer.Option(
+        30.0, "--dequeue-timeout", help="Max seconds to wait for new jobs."
+    ),
+    batch_size: int = typer.Option(
+        10, "--batch-size", help="Number of jobs to pull from the queue at once."
+    ),
+    restart_delay: float = typer.Option(
+        5.0, "--restart-delay", help="Delay between restarts if --restart-on-failure."
+    ),
+    restart_on_failure: bool = typer.Option(
+        False, "--restart-on-failure", help="Restart the manager if it fails."
+    ),
 ) -> None:
+    """
+    Run the job manager, pulling tasks from the queue and handling them with workers.
+    """
     asyncio_run(
         supervisor.runit(
             factories.load_factory(factory_fn),
@@ -346,17 +321,15 @@ def run(
 @app.command(help="Manage schedules in the PGQueuer system.")
 def schedules(
     ctx: Context,
-    remove: list[str] = typer.Option([], "-r", "--remove"),
+    remove: list[str] = typer.Option([], "-r", "--remove", help="Remove schedules by ID or name."),
 ) -> None:
-    config: AppConfig = ctx.obj
-
     async def run_async() -> None:
-        q = await query_adapter(config.dsn, qb.DBSettings())
-        if remove:
-            schedule_ids = {models.ScheduleId(int(x)) for x in remove if x.isdigit()}
-            schedule_names = {x for x in remove if not x.isdigit()}
-            await q.delete_schedule(schedule_ids, schedule_names)
-        await display_schedule(await q.peak_schedule())
+        async with yield_queries(ctx) as q:
+            if remove:
+                schedule_ids = {models.ScheduleId(int(x)) for x in remove if x.isdigit()}
+                schedule_names = {x for x in remove if not x.isdigit()}
+                await q.delete_schedule(schedule_ids, schedule_names)
+            await display_schedule(await q.peak_schedule())
 
     asyncio_run(run_async())
 
@@ -364,24 +337,19 @@ def schedules(
 @app.command(help="Manually enqueue a job into the PGQueuer system.")
 def queue(
     ctx: Context,
-    entrypoint: str = typer.Argument(
-        ...,
-        help="The entry point of the job to be executed.",
-    ),
-    payload: None | str = typer.Argument(
-        None,
-        help="Optional payload for the job. Can be any serialized data (e.g., JSON or a string)",
+    entrypoint: str = typer.Argument(..., help="The entry point of the job to be executed."),
+    payload: str | None = typer.Argument(
+        None, help="Optional payload for the job, can be any serialized data."
     ),
 ) -> None:
-    config: AppConfig = ctx.obj
-
     async def run_async() -> None:
-        await (await query_adapter(config.dsn, qb.DBSettings())).enqueue(
-            entrypoint,
-            None if payload is None else payload.encode(),
-            priority=0,
-            execute_after=timedelta(seconds=0),
-        )
+        async with yield_queries(ctx) as q:
+            await q.enqueue(
+                entrypoint,
+                None if payload is None else payload.encode(),
+                priority=0,
+                execute_after=timedelta(seconds=0),
+            )
 
     asyncio_run(run_async())
 
@@ -406,22 +374,17 @@ def alter_durability(
         durability: The desired durability level ('volatile', 'balanced', or 'durable').
         dry_run: Whether to print SQL commands without executing them.
     """
-    config: AppConfig = ctx.obj
     print(
         "\n".join(
-            queries.qb.QueryBuilderEnvironment(
+            qb.QueryBuilderEnvironment(
                 qb.DBSettings(durability=durability)
             ).build_alter_durability_query()
         )
     )
 
     async def run() -> None:
-        await (
-            await query_adapter(
-                config.dsn,
-                qb.DBSettings(durability=durability),
-            )
-        ).alter_durability()
+        async with yield_queries(ctx, qb.DBSettings(durability=durability)) as q:
+            await q.alter_durability()
 
     if not dry_run:
         asyncio_run(run())


### PR DESCRIPTION
This refactoring introduces a `--factory` option in the main callback for all commands, allowing users to override the default `Queries` creation with a custom factory. An async context manager centralizes the logic, ensuring consistent creation and cleanup. All docstrings, type hints, and help text have been updated accordingly.