### PR TITLE
feat!: simplify CLI connection config, remove dsn() helper

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -314,10 +314,9 @@ All commands accept the following connection options:
 
 | Flag | Env Variable | Description |
 |------|-------------|-------------|
-| `--pg-dsn` | `PGQUEUER_PG_DSN` | Full PostgreSQL DSN (overrides individual settings) |
-| `--pg-host` | `PGHOST` | Database host |
-| `--pg-port` | `PGPORT` | Database port |
-| `--pg-user` | `PGUSER` | Database user |
-| `--pg-password` | `PGPASSWORD` | Database password |
-| `--pg-database` | `PGDATABASE` | Database name |
-| `--pg-schema` | — | PostgreSQL schema for PgQueuer objects |
+| `--pg-dsn` | `PGDSN` | Full PostgreSQL connection string (DSN) |
+| `--prefix` | `PGQUEUER_PREFIX` | Prefix for PgQueuer database objects |
+
+When `--pg-dsn` is omitted, the database drivers (asyncpg / psycopg) read standard
+libpq environment variables automatically: `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`,
+`PGDATABASE`. Use `PGOPTIONS="-csearch_path=myschema"` to set a custom schema.

--- a/docs/reference/database-permissions.md
+++ b/docs/reference/database-permissions.md
@@ -86,7 +86,7 @@ CREATE SCHEMA pgq;
 GRANT USAGE ON SCHEMA pgq TO pgqueuer_app;
 
 -- Install into the dedicated schema
-pgq --pg-schema pgq install
+PGOPTIONS="-csearch_path=pgq" pgq install
 ```
 
 This separates PgQueuer objects from application tables and makes privilege management

--- a/examples/flask_sync_usage.py
+++ b/examples/flask_sync_usage.py
@@ -3,23 +3,23 @@ from typing import cast
 import psycopg
 from flask import Flask, Response, g, jsonify, request
 
-from pgqueuer import db
+from pgqueuer.db import SyncPsycopgDriver
 from pgqueuer.queries import SyncQueries
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
 
-    def get_driver() -> db.SyncPsycopgDriver:
+    def get_driver() -> SyncPsycopgDriver:
         if "driver" not in g:
-            conn = psycopg.connect(db.dsn(), autocommit=True)
-            g.driver = db.SyncPsycopgDriver(conn)
+            conn = psycopg.connect("", autocommit=True)
+            g.driver = SyncPsycopgDriver(conn)
 
-        return cast(db.SyncPsycopgDriver, g.driver)
+        return cast(SyncPsycopgDriver, g.driver)
 
     @app.teardown_appcontext
     def teardown_db(exception: BaseException | None) -> None:
-        driver = cast(db.SyncPsycopgDriver | None, g.pop("driver", None))
+        driver = cast(SyncPsycopgDriver | None, g.pop("driver", None))
 
         if driver is not None:
             driver._connection.close()

--- a/examples/scheduler.py
+++ b/examples/scheduler.py
@@ -4,7 +4,7 @@ from typing import AsyncGenerator
 
 import asyncpg
 
-from pgqueuer.db import AsyncpgDriver, dsn
+from pgqueuer.db import AsyncpgDriver
 from pgqueuer.models import Schedule
 from pgqueuer.sm import SchedulerManager
 
@@ -12,7 +12,7 @@ from pgqueuer.sm import SchedulerManager
 @asynccontextmanager
 async def create_scheduler() -> AsyncGenerator[SchedulerManager, None]:
     # Establish a connection to PostgreSQL
-    connection = await asyncpg.connect(dsn())
+    connection = await asyncpg.connect()
     driver = AsyncpgDriver(connection)
     sm = SchedulerManager(driver)
 

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
 from typing import Callable
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import typer
 from tabulate import tabulate
@@ -16,7 +15,6 @@ from typer import Context
 from typing_extensions import AsyncGenerator
 
 from pgqueuer.adapters.cli import factories, supervisor
-from pgqueuer.adapters.drivers import dsn
 from pgqueuer.adapters.persistence import qb, queries
 from pgqueuer.core import listeners, logconfig
 from pgqueuer.domain import models, types
@@ -46,48 +44,17 @@ class VerifyMode(Enum):
     ABSENT = "absent"
 
 
-def _add_schema_to_dsn(dsn_str: str, schema: str) -> str:
-    """Add a search_path schema to a PostgreSQL DSN, raising if one already exists."""
-    parts = urlparse(dsn_str)
-    query = parse_qs(parts.query)
-    options = query.get("options", [])
-    if any(opt.startswith("-c search_path=") for opt in options):
-        raise ValueError("search_path is already set in the options parameter.")
-    options.append(f"-csearch_path={schema}")
-    query["options"] = options
-    return urlunparse(parts._replace(query=urlencode(query, doseq=True)))
-
-
 @dataclass
 class AppConfig:
     """Application configuration for PGQueuer CLI."""
 
     prefix: str = ""
     pg_dsn: str = ""
-    pg_host: str = ""
-    pg_port: str = "5432"
-    pg_user: str = ""
-    pg_database: str = ""
-    pg_password: str = ""
-    pg_schema: str = ""
     factory_fn_ref: str | None = None
 
     def setup_env(self) -> None:
         if self.prefix:
             os.environ["PGQUEUER_PREFIX"] = self.prefix
-
-    @property
-    def dsn(self) -> str:
-        computed_dsn = self.pg_dsn or dsn(
-            database=self.pg_database,
-            password=self.pg_password,
-            port=self.pg_port,
-            user=self.pg_user,
-            host=self.pg_host,
-        )
-        if self.pg_schema is not None:
-            computed_dsn = _add_schema_to_dsn(computed_dsn, self.pg_schema)
-        return computed_dsn
 
 
 @app.callback()
@@ -99,39 +66,14 @@ def main(
         envvar="PGQUEUER_PREFIX",
     ),
     pg_dsn: str = typer.Option(
-        None,
-        help="Database DSN.",
+        "",
+        help=(
+            "PostgreSQL connection string (DSN). "
+            "When omitted, standard libpq env vars "
+            "(PGHOST, PGUSER, PGPASSWORD, PGDATABASE, PGPORT) are used. "
+            "Use PGOPTIONS for search_path."
+        ),
         envvar="PGDSN",
-    ),
-    pg_host: str = typer.Option(
-        None,
-        help="Database host.",
-        envvar="PGHOST",
-    ),
-    pg_port: str = typer.Option(
-        "5432",
-        help="Database port.",
-        envvar="PGPORT",
-    ),
-    pg_user: str = typer.Option(
-        None,
-        help="Database user.",
-        envvar="PGUSER",
-    ),
-    pg_database: str = typer.Option(
-        None,
-        help="Database name.",
-        envvar="PGDATABASE",
-    ),
-    pg_password: str = typer.Option(
-        None,
-        help="Database password.",
-        envvar="PGPASSWORD",
-    ),
-    pg_schema: str = typer.Option(
-        None,
-        help="Database schema.",
-        envvar="PGSCHEMA",
     ),
     factory_fn_ref: str | None = typer.Option(
         None,
@@ -143,12 +85,6 @@ def main(
     config = AppConfig(
         prefix=prefix,
         pg_dsn=pg_dsn,
-        pg_host=pg_host,
-        pg_port=pg_port,
-        pg_user=pg_user,
-        pg_database=pg_database,
-        pg_password=pg_password,
-        pg_schema=pg_schema,
         factory_fn_ref=factory_fn_ref,
     )
     config.setup_env()
@@ -172,7 +108,7 @@ def create_default_queries_factory(
             from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
             yield queries.Queries(
-                AsyncpgDriver(await asyncpg.connect(dsn=config.dsn)),
+                AsyncpgDriver(await asyncpg.connect(dsn=config.pg_dsn or None)),
                 qbe=qb.QueryBuilderEnvironment(settings),
                 qbq=qb.QueryQueueBuilder(settings),
                 qbs=qb.QuerySchedulerBuilder(settings),
@@ -184,7 +120,9 @@ def create_default_queries_factory(
             from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
             yield queries.Queries(
-                PsycopgDriver(await psycopg.AsyncConnection.connect(config.dsn, autocommit=True)),
+                PsycopgDriver(
+                    await psycopg.AsyncConnection.connect(config.pg_dsn or "", autocommit=True)
+                ),
                 qbe=qb.QueryBuilderEnvironment(settings),
                 qbq=qb.QueryQueueBuilder(settings),
                 qbs=qb.QuerySchedulerBuilder(settings),

--- a/pgqueuer/adapters/drivers/__init__.py
+++ b/pgqueuer/adapters/drivers/__init__.py
@@ -1,30 +1,3 @@
 """Database driver adapters and utilities."""
 
 from __future__ import annotations
-
-import os
-
-
-def dsn(
-    host: str = "",
-    user: str = "",
-    password: str = "",
-    database: str = "",
-    port: str = "",
-) -> str:
-    """
-    Construct a PostgreSQL DSN (Data Source Name) from parameters or environment variables.
-
-    Assembles a PostgreSQL connection string using provided parameters. If any parameter
-    is not specified, it attempts to retrieve it from environment variables (`PGHOST`, `PGUSER`,
-    `PGPASSWORD`, `PGDATABASE`, `PGPORT`).
-
-    Returns:
-        str: A PostgreSQL DSN string in the format 'postgresql://user:password@host:port/database'.
-    """
-    host = host or os.getenv("PGHOST", "")
-    user = user or os.getenv("PGUSER", "")
-    password = password or os.getenv("PGPASSWORD", "")
-    database = database or os.getenv("PGDATABASE", "")
-    port = port or os.getenv("PGPORT", "")
-    return f"postgresql://{user}:{password}@{host}:{port}/{database}"

--- a/pgqueuer/db.py
+++ b/pgqueuer/db.py
@@ -1,6 +1,5 @@
 """Backward-compatibility shim. Canonical: pgqueuer.ports.driver + pgqueuer.adapters.drivers.*"""
 
-from pgqueuer.adapters.drivers import dsn
 from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver, AsyncpgPoolDriver
 from pgqueuer.adapters.drivers.psycopg import PsycopgDriver, SyncPsycopgDriver
 from pgqueuer.ports.driver import Driver, SyncDriver
@@ -12,5 +11,4 @@ __all__ = [
     "PsycopgDriver",
     "SyncDriver",
     "SyncPsycopgDriver",
-    "dsn",
 ]

--- a/test/integration/test_flask_sync.py
+++ b/test/integration/test_flask_sync.py
@@ -4,6 +4,7 @@ import sys
 from http import HTTPStatus
 from pathlib import Path
 from typing import Generator
+from urllib.parse import urlparse
 
 import pytest
 from flask.testing import FlaskClient
@@ -11,22 +12,18 @@ from flask.testing import FlaskClient
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from examples.flask_sync_usage import create_app
-from pgqueuer import db as pgq_db
 
 
 @pytest.fixture(scope="function")
-def client() -> Generator[FlaskClient, None, None]:
+def client(monkeypatch: pytest.MonkeyPatch, dsn: str) -> Generator[FlaskClient, None, None]:
+    parsed = urlparse(dsn)
+    monkeypatch.setenv("PGHOST", parsed.hostname or "")
+    monkeypatch.setenv("PGPORT", str(parsed.port or 5432))
+    monkeypatch.setenv("PGUSER", parsed.username or "")
+    monkeypatch.setenv("PGPASSWORD", parsed.password or "")
+    monkeypatch.setenv("PGDATABASE", parsed.path.lstrip("/"))
     with create_app().test_client() as client:
         yield client
-
-
-@pytest.fixture(autouse=True)
-async def patch_dsn_fn(
-    monkeypatch: pytest.MonkeyPatch,
-    dsn: str,
-) -> None:
-    """Patch the DSN function to return the provided DSN."""
-    monkeypatch.setattr(pgq_db, "dsn", lambda: dsn)
 
 
 def test_enqueue_and_size(client: FlaskClient) -> None:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 
 import pytest
 
-from pgqueuer.adapters.cli.cli import _add_schema_to_dsn
 from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
 
 
@@ -39,31 +38,3 @@ def test_merge_tracing_headers(
     expected: list[dict],
 ) -> None:
     assert merge_tracing_headers(headers, trace_headers) == expected
-
-
-def test_add_schema_to_empty_dsn() -> None:
-    dsn = "postgresql://user:password@host:port/dbname"
-    schema = "myschema"
-    expected = "postgresql://user:password@host:port/dbname?options=-csearch_path%3Dmyschema"
-    assert _add_schema_to_dsn(dsn, schema) == expected
-
-
-def test_add_schema_to_dsn_with_existing_query() -> None:
-    dsn = "postgresql://user:password@host:port/dbname?sslmode=require"
-    schema = "myschema"
-    expected = "postgresql://user:password@host:port/dbname?sslmode=require&options=-csearch_path%3Dmyschema"
-    assert _add_schema_to_dsn(dsn, schema) == expected
-
-
-def test_raise_on_existing_search_path() -> None:
-    dsn = "postgresql://user:password@host:port/dbname?options=-c+search_path=otherschema"
-    schema = "myschema"
-    with pytest.raises(ValueError, match="search_path is already set in the options parameter."):
-        _add_schema_to_dsn(dsn, schema)
-
-
-def test_preserve_other_options_and_add_search_path() -> None:
-    dsn = "postgresql://user:password@host:port/dbname?options=-cother_option=foo"
-    schema = "myschema"
-    expected = "postgresql://user:password@host:port/dbname?options=-cother_option%3Dfoo&options=-csearch_path%3Dmyschema"
-    assert _add_schema_to_dsn(dsn, schema) == expected

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -21,7 +21,7 @@ from tqdm.asyncio import tqdm
 
 from pgqueuer import PgQueuer, types
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
-from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, PsycopgDriver, dsn
+from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, PsycopgDriver
 from pgqueuer.domain.settings import add_prefix
 from pgqueuer.models import Job
 from pgqueuer.ports import RepositoryPort
@@ -181,8 +181,8 @@ _shared_inmem: RepositoryPort | None = None
 
 
 def _get_conninfo(driver: DriverEnum) -> str:
-    """Return connection string, or empty for the in-memory driver."""
-    return "" if driver == DriverEnum.mem else dsn()
+    """Return connection string. Empty means libpq env vars are used."""
+    return ""
 
 
 async def make_queries(driver: DriverEnum, conninfo: str = "") -> RepositoryPort:

--- a/tools/concurrency_probe.py
+++ b/tools/concurrency_probe.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from asyncio import run as asyncio_run  # type: ignore[assignment]
 
-from pgqueuer.db import AsyncpgDriver, dsn
+from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.models import Job
 from pgqueuer.qm import QueueManager
@@ -61,7 +61,7 @@ async def consumer(driver: AsyncpgDriver) -> None:
 
 
 async def main() -> None:
-    connection = await asyncpg.connect(dsn())
+    connection = await asyncpg.connect()
     driver = AsyncpgDriver(connection)
 
     await producer(driver)


### PR DESCRIPTION
Delete the dsn() function that reimplemented libpq env var reading. Both asyncpg and psycopg natively read PGHOST/PGUSER/PGPASSWORD/ PGDATABASE/PGPORT when dsn=None.

Remove 6 CLI options (--pg-host, --pg-port, --pg-user, --pg-database, --pg-password, --pg-schema) and all schema-injection code. Users set standard libpq env vars directly, or pass --pg-dsn for a full connection string. PGOPTIONS="-csearch_path=myschema" replaces --pg-schema.

Migration:
- pgq --pg-host h --pg-user u install → PGHOST=h PGUSER=u pgq install
- pgq --pg-schema s install → PGOPTIONS="-csearch_path=s" pgq install
- from pgqueuer.db import dsn → use asyncpg.connect() with no args

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
