### PR TITLE
perf(sm): batch scheduler heartbeat updates

### DIFF
--- a/pgqueuer/core/sm.py
+++ b/pgqueuer/core/sm.py
@@ -12,6 +12,7 @@ import croniter
 from pgqueuer.adapters.persistence import queries
 from pgqueuer.core import executors, logconfig, tm
 from pgqueuer.domain import models
+from pgqueuer.domain.types import ScheduleId
 from pgqueuer.ports import RepositoryPort
 from pgqueuer.ports.driver import Driver
 
@@ -45,6 +46,10 @@ class SchedulerManager:
             init=False,
             default_factory=dict,
         )
+    )
+    active_heartbeat_ids: set[ScheduleId] = dataclasses.field(
+        init=False,
+        default_factory=set,
     )
 
     def __post_init__(self) -> None:
@@ -148,6 +153,7 @@ class SchedulerManager:
             tm.TaskManager() as task_manager,
             self.connection,
         ):
+            task_manager.add(asyncio.create_task(self._heartbeat_loop()))
             while not self.shutdown.is_set():
                 scheduled = await self.queries.fetch_schedule(
                     {k: v.next_in() for k, v in self.registry.items()}
@@ -163,7 +169,6 @@ class SchedulerManager:
                                     )
                                 ],
                                 schedule,
-                                task_manager,
                             ),
                         )
                     )
@@ -185,7 +190,6 @@ class SchedulerManager:
         self,
         executor: executors.AbstractScheduleExecutor,
         schedule: models.Schedule,
-        task_manager: tm.TaskManager,
     ) -> None:
         """
         Dispatch a scheduled job for execution.
@@ -195,23 +199,14 @@ class SchedulerManager:
                 responsible for running the job.
             schedule (models.Schedule): The schedule object containing details
                 of the job to be executed.
-            task_manager (tm.TaskManager): The task manager to manage the
-                execution tasks.
         """
         logconfig.logger.debug(
             "Dispatching entrypoint/expression: %s/%s",
             schedule.entrypoint,
             schedule.expression,
         )
-        shutdown = asyncio.Event()
 
-        async def heartbeat() -> None:
-            while not shutdown.is_set() and not self.shutdown.is_set():
-                await self.queries.update_schedule_heartbeat({schedule.id})
-                await asyncio.sleep(1)
-
-        task_manager.add(asyncio.create_task(heartbeat()))
-
+        self.active_heartbeat_ids.add(schedule.id)
         context = models.ScheduleContext(resources=self.resources)
         try:
             await executor.execute(schedule, context)
@@ -228,7 +223,20 @@ class SchedulerManager:
                 schedule.expression,
             )
         finally:
-            shutdown.set()
+            self.active_heartbeat_ids.discard(schedule.id)
             await asyncio.shield(
                 self.queries.set_schedule_queued({schedule.id}),
             )
+
+    async def _heartbeat_loop(self) -> None:
+        """Send batched heartbeat updates for all active schedules."""
+        while not self.shutdown.is_set():
+            if self.active_heartbeat_ids:
+                await self.queries.update_schedule_heartbeat(
+                    set(self.active_heartbeat_ids),
+                )
+            with suppress(TimeoutError, asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    self.shutdown.wait(),
+                    timeout=1.0,
+                )

--- a/test/test_scheduler_heartbeat.py
+++ b/test/test_scheduler_heartbeat.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from pgqueuer import db
+from pgqueuer.domain.types import ScheduleId
+from pgqueuer.sm import SchedulerManager
+
+
+async def test_scheduler_heartbeat_batches(apgdriver: db.Driver) -> None:
+    """The heartbeat loop must send batched updates for all active schedule IDs."""
+    sm = SchedulerManager(apgdriver)
+
+    captured_calls: list[set[ScheduleId]] = []
+
+    async def capture_heartbeat(ids: set[ScheduleId]) -> None:
+        captured_calls.append(set(ids))
+
+    # Simulate two active schedules.
+    sm.active_heartbeat_ids.add(ScheduleId(1))
+    sm.active_heartbeat_ids.add(ScheduleId(2))
+
+    with patch.object(sm.queries, "update_schedule_heartbeat", side_effect=capture_heartbeat):
+        # Run the heartbeat loop for ~2.5 seconds then shut down.
+        async def stop_after() -> None:
+            await asyncio.sleep(2.5)
+            sm.shutdown.set()
+
+        await asyncio.gather(
+            sm._heartbeat_loop(),
+            stop_after(),
+        )
+
+    # Should have at least 1 batched call containing both IDs.
+    assert captured_calls, "Expected at least one heartbeat call"
+    assert any(len(c) == 2 for c in captured_calls), (
+        f"Expected a call with 2 IDs, got: {captured_calls}"
+    )
+    assert all({ScheduleId(1), ScheduleId(2)} == c for c in captured_calls), (
+        f"Unexpected IDs in calls: {captured_calls}"
+    )
+
+
+async def test_scheduler_heartbeat_skips_when_empty(apgdriver: db.Driver) -> None:
+    """The heartbeat loop must not call update when no schedules are active."""
+    sm = SchedulerManager(apgdriver)
+
+    call_count = 0
+
+    async def counting_heartbeat(ids: set[ScheduleId]) -> None:
+        nonlocal call_count
+        call_count += 1
+
+    with patch.object(sm.queries, "update_schedule_heartbeat", side_effect=counting_heartbeat):
+
+        async def stop_after() -> None:
+            await asyncio.sleep(1.5)
+            sm.shutdown.set()
+
+        await asyncio.gather(
+            sm._heartbeat_loop(),
+            stop_after(),
+        )
+
+    assert call_count == 0, f"Expected no heartbeat calls with empty set, got {call_count}"


### PR DESCRIPTION
Replace per-schedule heartbeat tasks (each sending individual UPDATE every 1s) with a single shared heartbeat loop that flushes all active schedule IDs in one batched call. Reduces N queries/second to 1 for N concurrent schedules.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
