### PR TITLE
Make trigger ignore heartbeat updates

### DIFF
--- a/pgqueuer/qb.py
+++ b/pgqueuer/qb.py
@@ -336,7 +336,8 @@ class QueryBuilderEnvironment:
     $$ LANGUAGE plpgsql;
 
     CREATE TRIGGER {self.settings.trigger}
-    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON {self.settings.queue_table}
+    AFTER INSERT OR UPDATE OF priority, queue_manager_id, execute_after, status,
+          entrypoint, dedupe_key, payload OR DELETE OR TRUNCATE ON {self.settings.queue_table}
     EXECUTE FUNCTION {self.settings.function}();
         """  # noqa: E501
 
@@ -414,6 +415,11 @@ class QueryBuilderEnvironment:
 
     END;
     $$ LANGUAGE plpgsql;"""
+        yield f"DROP TRIGGER IF EXISTS {self.settings.trigger} ON {self.settings.queue_table};"
+        yield f"""CREATE TRIGGER {self.settings.trigger}
+    AFTER INSERT OR UPDATE OF priority, queue_manager_id, execute_after, status,
+          entrypoint, dedupe_key, payload OR DELETE OR TRUNCATE ON {self.settings.queue_table}
+    EXECUTE FUNCTION {self.settings.function}();"""
         yield f"ALTER TABLE {self.settings.queue_table} ADD COLUMN IF NOT EXISTS heartbeat TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();"  # noqa: E501
         yield f"CREATE INDEX IF NOT EXISTS {self.settings.queue_table}_heartbeat_id_id1_idx ON {self.settings.queue_table} (heartbeat ASC, id DESC) INCLUDE (id) WHERE status = 'picked';"  # noqa: E501
         yield f"ALTER TABLE {self.settings.queue_table} ADD COLUMN IF NOT EXISTS queue_manager_id UUID;"  # noqa: E501


### PR DESCRIPTION
## Summary
- avoid notifications when only housekeeping columns change
- drop & recreate trigger during upgrades so it monitors fewer columns

## Testing
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run ruff check .`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run mypy .`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv sync --all-extras --frozen`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_6865017952cc832d89972f6a67d038cd