### PR TITLE
docs: adopt Conventional Commits specification in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,33 +204,43 @@ Google-style when present: `Args:`, `Returns:`, `Raises:` sections. Not every me
 
 ## Commit Conventions
 
+This project follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
 ### Title Format
 
-All commit titles must follow this format:
-
 ```
-{Title} (#{PR_ID})
+<type>[optional scope]: <description> (#{PR_ID})
 ```
 
-- **Title**: Imperative mood, starting with a capital letter.
-- **PR reference**: End with the PR number in parentheses, prefixed with `#`.
+- **type**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+- **scope** (optional): area of the codebase, e.g. `cli`, `qm`, `sm`, `schema`, `drivers`, `inmemory`
+- **description**: imperative mood, lowercase, no period at the end
+- **`!` after type/scope**: marks a breaking change (e.g. `feat!:` or `feat(cli)!:`)
+- **PR reference**: end with the PR number in parentheses, prefixed with `#`
 
-Examples:
+### Examples
 
 ```
-Add heartbeat buffer flush on shutdown (#87)
-Fix duplicate job detection in concurrent workers (#91)
+feat(qm): add global concurrency limit (#92)
+fix: restore partial index usage in dequeue CTE (#607)
+feat!: simplify CLI connection config, remove dsn() helper (#605)
+docs: add custom executor guide (#88)
+refactor(core): extract heartbeat into standalone module (#95)
+test: add parametrized dequeue batch tests (#100)
+chore: bump ruff to 0.8 (#101)
 ```
+
+### Body and Footer
+
+- Body: present tense, wrap at 72 characters. Explain **why**, not just what.
+- Footer: use `BREAKING CHANGE: <description>` for breaking changes (in addition to or instead of `!` in the title).
 
 ### Rationale
 
-- `git log --oneline` gives a clean, readable history.
+- `git log --oneline` gives a clean, typed, scannable history.
 - `git blame` gives immediate context.
 - The `#{PR_ID}` suffix implicitly links to the PR in GitHub.
-
-### Body and Trailers
-
-Present tense, wrap at 72 characters. Reference additional context in the body when needed. See `CONTRIBUTING.md`.
+- Types enable automated changelogs and semantic versioning.
 
 ## CI Matrix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,16 @@ While the prerequisites above must be satisfied prior to having your pull reques
 
 ### Git Commit Messages
 
-* Use the present tense ("Add feature" not "Added feature").
-* Limit the first line to 72 characters or less.
-* Reference issues and pull requests liberally after the first line.
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). See the full specification in [AGENTS.md](AGENTS.md#commit-conventions).
+
+```
+<type>[optional scope]: <description> (#{PR_ID})
+```
+
+* **type**: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, etc.
+* Use imperative mood, lowercase description, no trailing period.
+* Append `!` after type/scope for breaking changes (e.g. `feat!:`).
+* Reference the PR number at the end: `(#123)`.
 
 ### Python Styleguide
 


### PR DESCRIPTION
Replace the freeform commit title format with Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/). Adds type prefixes, optional scopes, breaking-change markers, and BREAKING CHANGE footer convention.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
