### PR TITLE
Add QueueExecutionMode to Support Continuous and Drain Execution Modes

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -100,6 +100,20 @@ This design minimizes disruptions and ensures job integrity.
     # Using the traditional approach
     python3 -m pgqueuer run <module+factory-function>
 
+### Queue Execution Modes
+
+The `run` command supports two execution modes:
+
+- **Continuous (default)**: Keeps processing jobs indefinitely, waiting for new ones as they arrive.
+- **Drain**: Processes all available jobs and shuts down once the queue is empty.
+
+**Example**:
+```sh
+pgq run my_module.my_factory --mode drain
+```
+
+Use **continuous** for long-running workers and **drain** for batch processing.
+
 Durability Explained
 --------------------
 

--- a/pgqueuer/applications.py
+++ b/pgqueuer/applications.py
@@ -26,6 +26,7 @@ from .qb import DBSettings
 from .qm import QueueManager
 from .sm import SchedulerManager
 from .tm import TaskManager
+from .types import QueueExecutionMode
 
 
 @dataclasses.dataclass
@@ -62,7 +63,7 @@ class PgQueuer:
         self,
         dequeue_timeout: timedelta = timedelta(seconds=30),
         batch_size: int = 10,
-        burst_mode: bool = False,
+        mode: QueueExecutionMode = QueueExecutionMode.continuous,
     ) -> None:
         """
         Run both QueueManager and SchedulerManager concurrently.
@@ -80,7 +81,7 @@ class PgQueuer:
                     self.qm.run(
                         batch_size=batch_size,
                         dequeue_timeout=dequeue_timeout,
-                        brust_mode=burst_mode,
+                        mode=mode,
                     )
                 )
             )

--- a/pgqueuer/applications.py
+++ b/pgqueuer/applications.py
@@ -62,6 +62,7 @@ class PgQueuer:
         self,
         dequeue_timeout: timedelta = timedelta(seconds=30),
         batch_size: int = 10,
+        burst_mode: bool = False,
     ) -> None:
         """
         Run both QueueManager and SchedulerManager concurrently.
@@ -79,6 +80,7 @@ class PgQueuer:
                     self.qm.run(
                         batch_size=batch_size,
                         dequeue_timeout=dequeue_timeout,
+                        brust_mode=burst_mode,
                     )
                 )
             )

--- a/pgqueuer/cli.py
+++ b/pgqueuer/cli.py
@@ -12,7 +12,7 @@ from tabulate import tabulate
 from typer import Context
 from typing_extensions import AsyncGenerator
 
-from . import db, factories, helpers, listeners, logconfig, models, qb, queries, supervisor
+from . import db, factories, helpers, listeners, logconfig, models, qb, queries, supervisor, types
 
 try:
     from uvloop import run as asyncio_run
@@ -365,7 +365,7 @@ def listen(
     asyncio_run(run())
 
 
-@app.command(help="Start a QueueManager to manage and process jobs.")
+@app.command(help="Start a PGQueuer.")
 def run(
     factory_fn: str = typer.Argument(
         ...,
@@ -396,6 +396,11 @@ def run(
         "--log-level",
         help="Set pgqueuer log level.",
     ),
+    mode: types.QueueExecutionMode = typer.Option(
+        types.QueueExecutionMode.continuous.name,
+        "--mode",
+        help="Queue execution mode.",
+    ),
 ) -> None:
     """
     Run the job manager, pulling tasks from the queue and handling them with workers.
@@ -410,6 +415,7 @@ def run(
             restart_delay=timedelta(seconds=restart_delay if restart_on_failure else 0),
             restart_on_failure=restart_on_failure,
             shutdown=asyncio.Event(),
+            mode=mode,
         )
     )
 

--- a/pgqueuer/qm.py
+++ b/pgqueuer/qm.py
@@ -35,6 +35,7 @@ from . import (
     qb,
     queries,
     tm,
+    types,
 )
 
 warnings.simplefilter("default", DeprecationWarning)
@@ -378,7 +379,7 @@ class QueueManager:
         self,
         dequeue_timeout: timedelta = timedelta(seconds=30),
         batch_size: int = 10,
-        burst_mode: bool = False,
+        mode: types.QueueExecutionMode = types.QueueExecutionMode.continuous,
     ) -> None:
         """
         Run the main loop to process jobs from the queue.
@@ -451,12 +452,12 @@ class QueueManager:
                         )
                     )
 
-                # Run until the queue is empty and then shutdown.
-                if burst_mode:
-                    self.shutdown.set()
-
                     with contextlib.suppress(asyncio.QueueEmpty):
                         notice_event_listener.get_nowait()
+
+                # Run until the queue is empty and then shutdown.
+                if mode is types.QueueExecutionMode.drain:
+                    self.shutdown.set()
 
                 event_task = helpers.wait_for_notice_event(
                     notice_event_listener,

--- a/pgqueuer/qm.py
+++ b/pgqueuer/qm.py
@@ -378,6 +378,7 @@ class QueueManager:
         self,
         dequeue_timeout: timedelta = timedelta(seconds=30),
         batch_size: int = 10,
+        burst_mode: bool = False,
     ) -> None:
         """
         Run the main loop to process jobs from the queue.
@@ -388,6 +389,8 @@ class QueueManager:
         Args:
             dequeue_timeout (timedelta): Timeout duration for waiting to dequeue jobs.
             batch_size (int): Number of jobs to retrieve in each batch.
+            burst_mode (bool): Whether to run in burst mode, fetch until
+                queue is empty then shutdown.
 
         Raises:
             RuntimeError: If required database columns or types are missing.
@@ -447,6 +450,10 @@ class QueueManager:
                             )
                         )
                     )
+
+                # Run until the queue is empty and then shutdown.
+                if burst_mode:
+                    self.shutdown.set()
 
                     with contextlib.suppress(asyncio.QueueEmpty):
                         notice_event_listener.get_nowait()

--- a/pgqueuer/types.py
+++ b/pgqueuer/types.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import Literal, NewType
+
+
+###### Queue ######
+class QueueExecutionMode(Enum):
+    continuous = "continuous"  # Normal queue processing with a continuous worker loop
+    drain = "drain"  # Process all jobs until empty, then shut down
+
 
 ###### Events ######
 Channel = NewType("Channel", str)

--- a/test/test_superviser.py
+++ b/test/test_superviser.py
@@ -10,6 +10,7 @@ import async_timeout
 import pytest
 
 from pgqueuer import AsyncpgDriver, PgQueuer, QueueManager, SchedulerManager, supervisor
+from pgqueuer.types import QueueExecutionMode
 
 
 @pytest.fixture(scope="function")
@@ -102,6 +103,7 @@ async def test_runit_normal_operation(
             restart_delay=timedelta(seconds=2),
             restart_on_failure=False,
             shutdown=shutdown_event,
+            mode=QueueExecutionMode.continuous,
         )
     )
 
@@ -145,6 +147,7 @@ async def test_runit_restart_on_failure(
             restart_delay=timedelta(seconds=0.05),
             restart_on_failure=True,
             shutdown=shutdown_event,
+            mode=QueueExecutionMode.continuous,
         )
     )
 
@@ -182,6 +185,7 @@ async def test_runit_no_restart_on_failure(
             restart_delay=timedelta(seconds=2),
             restart_on_failure=False,
             shutdown=shutdown_event,
+            mode=QueueExecutionMode.continuous,
         )
 
 
@@ -194,6 +198,7 @@ async def test_runit_negative_restart_delay(shutdown_event: asyncio.Event) -> No
             restart_delay=timedelta(seconds=-1),
             restart_on_failure=True,
             shutdown=shutdown_event,
+            mode=QueueExecutionMode.continuous,
         )
 
 
@@ -206,4 +211,5 @@ async def test_run_manager_invalid_manager() -> None:
             InvalidManager(),  # type: ignore
             dequeue_timeout=timedelta(seconds=1),
             batch_size=10,
+            mode=QueueExecutionMode.continuous,
         )


### PR DESCRIPTION
Closes #314 

Introduces `QueueExecutionMode`, an enumeration defining two execution modes for queue processing: `continuous` (default) and `drain` (process until empty, then shut down). The mode is now configurable across `PgQueuer`, `QueueManager`, CLI, and `supervisor.py`, ensuring flexible execution control. Corresponding tests and type annotations have been updated accordingly.