### PR TITLE
Add PgQueuer classmethods for connection initialization

### DIFF
--- a/test/test_pgqueuer.py
+++ b/test/test_pgqueuer.py
@@ -8,7 +8,7 @@ import pytest
 
 from pgqueuer import db
 from pgqueuer.applications import PgQueuer
-from pgqueuer.db import AsyncpgDriver, Driver
+from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, Driver, PsycopgDriver
 from pgqueuer.models import CronExpressionEntrypoint, Job, Schedule
 from pgqueuer.qb import DBSettings
 from pgqueuer.queries import Queries
@@ -276,3 +276,185 @@ async def test_schedule_storage_and_retrieval(
     assert received is not None
     assert received.entrypoint == entrypoint
     assert received.expression == expression
+
+
+# Tests for PgQueuer classmethods
+
+
+async def test_pgqueuer_from_asyncpg_connection(dsn: str) -> None:
+    """Test creating PgQueuer from an asyncpg connection."""
+    import asyncpg
+
+    connection = await asyncpg.connect(dsn=dsn)
+    try:
+        pgq = PgQueuer.from_asyncpg_connection(connection)
+
+        # Verify the instance is properly configured
+        assert isinstance(pgq, PgQueuer)
+        assert isinstance(pgq.connection, AsyncpgDriver)
+        assert pgq.qm is not None
+        assert pgq.sm is not None
+        assert pgq.resources == {}
+
+        # Test that it can be used to enqueue and process jobs
+        seen = list[int]()
+
+        @pgq.entrypoint("test_job")
+        async def test_job(job: Job) -> None:
+            assert job.payload is not None
+            seen.append(int(job.payload))
+
+        await pgq.qm.queries.enqueue(
+            ["test_job"] * 3,
+            [f"{n}".encode() for n in range(3)],
+            [0] * 3,
+        )
+
+        await asyncio.gather(
+            pgq.run(),
+            wait_until_empty_queue(pgq.qm.queries, [pgq]),
+        )
+
+        assert seen == list(range(3))
+    finally:
+        await connection.close()
+
+
+async def test_pgqueuer_from_asyncpg_connection_with_resources(dsn: str) -> None:
+    """Test creating PgQueuer from an asyncpg connection with custom resources."""
+    import asyncpg
+
+    connection = await asyncpg.connect(dsn=dsn)
+    try:
+        custom_resources = {"shared_cache": {}, "counter": 0}
+        pgq = PgQueuer.from_asyncpg_connection(
+            connection,
+            resources=custom_resources,
+        )
+
+        # Verify resources are passed through
+        assert pgq.resources is custom_resources
+        assert pgq.resources["shared_cache"] == {}
+        assert pgq.resources["counter"] == 0
+        assert pgq.qm.resources is custom_resources
+    finally:
+        await connection.close()
+
+
+async def test_pgqueuer_from_asyncpg_pool(dsn: str) -> None:
+    """Test creating PgQueuer from an asyncpg connection pool."""
+    import asyncpg
+
+    pool = await asyncpg.create_pool(dsn=dsn, min_size=2, max_size=5)
+    try:
+        pgq = PgQueuer.from_asyncpg_pool(pool)
+
+        # Verify the instance is properly configured
+        assert isinstance(pgq, PgQueuer)
+        assert isinstance(pgq.connection, AsyncpgPoolDriver)
+        assert pgq.qm is not None
+        assert pgq.sm is not None
+        assert pgq.resources == {}
+
+        # Test that it can be used to enqueue and process jobs
+        seen = list[int]()
+
+        @pgq.entrypoint("pool_job")
+        async def pool_job(job: Job) -> None:
+            assert job.payload is not None
+            seen.append(int(job.payload))
+
+        await pgq.qm.queries.enqueue(
+            ["pool_job"] * 3,
+            [f"{n}".encode() for n in range(3)],
+            [0] * 3,
+        )
+
+        await asyncio.gather(
+            pgq.run(),
+            wait_until_empty_queue(pgq.qm.queries, [pgq]),
+        )
+
+        assert sorted(seen) == list(range(3))
+    finally:
+        await pool.close()
+
+
+async def test_pgqueuer_from_asyncpg_pool_with_resources(dsn: str) -> None:
+    """Test creating PgQueuer from an asyncpg pool with custom resources."""
+    import asyncpg
+
+    pool = await asyncpg.create_pool(dsn=dsn, min_size=2, max_size=5)
+    try:
+        custom_resources = {"db_pool": pool, "request_count": 0}
+        pgq = PgQueuer.from_asyncpg_pool(
+            pool,
+            resources=custom_resources,
+        )
+
+        # Verify resources are passed through
+        assert pgq.resources is custom_resources
+        assert pgq.resources["db_pool"] is pool
+        assert pgq.resources["request_count"] == 0
+    finally:
+        await pool.close()
+
+
+async def test_pgqueuer_from_psycopg_connection(dsn: str) -> None:
+    """Test creating PgQueuer from a psycopg async connection."""
+    import psycopg
+
+    connection = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    try:
+        pgq = PgQueuer.from_psycopg_connection(connection)
+
+        # Verify the instance is properly configured
+        assert isinstance(pgq, PgQueuer)
+        assert isinstance(pgq.connection, PsycopgDriver)
+        assert pgq.qm is not None
+        assert pgq.sm is not None
+        assert pgq.resources == {}
+
+        # Test that it can be used to enqueue and process jobs
+        seen = list[int]()
+
+        @pgq.entrypoint("psycopg_job")
+        async def psycopg_job(job: Job) -> None:
+            assert job.payload is not None
+            seen.append(int(job.payload))
+
+        await pgq.qm.queries.enqueue(
+            ["psycopg_job"] * 3,
+            [f"{n}".encode() for n in range(3)],
+            [0] * 3,
+        )
+
+        await asyncio.gather(
+            pgq.run(),
+            wait_until_empty_queue(pgq.qm.queries, [pgq]),
+        )
+
+        assert seen == list(range(3))
+    finally:
+        await connection.close()
+
+
+async def test_pgqueuer_from_psycopg_connection_with_resources(dsn: str) -> None:
+    """Test creating PgQueuer from a psycopg connection with custom resources."""
+    import psycopg
+
+    connection = await psycopg.AsyncConnection.connect(dsn, autocommit=True)
+    try:
+        custom_resources = {"psycopg_conn": connection, "transaction_count": 0}
+        pgq = PgQueuer.from_psycopg_connection(
+            connection,
+            resources=custom_resources,
+        )
+
+        # Verify resources are passed through
+        assert pgq.resources is custom_resources
+        assert pgq.resources["psycopg_conn"] is connection
+        assert pgq.resources["transaction_count"] == 0
+        assert pgq.qm.resources is custom_resources
+    finally:
+        await connection.close()


### PR DESCRIPTION
- Add from_asyncpg_connection() classmethod
- Add from_asyncpg_pool() classmethod
- Add from_psycopg_connection() classmethod

These classmethods simplify PgQueuer setup by handling driver instantiation automatically. All methods support optional channel and resources parameters.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [x] `make check` passed
- [x] Additional testing steps

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated documentation if necessary
