### PR TITLE
Refine queue trigger heartbeat handling

### DIFF
--- a/pgqueuer/queries.py
+++ b/pgqueuer/queries.py
@@ -239,6 +239,27 @@ class Queries:
         (row,) = rows
         return row["exists"]
 
+    async def table_has_trigger(self, table: str, trigger: str) -> bool:
+        """
+        Check if the trigger exists on table.
+
+        Returns:
+            bool: True if the trigger exists, False otherwise.
+        """
+        rows = await self.driver.fetch(
+            self.qbe.build_table_has_trigger_query(),
+            table,
+            trigger,
+        )
+        assert len(rows) == 1
+        (row,) = rows
+        return row["exists"]
+
+    async def ensure_notify_triggers(self) -> None:
+        """Install or refresh the queue notification triggers."""
+
+        await self.driver.execute(self.qbe.build_notify_triggers_reinstall_query())
+
     async def has_user_defined_enum(self, key: str, enum: str) -> bool:
         """Check if a value exists in a user-defined ENUM type."""
         rows = await self.driver.fetch(self.qbe.build_user_types_query())

--- a/test/test_listeners.py
+++ b/test/test_listeners.py
@@ -218,8 +218,15 @@ async def test_emit_stable_changed_update(apgdriver: db.Driver) -> None:
         uuid.uuid4(),
         global_concurrency_limit=1000,
     )
-    await asyncio.sleep(0.1)
-    assert len(evnets) == 0
+    async with timeout(1):
+        while len(evnets) < 1:
+            await asyncio.sleep(0)
+
+    (update_event,) = evnets
+    assert update_event.root.type == "table_changed_event"
+    assert update_event.root.table == add_prefix("pgqueuer")
+    assert update_event.root.operation == "update"
+    evnets.clear()
 
 
 async def test_emits_truncate_table_truncate(apgdriver: db.Driver) -> None:


### PR DESCRIPTION
## Summary
- Replaced the queue notification trigger with a straightforward row-level version that skips heartbeat-only updates yet still issues NOTIFY for meaningful changes.
- Added trigger recreation steps to the upgrade planner so existing installations pick up the new row-level + `_truncate` triggers without touching prior yields.
- Extended `QueueManager.verify_structure` to insist both triggers are present, steering users toward `pgq upgrade` if either is missing.

## Testing
- [ ] `make check` passed
- [x] Additional testing steps

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated documentation if necessary
