### PR TITLE
Refine docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,16 @@
+version: "3.9"
+
+x-app-environment: &app-environment
+  PGUSER: pgquser
+  PGDATABASE: pgqdb
+  PGPASSWORD: pgqpw
+  PGHOST: db
+
+x-app-base: &app-base
+  build: .
+  working_dir: /app
+  environment: *app-environment
+
 services:
   db:
     image: postgres:${POSTGRES_VERSION:-16}
@@ -17,45 +30,27 @@ services:
     restart: "no"
 
   populate:
-    environment:
-      PGUSER: pgquser
-      PGDATABASE: pgqdb
-      PGPASSWORD: pgqpw
-      PGHOST: db
+    <<: *app-base
     depends_on:
       db:
         condition: service_healthy
-    build: .
-    working_dir: /app
     command: >
-      uv run --frozen pgq install || true;
-      uv run --frozen pgq autovac || true;
+      uv run --frozen pgq install || uv run --frozen pgq upgrade;
+      uv run --frozen pgq autovac;
     restart: "no"
 
   test:
-    environment:
-      PGUSER: pgquser
-      PGDATABASE: pgqdb
-      PGPASSWORD: pgqpw
-      PGHOST: db
+    <<: *app-base
     depends_on:
       populate:
         condition: service_completed_successfully
-    build: .
-    working_dir: /app
     command: uv -n run --frozen pytest
     restart: "no"
 
   benchmark:
-    environment:
-      PGUSER: pgquser
-      PGDATABASE: pgqdb
-      PGPASSWORD: pgqpw
-      PGHOST: db
+    <<: *app-base
     depends_on:
       populate:
         condition: service_completed_successfully
-    build: .
-    working_dir: /app
     command: uv -n run --frozen tools/benchmark.py
     restart: "no"


### PR DESCRIPTION
## Summary
- clean up docker-compose using YAML anchors
- use a shared base service for `test` and `benchmark`
- keep populate step but depend on DB health
- update populate command to upgrade existing schema

## Testing
- `ruff check .`
- `mypy .`
- `uv sync --all-extras --frozen`
- `pytest -v` *(failed: tests hung, terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_685868f220b0832db22056f63318163d