### PR TITLE
fix: wait interval before first heartbeat send

### DIFF
--- a/pgqueuer/core/heartbeat.py
+++ b/pgqueuer/core/heartbeat.py
@@ -42,13 +42,14 @@ class Heartbeat:
 
     async def send_heartbeat(self) -> None:
         while not self.shutdown.is_set():
+            with suppress(TimeoutError, asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    self.shutdown.wait(),
+                    timeout=self.interval.total_seconds(),
+                )
+            if self.shutdown.is_set():
+                break
             try:
                 await self.buffer.add(self.job_id)
             except Exception as e:
                 logconfig.logger.exception("Failed to send heartbeat: %s", e)
-            finally:
-                with suppress(TimeoutError, asyncio.TimeoutError):
-                    await asyncio.wait_for(
-                        self.shutdown.wait(),
-                        timeout=self.interval.total_seconds(),
-                    )

--- a/test/test_heartbeat.py
+++ b/test/test_heartbeat.py
@@ -75,6 +75,36 @@ async def test_heartbeat_max_size(max_size: int) -> None:
     assert len(callbacks) >= 2
 
 
+async def test_no_heartbeat_when_job_completes_before_interval() -> None:
+    """Fast-completing jobs must never write to the heartbeat buffer.
+
+    The heartbeat loop should wait the full interval before sending.
+    If shutdown fires during that wait, the buffer should remain untouched.
+    """
+
+    class _NoopSink:
+        async def update_heartbeat(self, _: list[JobId]) -> None:
+            pass
+
+    class DummyBuffer(HeartbeatBuffer):
+        def __init__(self) -> None:
+            super().__init__(
+                max_size=10,
+                timeout=timedelta(seconds=0),
+                repository=_NoopSink(),
+            )
+            self.received = 0
+
+        async def add(self, _: object) -> None:
+            self.received += 1
+
+    hbuf = DummyBuffer()
+    # Interval is 10s but we exit immediately — no heartbeat should fire.
+    async with Heartbeat(JobId(1), timedelta(seconds=10), hbuf):
+        await asyncio.sleep(0)
+    assert hbuf.received == 0, f"Expected 0 heartbeat writes, got {hbuf.received}"
+
+
 async def test_heartbeat_keeps_buffer_ticking() -> None:
     class _NoopSink:
         async def update_heartbeat(self, _: list[JobId]) -> None:


### PR DESCRIPTION
Previously send_heartbeat() sent a heartbeat immediately on entry then waited the interval.  For fast-completing jobs (sub-second) this meant every job created an asyncio.Task, pushed into the heartbeat buffer, and triggered UPDATE queries against already-deleted rows — pure overhead.

Move the sleep-or-shutdown wait to *before* the first buffer.add() call. Jobs that finish before the interval elapses now exit the heartbeat loop without ever touching the buffer, restoring the v0.26.3 behaviour where retry_timer=0 disabled heartbeat entirely.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
