### PR TITLE
Improve Makefile helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,48 @@
-COMPOSE_FILE = docker-compose.yml
+COMPOSE_FILE ?= docker-compose.yml
+HOST_ENV = PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432
 
-.PHONY: help build up populate test down clean
+.PHONY: help build up db down clean pytest benchmark lint typecheck sync check
 
 help:
-	@echo "============================="
-	@echo " PGQueuer Makefile Commands"
-	@echo "============================="
-	@echo " build     Build Docker images"
-	@echo " up        Start pgq container in background"
-	@echo " populate  Run the populate service"
-	@echo " test      Bring everything up, run tests, then exit"
-	@echo " down      Stop and remove containers"
-	@echo " clean     Remove containers, networks, volumes, and images"
-
+	@echo "PGQueuer Makefile"
+	@echo "Available commands:"
+	@echo "  build       Build docker images"
+	@echo "  up          Start database container"
+	@echo "  db          Start database and populate tables"
+	@echo "  pytest      Run pytest"
+	@echo "  benchmark   Run benchmark"
+	@echo "  lint        Run ruff linter"
+	@echo "  typecheck   Run mypy type checks"
+	@echo "  sync        Install dependencies via uv"
+	@echo "  check       Run lint, typecheck, sync and pytest"
+	@echo "  down        Stop containers"
+	@echo "  clean       Remove containers, networks, volumes and images"
 
 build:
 	docker compose -f $(COMPOSE_FILE) build
 
 up:
-	docker compose -f $(COMPOSE_FILE) up db
+	docker compose -f $(COMPOSE_FILE) up -d db
 
-db:
-	docker compose -f $(COMPOSE_FILE) up db populate
-
-populate:
+db: up
 	docker compose -f $(COMPOSE_FILE) run --rm populate
 
-test:
-	docker compose -f $(COMPOSE_FILE) run --rm test
+pytest:
+	$(HOST_ENV) uv run pytest $(ARGS)
 
 benchmark:
 	docker compose -f $(COMPOSE_FILE) run --rm benchmark
+
+lint:
+	$(HOST_ENV) uv run ruff check .
+
+typecheck:
+	$(HOST_ENV) uv run mypy .
+
+sync:
+	$(HOST_ENV) uv sync --all-extras --frozen
+
+check: lint typecheck sync pytest
 
 down:
 	docker compose -f $(COMPOSE_FILE) down


### PR DESCRIPTION
## Summary
- simplify Makefile usage
- add helper targets for pytest, lint, type checks and more

## Testing
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run ruff check .`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run mypy .`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv sync --all-extras --frozen`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_685842bed164832daad53108445ea7b1