### PR TITLE
fix: restore async-timeout dev dependency for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,11 @@ docs = [
     "pymdown-extensions",
 ]
 
+[dependency-groups]
+dev = [
+    "async-timeout>=5.0.1",
+]
+
 [tool.ruff]
 line-length = 100
 

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,6 @@ name = "pgqueuer"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
-    { name = "async-timeout" },
     { name = "croniter" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1354,7 +1353,6 @@ asyncpg = [
     { name = "asyncpg" },
 ]
 dev = [
-    { name = "async-timeout" },
     { name = "asyncpg" },
     { name = "asyncpg-stubs" },
     { name = "fastapi" },
@@ -1410,11 +1408,14 @@ sentry = [
     { name = "sentry-sdk" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "async-timeout" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.0" },
-    { name = "async-timeout", specifier = ">=5.0.1" },
-    { name = "async-timeout", marker = "extra == 'dev'", specifier = ">=4.0.3" },
     { name = "asyncpg", marker = "extra == 'asyncpg'", specifier = ">=0.30.0" },
     { name = "asyncpg", marker = "extra == 'dev'" },
     { name = "asyncpg", marker = "extra == 'mcp'", specifier = ">=0.30.0" },
@@ -1463,6 +1464,9 @@ requires-dist = [
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.22.0" },
 ]
 provides-extras = ["asyncpg", "psycopg", "logfire", "sentry", "opentelemetry", "fastapi", "mcp", "dev", "docs"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "async-timeout", specifier = ">=5.0.1" }]
 
 [[package]]
 name = "platformdirs"


### PR DESCRIPTION
The async-timeout package was removed as a runtime dependency but tests still import it. Add it back as a dev-only dependency.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
