### PR TITLE
Fix TTLCache expiration timing

### DIFF
--- a/pgqueuer/cache.py
+++ b/pgqueuer/cache.py
@@ -50,7 +50,6 @@ class TTLCache(Generic[T]):
         if self.value is not UNSET and now <= self.expires_at:
             return cast(T, self.value)
         if self.update_task is None or self.update_task.done():
-            self.expires_at = datetime.now() + self.ttl
             self.update_task = asyncio.create_task(self._update_value())
         await self.update_task
         return cast(T, self.value)
@@ -66,6 +65,7 @@ class TTLCache(Generic[T]):
         """
         async with self.lock:
             self.value = await self.on_expired()
+            self.expires_at = datetime.now() + self.ttl
 
     @classmethod
     def create(cls, ttl: timedelta, on_expired: Callable[[], Awaitable[T]]) -> TTLCache[T]:


### PR DESCRIPTION
## Summary
- ensure TTLCache's expiration is set after updating

## Testing
- `pytest test/test_cache.py -q`
- `pytest -q` *(fails: connection refused to postgres)*

------
https://chatgpt.com/codex/tasks/task_e_683fe4fbc6cc832d8a2afc9419371064