### PR TITLE
docs: reliability, performance, deployment, and database permissons

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,0 +1,203 @@
+# Deployment Patterns
+
+PgQueuer requires no message broker, Redis instance, or additional infrastructure — just
+PostgreSQL. This page covers how to run workers in production.
+
+## Single Worker Process
+
+The simplest deployment: one process, one `QueueManager`.
+
+```python
+# myapp.py
+import asyncpg
+from pgqueuer import PgQueuer
+from pgqueuer.db import AsyncpgDriver
+from pgqueuer.models import Job
+
+async def main() -> PgQueuer:
+    conn = await asyncpg.connect()
+    driver = AsyncpgDriver(conn)
+    pgq = PgQueuer(driver)
+
+    @pgq.entrypoint("process_order")
+    async def process_order(job: Job) -> None:
+        ...
+
+    return pgq
+```
+
+```bash
+pgq run myapp:main
+```
+
+This is sufficient for most workloads. A single `QueueManager` handles multiple entrypoints
+concurrently via asyncio.
+
+## Horizontal Scaling
+
+Run multiple worker processes against the same PostgreSQL database. PgQueuer uses
+`FOR UPDATE SKIP LOCKED` in every dequeue query, so workers never claim the same job:
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│  Worker  1   │     │  Worker  2   │     │  Worker  3   │
+│ QueueManager │     │ QueueManager │     │ QueueManager │
+└──────┬───────┘     └──────┬───────┘     └──────┬───────┘
+       │                    │                    │
+       └────────────────────┴────────────────────┘
+                            │
+                     ┌──────┴──────┐
+                     │ PostgreSQL  │
+                     └─────────────┘
+```
+
+Each worker:
+- Listens on the same `ch_pgqueuer` channel independently
+- Claims jobs atomically — no coordinator or leader election needed
+- Can run on separate VMs, containers, or processes on the same host
+
+**Starting multiple workers:**
+
+```bash
+# Fly.io: scale to 3 machines
+fly scale count 3
+
+# Docker Compose: scale service
+docker compose up --scale worker=3
+
+# Local: multiple terminals or background processes
+pgq run myapp:main &
+pgq run myapp:main &
+pgq run myapp:main
+```
+
+## One Process per CPU Core
+
+For CPU-bound workloads, run one worker per core to avoid GIL contention in Python:
+
+```bash
+# Using a shell loop
+for i in $(seq 1 $(nproc)); do
+    pgq run myapp:main &
+done
+wait
+```
+
+For IO-bound workloads (HTTP calls, database queries), a single asyncio process typically
+saturates a database connection before needing additional processes.
+
+## Process Supervision
+
+Use a supervisor to restart workers on crash.
+
+**systemd:**
+
+```ini
+# /etc/systemd/system/pgqueuer-worker.service
+[Unit]
+Description=PgQueuer Worker
+After=network.target postgresql.service
+
+[Service]
+User=app
+WorkingDirectory=/app
+ExecStart=pgq run myapp:main --shutdown-on-listener-failure
+Restart=always
+RestartSec=5
+Environment=PGHOST=localhost
+Environment=PGUSER=pgqueuer_app
+Environment=PGDATABASE=mydb
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl enable --now pgqueuer-worker
+```
+
+**Docker / Docker Compose:**
+
+```yaml
+services:
+  worker:
+    image: myapp:latest
+    command: pgq run myapp:main --shutdown-on-listener-failure
+    restart: always
+    environment:
+      PGHOST: db
+      PGUSER: pgqueuer_app
+      PGDATABASE: mydb
+    depends_on:
+      db:
+        condition: service_healthy
+```
+
+**Fly.io:**
+
+Fly machines restart automatically on exit. Add `--shutdown-on-listener-failure` so a broken
+LISTEN connection causes a clean restart rather than silent degradation:
+
+```toml
+# fly.toml
+[processes]
+  worker = "pgq run myapp:main --shutdown-on-listener-failure"
+```
+
+## Graceful Shutdown
+
+`pgq run` handles `SIGTERM` and `SIGINT`. On receiving a signal:
+
+1. Stop accepting new jobs from the queue.
+2. Wait for in-flight jobs to complete (up to a configurable drain period).
+3. Exit cleanly.
+
+Container orchestrators (Kubernetes, Fly.io, ECS) send `SIGTERM` before `SIGKILL`, so
+in-flight jobs finish provided the `terminationGracePeriodSeconds` is long enough.
+
+!!! tip
+    Set `terminationGracePeriodSeconds` to at least the 95th-percentile runtime of your
+    longest job plus a 30-second buffer.
+
+## Schema Migrations on Deploy
+
+Run `pgq upgrade` before deploying new application code. It is safe to run against a live
+database — migrations are additive and non-destructive:
+
+```bash
+# Deploy workflow
+pgq upgrade          # apply schema changes
+# then roll out new workers
+```
+
+`pgq upgrade` is idempotent: running it multiple times produces no side effects.
+
+## Environment Configuration
+
+PgQueuer reads standard PostgreSQL environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `PGHOST` | Database host |
+| `PGPORT` | Database port (default `5432`) |
+| `PGUSER` | Database user |
+| `PGPASSWORD` | Database password |
+| `PGDATABASE` | Database name |
+| `PGQUEUER_PREFIX` | Prefix for table/channel names (default `pgqueuer`) |
+
+Use `PGQUEUER_PREFIX` to run multiple isolated PgQueuer instances in the same database:
+
+```bash
+PGQUEUER_PREFIX=billing pgq install
+PGQUEUER_PREFIX=billing pgq run billing_app:main
+```
+
+## Deployment Checklist
+
+- [ ] `pgq install` run once against the target database
+- [ ] `pgq autovac` applied after installation
+- [ ] Application role granted [minimal runtime privileges](../reference/database-permissions.md)
+- [ ] Workers started with `--shutdown-on-listener-failure`
+- [ ] Supervisor configured to restart workers on exit
+- [ ] `pgq upgrade` included in the deploy pipeline before rolling out new workers
+- [ ] `terminationGracePeriodSeconds` (or equivalent) set to cover longest expected job runtime

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -1,0 +1,159 @@
+# Performance Tuning
+
+This page covers the knobs available for tuning PgQueuer throughput and latency in production.
+
+## Batch Size
+
+`batch_size` controls how many jobs are fetched from the database in a single `FOR UPDATE SKIP LOCKED` query.
+
+```python
+await pgq.run(batch_size=25, dequeue_timeout=timedelta(seconds=10))
+```
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| `batch_size` | `10` | Jobs fetched per dequeue round-trip |
+| `dequeue_timeout` | `30 s` | How long to wait for new NOTIFY before polling |
+
+**Tuning guidance:**
+- Increase `batch_size` when jobs are short-lived (< 1 s) and you see many dequeue round-trips
+  per second in your query logs.
+- Decrease it when jobs are long-running and you want finer concurrency control.
+- `max_concurrent_tasks` must be at least `2 × batch_size`; PgQueuer enforces this.
+
+## Concurrency Limits
+
+Limit concurrent execution globally or per-entrypoint:
+
+```python
+# Global cap across all entrypoints
+await pgq.run(batch_size=20, max_concurrent_tasks=100)
+
+# Per-entrypoint cap
+@pgq.entrypoint("resize_image", concurrency_limit=4)
+async def resize_image(job: Job) -> None:
+    ...
+
+# Per-entrypoint rate cap
+@pgq.entrypoint("send_sms", requests_per_second=10.0)
+async def send_sms(job: Job) -> None:
+    ...
+```
+
+Use per-entrypoint limits when specific tasks share a scarce external resource (e.g., an API
+with rate limits). Use `max_concurrent_tasks` as a safety ceiling on total asyncio tasks.
+
+## Connection Pooling
+
+For high-throughput deployments, use a connection pool driver instead of a single connection:
+
+```python
+import asyncpg
+from pgqueuer.db import AsyncpgPoolDriver
+
+pool = await asyncpg.create_pool(min_size=5, max_size=20)
+driver = AsyncpgPoolDriver(pool)
+pgq = PgQueuer(driver)
+```
+
+**Pool sizing guidance:**
+- A single `QueueManager` uses one connection for the LISTEN channel and borrows connections
+  briefly for each dequeue/status-update round-trip.
+- Start with `max_size = 2 × expected_concurrent_jobs` and adjust based on `pg_stat_activity`.
+- Avoid pools larger than your PostgreSQL `max_connections` allows.
+
+## Durability vs. Throughput
+
+Choose the durability level that matches your risk tolerance:
+
+| Level | Tables | Crash behaviour | Throughput |
+|-------|--------|-----------------|------------|
+| `durable` (default) | Logged (WAL) | No data loss | Baseline |
+| `balanced` | Queue: unlogged; Log: logged | Queue data lost on crash | ~2× |
+| `volatile` | All unlogged | All data lost on crash | Highest |
+
+Change durability after installation without data loss:
+
+```bash
+pgq durability balanced
+```
+
+!!! warning
+    `volatile` and `balanced` modes lose in-flight jobs on a PostgreSQL crash or restart.
+    Use only for jobs that are safe to drop and re-enqueue (e.g., cache-warming, fire-and-forget
+    analytics).
+
+## Autovacuum Tuning
+
+The `pgqueuer` table is high-churn: rows are inserted and then deleted rapidly. Without tuned
+autovacuum, dead tuple bloat accumulates and slows down index scans.
+
+Apply PgQueuer's recommended autovacuum settings:
+
+```bash
+pgq autovac
+```
+
+What this sets on `pgqueuer` and `pgqueuer_schedules` (high-churn tables):
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `autovacuum_vacuum_scale_factor` | `0.01` | Vacuum at 1% dead-tuple ratio |
+| `autovacuum_vacuum_cost_limit` | `10000` | Aggressive vacuum speed |
+| `autovacuum_vacuum_cost_delay` | `0` | No throttling |
+| `fillfactor` | `70` | Leave 30% free for HOT updates |
+
+`pgqueuer_log` uses conservative settings (vacuum at 95% dead-tuple ratio) since it is
+append-only.
+
+Revert to system defaults:
+
+```bash
+pgq autovac --rollback
+```
+
+## NOTIFY Channel and Polling Fallback
+
+PgQueuer uses `LISTEN/NOTIFY` for near-instant job pickup. A trigger fires on every insert
+into `pgqueuer` and sends a notification on the `ch_pgqueuer` channel.
+
+**What can go wrong:** pgBouncer in transaction-pooling mode drops `LISTEN` subscriptions
+between transactions. PgQueuer handles this in two ways:
+
+1. **Polling fallback** — `QueueManager` re-polls after `dequeue_timeout` even without a
+   NOTIFY, so jobs are never permanently stuck.
+2. **Listener health check** — start with `--shutdown-on-listener-failure` so a supervisor
+   can restart a manager whose LISTEN channel has become unhealthy:
+
+```bash
+pgq run myapp:main --shutdown-on-listener-failure
+```
+
+!!! tip "Use a dedicated connection for LISTEN"
+    Always use a direct `asyncpg` connection (not a pool) for the `QueueManager`. Reserve
+    the pool for producers. This avoids the LISTEN-loss problem entirely.
+
+## Indexes
+
+PgQueuer installs all required indexes automatically. The most important for throughput:
+
+```sql
+-- Used for every dequeue: priority-ordered job selection
+CREATE INDEX ON pgqueuer (priority DESC, id ASC)
+WHERE status = 'queued';
+
+-- Used for heartbeat-based retry detection
+CREATE INDEX ON pgqueuer (updated, id)
+WHERE status = 'picked';
+```
+
+These partial indexes are maintained by `pgq install` and `pgq upgrade`. Do not drop them.
+
+## Quick-Reference Checklist
+
+- [ ] Run `pgq autovac` after installation
+- [ ] Choose a `durability` level appropriate for your crash recovery requirements
+- [ ] Use `AsyncpgPoolDriver` for producers; a single connection for `QueueManager`
+- [ ] Set `retry_timer` to recover from worker crashes automatically
+- [ ] Add `--shutdown-on-listener-failure` when running behind a PgBouncer pool
+- [ ] Monitor `pgqueuer_log` table size and prune if needed

--- a/docs/guides/reliability.md
+++ b/docs/guides/reliability.md
@@ -1,0 +1,146 @@
+# Reliability Model
+
+This page explains how PgQueuer handles failures, ensures jobs are not lost, supports
+idempotent enqueuing, and provides an audit trail of every completed job.
+
+## Failure Handling
+
+When a job raises an unhandled exception, PgQueuer:
+
+1. Marks the job status as `exception`.
+2. Captures the full traceback, exception type, and message into a **TracebackRecord**.
+3. Moves the record from the active queue (`pgqueuer`) to the log table (`pgqueuer_log`).
+
+The job is **not** automatically retried at this point — it is considered definitively failed
+for this execution attempt. The traceback is persisted for inspection via `pgq logs` or a
+direct query:
+
+```sql
+SELECT job_id, entrypoint, exception_type, exception_message, traceback
+FROM pgqueuer_log
+WHERE status = 'exception'
+ORDER BY created DESC
+LIMIT 20;
+```
+
+## Retry Strategies
+
+PgQueuer provides two complementary retry mechanisms.
+
+### Per-attempt retry: transient errors
+
+Use `RetryWithBackoffEntrypointExecutor` to automatically retry a job function when it raises
+an exception, before the job is marked as failed. This is suitable for transient errors such
+as network timeouts or rate-limited APIs.
+
+```python
+from datetime import timedelta
+from pgqueuer.executors import RetryWithBackoffEntrypointExecutor
+
+@pgq.entrypoint(
+    "send_email",
+    executor_factory=lambda parameters: RetryWithBackoffEntrypointExecutor(
+        parameters=parameters,
+        max_attempts=5,
+        max_delay=timedelta(seconds=30),
+        max_time=timedelta(minutes=2),
+    ),
+)
+async def send_email(job: Job) -> None:
+    await smtp_client.send(job.payload)
+```
+
+See [Custom Executors](custom-executors.md#retry-with-backoff-executor) for full parameter
+details.
+
+### Worker-crash recovery: stalled jobs
+
+If a worker process crashes mid-job, the job remains in `picked` state with a stale heartbeat.
+Configure `retry_timer` on `QueueManager` to automatically re-queue jobs whose heartbeat has
+not been updated within the specified window:
+
+```python
+from datetime import timedelta
+pgq = PgQueuer(driver, retry_timer=timedelta(minutes=5))
+```
+
+Any worker can then claim and re-run the stalled job. See
+[Heartbeat Monitoring](heartbeat.md) for stall detection queries.
+
+!!! warning "Design for re-execution"
+    A job recovered via `retry_timer` **will run again from the start**. Ensure your job
+    functions are idempotent, or checkpoint progress externally so a restart is safe.
+
+## Idempotency
+
+Pass a `dedupe_key` to prevent duplicate jobs from entering the queue:
+
+```python
+job_ids = await queries.enqueue(
+    "send_invoice",
+    payload=b'{"order_id": 42}',
+    dedupe_key="invoice-order-42",
+)
+```
+
+PgQueuer enforces a database-level unique constraint:
+
+```sql
+UNIQUE (dedupe_key)
+WHERE status IN ('queued', 'picked') AND dedupe_key IS NOT NULL
+```
+
+If a job with the same `dedupe_key` already exists in `queued` or `picked` state, a
+`DuplicateJobError` is raised. Once the job reaches a terminal state (`successful`,
+`exception`, `canceled`, `deleted`), the key is released and the same key can be used again.
+
+**Choosing a dedupe key:** Use a stable, business-meaningful identifier — for example,
+`f"invoice-{order_id}"` or `f"report-{date}-{user_id}"`. This turns enqueue into an
+idempotent operation: calling it twice with the same key and payload is safe.
+
+## Poison Jobs
+
+A "poison job" is one that consistently causes worker crashes or hangs without updating its
+heartbeat. PgQueuer does not include a built-in dead-letter queue, but you can detect and
+handle poison jobs with a query:
+
+```sql
+-- Jobs that have been re-picked more than 3 times (indicative of repeated failure)
+-- Adjust threshold based on your retry_timer and expected job runtime
+SELECT id, entrypoint, status, heartbeat, updated
+FROM pgqueuer
+WHERE status = 'picked'
+  AND heartbeat < NOW() - INTERVAL '10 minutes'
+ORDER BY heartbeat ASC;
+```
+
+**Recommended pattern:** route these to a separate monitoring alert or move them to a
+dedicated "quarantine" entrypoint by updating their entrypoint column and re-queuing.
+
+## Audit Trail
+
+Every job that leaves the active queue is written to `pgqueuer_log`:
+
+| Event | Status in log |
+|-------|--------------|
+| Job completes without error | `successful` |
+| Job raises an exception | `exception` (with traceback) |
+| Job is canceled | `canceled` |
+| Job is deleted without running | `deleted` |
+
+The log is **append-only** and serves as a permanent audit record. You can query it directly
+or use `pgq logs` from the CLI.
+
+!!! note "Log table retention"
+    PgQueuer does not automatically prune `pgqueuer_log`. Add a periodic `DELETE` job or
+    PostgreSQL table partition policy to manage log growth in high-throughput systems.
+
+## Summary
+
+| Concern | Mechanism |
+|---------|-----------|
+| Transient errors | `RetryWithBackoffEntrypointExecutor` |
+| Worker crash recovery | `retry_timer` + heartbeat |
+| Duplicate enqueue prevention | `dedupe_key` unique constraint |
+| Failure inspection | `pgqueuer_log` with traceback |
+| Audit trail | `pgqueuer_log` for all terminal states |

--- a/docs/reference/database-permissions.md
+++ b/docs/reference/database-permissions.md
@@ -1,0 +1,112 @@
+# Database Permissions
+
+This page lists every PostgreSQL object PgQueuer creates, the privileges needed to install
+the schema, and the minimal runtime privileges for the application user.
+
+## Objects Created by `pgq install`
+
+| Object | Name | Type |
+|--------|------|------|
+| ENUM | `pgqueuer_status` | Custom type |
+| Table | `pgqueuer` | Active job queue |
+| Table | `pgqueuer_log` | Execution history & audit trail |
+| Table | `pgqueuer_statistics` | Aggregated statistics |
+| Table | `pgqueuer_schedules` | Recurring schedule definitions |
+| Function | `fn_pgqueuer_changed()` | TRIGGER FUNCTION (PL/pgSQL) |
+| Trigger | `tg_pgqueuer_changed` | AFTER INSERT/UPDATE/DELETE/TRUNCATE on `pgqueuer` |
+| Indexes | (8+) | Priority, heartbeat, dedupe key, log queries |
+
+The trigger calls `pg_notify()` to emit a `table_changed_event` on the configured channel
+(`ch_pgqueuer` by default) whenever the queue table changes.
+
+## Installation Privileges
+
+The database role that runs `pgq install` needs:
+
+```sql
+-- Required one-time privileges for schema installation
+GRANT CREATE ON DATABASE mydb TO pgqueuer_installer;
+-- Or, if using a dedicated schema:
+GRANT CREATE ON SCHEMA pgqueuer_schema TO pgqueuer_installer;
+
+-- Specific object-level permissions needed:
+-- CREATE TYPE   → for pgqueuer_status ENUM
+-- CREATE TABLE  → for all 4 tables
+-- CREATE INDEX  → for all indexes
+-- CREATE FUNCTION → for fn_pgqueuer_changed()
+-- CREATE TRIGGER  → for tg_pgqueuer_changed
+```
+
+!!! tip "Superuser for install only"
+    The simplest approach is to run `pgq install` as a superuser or database owner, then
+    grant minimal runtime privileges to the application role separately. The installer role
+    does not need to be the role your application runs as.
+
+## Runtime Privileges
+
+The role your application uses at runtime needs significantly fewer permissions:
+
+```sql
+-- Create a dedicated application role
+CREATE ROLE pgqueuer_app LOGIN PASSWORD 'secret';
+
+-- Schema access
+GRANT USAGE ON SCHEMA public TO pgqueuer_app;
+
+-- Active queue: full CRUD needed for enqueue, dequeue, and status updates
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE pgqueuer TO pgqueuer_app;
+
+-- Execution log: insert on completion, select for queries
+GRANT SELECT, INSERT ON TABLE pgqueuer_log TO pgqueuer_app;
+
+-- Statistics: aggregation writes
+GRANT SELECT, INSERT, UPDATE ON TABLE pgqueuer_statistics TO pgqueuer_app;
+
+-- Schedules: read/write for scheduler
+GRANT SELECT, INSERT, UPDATE ON TABLE pgqueuer_schedules TO pgqueuer_app;
+
+-- Trigger function: must be executable by the application user
+GRANT EXECUTE ON FUNCTION fn_pgqueuer_changed() TO pgqueuer_app;
+
+-- Sequences (if using serial/bigserial PKs)
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO pgqueuer_app;
+```
+
+!!! note "LISTEN/NOTIFY"
+    `pg_notify()` is called inside `fn_pgqueuer_changed()`, which runs as the trigger's
+    invoker. The application also needs to issue `LISTEN ch_pgqueuer`, which requires no
+    special privilege beyond a database connection.
+
+## Recommended: Dedicated Schema
+
+For stronger isolation, install PgQueuer into its own schema:
+
+```sql
+CREATE SCHEMA pgq;
+GRANT USAGE ON SCHEMA pgq TO pgqueuer_app;
+
+-- Install into the dedicated schema
+pgq install --schema pgq
+```
+
+This separates PgQueuer objects from application tables and makes privilege management
+cleaner — you can grant or revoke schema-level access as a single operation.
+
+## Verifying Permissions
+
+Use `pgq verify` to confirm the schema is correctly installed:
+
+```bash
+pgq verify --expect present
+```
+
+Exit code `0` means all required objects exist; exit code `1` means something is missing or
+extra.
+
+To check that the application role can connect and has the required access:
+
+```sql
+-- Run as pgqueuer_app
+SELECT has_table_privilege('pgqueuer_app', 'pgqueuer', 'SELECT, INSERT, UPDATE, DELETE');
+SELECT has_function_privilege('pgqueuer_app', 'fn_pgqueuer_changed()', 'EXECUTE');
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,12 +104,16 @@ nav:
     - Completion Tracking: guides/completion-tracking.md
     - Job Cancellation: guides/job-cancellation.md
     - Heartbeat Monitoring: guides/heartbeat.md
+    - Reliability Model: guides/reliability.md
+    - Performance Tuning: guides/performance-tuning.md
+    - Deployment: guides/deployment.md
   - Reference:
     - Architecture: reference/architecture.md
     - Database Setup: reference/database-setup.md
     - CLI: reference/cli.md
     - Drivers: reference/drivers.md
     - In-Memory Adapter: reference/in-memory.md
+    - Database Permissions: reference/database-permissions.md
   - Integrations:
     - Prometheus Metrics: integrations/prometheus.md
     - Distributed Tracing: integrations/tracing.md


### PR DESCRIPTION
Adds four new documentation pages covering previously undocumented topics:

- guides/reliability.md — idempotency (dedupe_key), failure handling, retry strategies (RetryWithBackoffEntrypointExecutor + retry_timer), poison job detection, and pgqueuer_log audit trail
- guides/performance-tuning.md — batch size, concurrency limits, connection pooling, durability trade-offs, autovacuum, NOTIFY/polling balance
- guides/deployment.md — single vs. multi-worker patterns, horizontal scaling via SKIP LOCKED, systemd/Docker/Fly.io supervision, graceful shutdown, schema migrations on deploy
- reference/database-permissions.md — all PostgreSQL objects created, installation vs. runtime privileges, dedicated role setup example

All four pages added to mkdocs.yml nav. Build passes with --strict.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
