### PR TITLE
Fix TODO comment typo

### DIFF
--- a/pgqueuer/types.py
+++ b/pgqueuer/types.py
@@ -12,7 +12,7 @@ class QueueExecutionMode(Enum):
 
 ###### Events ######
 Channel = NewType("Channel", str)
-PGChannel = Channel  # TODO: Depricate
+PGChannel = Channel  # TODO: Deprecate
 OPERATIONS = Literal["insert", "update", "delete", "truncate"]
 EVENT_TYPES = Literal[
     "table_changed_event",


### PR DESCRIPTION
## Summary
- fix a typo in `PGChannel` comment

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: ERROR at setup of test_enqueue_and_size)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9ec9170832d9e9d614872c434d9