### PR TITLE
Improve TimedOverflowBuffer retries via dedicated RetryManager

### DIFF
--- a/pgqueuer/retries.py
+++ b/pgqueuer/retries.py
@@ -1,0 +1,146 @@
+"""
+Module for retry logic and strategy management.
+
+This module provides utilities for handling retry operations with different backoff strategies,
+extracted from the TimedOverflowBuffer to separate concerns and improve maintainability.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Awaitable, Callable, Generic, TypeVar
+
+from . import helpers, logconfig
+
+T = TypeVar("T")
+
+
+@dataclass
+class RetryManager(Generic[T]):
+    """
+    Manages retry logic with configurable backoff strategies.
+
+    This class handles the retry behavior for operations that may fail temporarily,
+    using exponential backoff to avoid overwhelming the target system.
+
+    Attributes:
+        retry_backoff (helpers.ExponentialBackoff): Backoff strategy for regular retries.
+        shutdown_backoff (helpers.ExponentialBackoff): Backoff strategy during shutdown.
+        shutdown (asyncio.Event): Event that signals when retries should stop.
+        logger (logging.Logger): Logger for retry operations.
+    """
+
+    retry_backoff: helpers.ExponentialBackoff = field(
+        default_factory=lambda: helpers.ExponentialBackoff(
+            start_delay=timedelta(seconds=0.01),
+            max_delay=timedelta(seconds=10),
+        ),
+    )
+    shutdown_backoff: helpers.ExponentialBackoff = field(
+        default_factory=lambda: helpers.ExponentialBackoff(
+            start_delay=timedelta(milliseconds=1),
+            max_delay=timedelta(milliseconds=100),
+        )
+    )
+    shutdown: asyncio.Event = field(init=False, default_factory=asyncio.Event)
+    logger: logging.Logger = field(default=logconfig.logger)
+
+    async def execute_with_retry(
+        self,
+        operation: Callable[[T], Awaitable[None]],
+        data: T,
+        *,
+        use_shutdown_backoff: bool = False,
+    ) -> bool:
+        """
+        Execute an operation with retry logic.
+
+        Args:
+            operation: The async operation to execute.
+            data: The data to pass to the operation.
+            use_shutdown_backoff: Whether to use shutdown backoff strategy.
+
+        Returns:
+            bool: True if operation succeeded, False if failed after retries.
+        """
+        backoff = self._select_backoff(use_shutdown_backoff)
+
+        try:
+            await operation(data)
+        except Exception as exc:  # noqa: BLE001 - propagate via logging
+            delay = backoff.next_delay()
+            self.logger.warning(
+                "Unable to execute %s: %s\nRetry in: %r",
+                getattr(operation, "__name__", operation.__class__.__name__),
+                str(exc),
+                delay,
+            )
+            await self._sleep(delay)
+            return False
+
+        backoff.reset()
+        return True
+
+    async def retry_until_success_or_limit(
+        self,
+        operation: Callable[[T], Awaitable[None]],
+        data: T,
+        *,
+        use_shutdown_backoff: bool = False,
+    ) -> bool:
+        """
+        Retry an operation until it succeeds or reaches the backoff limit.
+
+        Args:
+            operation: The async operation to execute.
+            data: The data to pass to the operation.
+            use_shutdown_backoff: Whether to use shutdown backoff strategy.
+
+        Returns:
+            bool: True if operation eventually succeeded, False if limit reached.
+        """
+        backoff = self._select_backoff(use_shutdown_backoff)
+        reached_limit = False
+
+        while True:
+            succeeded = await self.execute_with_retry(
+                operation,
+                data,
+                use_shutdown_backoff=use_shutdown_backoff,
+            )
+            if succeeded:
+                return True
+            if self.shutdown.is_set():
+                break
+
+            if backoff.current_delay >= backoff.max_delay:
+                if reached_limit:
+                    break
+                reached_limit = True
+
+        return False
+
+    def reset_backoff(self) -> None:
+        """Reset the retry backoff to initial values."""
+        self.retry_backoff.reset()
+
+    def reset_shutdown_backoff(self) -> None:
+        """Reset the shutdown backoff to initial values."""
+        self.shutdown_backoff.reset()
+
+    def set_shutdown(self) -> None:
+        """Signal that shutdown has been requested."""
+        self.shutdown.set()
+
+    def _select_backoff(self, use_shutdown_backoff: bool) -> helpers.ExponentialBackoff:
+        return self.shutdown_backoff if use_shutdown_backoff else self.retry_backoff
+
+    async def _sleep(self, delay: timedelta) -> None:
+        if self.shutdown.is_set():
+            await asyncio.sleep(0)
+            return
+
+        await asyncio.sleep(helpers.timeout_with_jitter(delay).total_seconds())

--- a/test/test_retries.py
+++ b/test/test_retries.py
@@ -1,0 +1,105 @@
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from pgqueuer import helpers, retries
+
+
+@pytest.mark.asyncio
+async def test_retry_manager_execute_success_resets_backoff() -> None:
+    backoff = helpers.ExponentialBackoff(
+        start_delay=timedelta(milliseconds=1),
+        max_delay=timedelta(milliseconds=8),
+    )
+    backoff.next_delay()  # advance state away from start_delay
+    manager: retries.RetryManager[list[int]] = retries.RetryManager(
+        retry_backoff=backoff,
+    )
+
+    async def noop(_: list[int]) -> None:
+        await asyncio.sleep(0)
+
+    succeeded = await manager.execute_with_retry(noop, [1, 2, 3])
+
+    assert succeeded is True
+    assert backoff.current_delay == backoff.start_delay
+
+
+@pytest.mark.asyncio
+async def test_retry_manager_execute_failure_invokes_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backoff = helpers.ExponentialBackoff(
+        start_delay=timedelta(milliseconds=1),
+        max_delay=timedelta(milliseconds=8),
+    )
+    manager: retries.RetryManager[list[int]] = retries.RetryManager(
+        retry_backoff=backoff,
+    )
+
+    sleep_calls: list[float] = []
+    jitter_calls: list[timedelta] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    def fake_jitter(delay: timedelta) -> timedelta:
+        jitter_calls.append(delay)
+        return timedelta(milliseconds=2)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(helpers, "timeout_with_jitter", fake_jitter)
+
+    async def fail(_: list[int]) -> None:
+        raise RuntimeError("boom")
+
+    succeeded = await manager.execute_with_retry(fail, [1])
+
+    assert succeeded is False
+    assert backoff.current_delay == timedelta(milliseconds=2)
+    assert jitter_calls == [timedelta(milliseconds=2)]
+    assert sleep_calls == [pytest.approx(timedelta(milliseconds=2).total_seconds())]
+
+
+@pytest.mark.asyncio
+async def test_retry_manager_retry_until_success_or_limit() -> None:
+    backoff = helpers.ExponentialBackoff(
+        start_delay=timedelta(milliseconds=1),
+        max_delay=timedelta(milliseconds=4),
+    )
+    manager: retries.RetryManager[list[int]] = retries.RetryManager(
+        retry_backoff=backoff,
+    )
+
+    attempts = 0
+
+    async def op(_: list[int]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise RuntimeError("try again")
+
+    succeeded = await manager.retry_until_success_or_limit(op, [1])
+
+    assert succeeded is True
+    assert attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_manager_stops_when_shutdown_set() -> None:
+    backoff = helpers.ExponentialBackoff(
+        start_delay=timedelta(milliseconds=1),
+        max_delay=timedelta(milliseconds=2),
+    )
+    manager: retries.RetryManager[list[int]] = retries.RetryManager(
+        retry_backoff=backoff,
+    )
+    manager.set_shutdown()
+
+    async def fail(_: list[int]) -> None:
+        raise RuntimeError("fail")
+
+    succeeded = await manager.retry_until_success_or_limit(fail, [1])
+
+    assert succeeded is False


### PR DESCRIPTION
Closes: https://github.com/janbjorge/pgqueuer/issues/379

Summary
- Extracted retry orchestration into `RetryManager`, keeping backoff logic, jittered sleeps, and shutdown coordination isolated from buffering concerns (`pgqueuer/retries.py`).  
- Updated `TimedOverflowBuffer` to delegate flush attempts through `RetryManager`, clarified batch collection/requeue helpers, and tightened shutdown flow for readability (`pgqueuer/buffers.py`).  
- Added focused tests covering retry jitter, shutdown behaviour, lock-guarded flushes, and success-after-retry scenarios, plus new unit tests for `RetryManager` operations (`test/test_buffers.py`, `test/test_retries.py`).