### PR TITLE
Make trigger ignore heartbeat updates

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -38,6 +38,7 @@ async def apgdriver() -> AsyncGenerator[AsyncpgDriver, None]:
     conn = await asyncpg.connect(dsn=dsn())
     driver = AsyncpgDriver(conn)
     await clear_all(driver)
+    await Queries(driver).upgrade()
     try:
         yield driver
     finally:

--- a/test/test_listeners.py
+++ b/test/test_listeners.py
@@ -216,8 +216,15 @@ async def test_emit_stable_changed_update(apgdriver: db.Driver) -> None:
         uuid.uuid4(),
         global_concurrency_limit=1000,
     )
-    await asyncio.sleep(0.1)
-    assert len(evnets) == 0
+    async with timeout(1):
+        while len(evnets) < 1:
+            await asyncio.sleep(0)
+
+    assert len(evnets) == 1
+    (evt,) = evnets
+    assert evt.root.type == "table_changed_event"
+    assert evt.root.table == add_prefix("pgqueuer")
+    assert evt.root.operation == "update"
 
 
 async def test_emits_truncate_table_truncate(apgdriver: db.Driver) -> None:


### PR DESCRIPTION
## Summary
- avoid notifications when only housekeeping columns change
- drop & recreate trigger during upgrades so it monitors fewer columns
- delay the first heartbeat flush so quick jobs do not update
- include new update trigger tests
- run upgrade in tests so new triggers get installed

## Testing
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run ruff check .`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run mypy .`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv sync --all-extras --frozen`
- `PGUSER=pgquser PGDATABASE=pgqdb PGPASSWORD=pgqpw PGHOST=localhost PGPORT=5432 uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865017952cc832d89972f6a67d038cd