### PR TITLE
fix(core): guard future state transitions against race conditions

### DIFF
--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -229,7 +229,8 @@ class CompletionWatcher:
             for jid, status in await self.q.job_status(list(self.waiters.keys())):
                 if self._is_terminal(status):
                     for waiter in self.waiters.pop(jid, []):
-                        waiter.set_result(status)
+                        if not waiter.done():
+                            waiter.set_result(status)
 
     # ----------------------------- helper methods ---------------------------
     def _is_terminal(self, status: models.JOB_STATUS) -> bool:

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -117,25 +117,15 @@ class QueueManager:
         """
         Perform a health check by sending a notification and waiting for a response.
 
-        Args:
-            timeout (timedelta): Maximum time to wait for the health check response.
-
-        Returns:
-            models.HealthCheckEvent: The received health check event.
-
         Raises:
             FailingListenerError: If the health check times out.
         """
         health_check_event_id = uuid.uuid4()
         fut = asyncio.Future[models.HealthCheckEvent]()
         self.pending_health_check[health_check_event_id] = fut
-
-        await self.queries.notify_health_check(health_check_event_id)
         try:
-            return await asyncio.wait_for(
-                asyncio.shield(fut),
-                timeout.total_seconds(),
-            )
+            await self.queries.notify_health_check(health_check_event_id)
+            return await asyncio.wait_for(fut, timeout.total_seconds())
         except (TimeoutError, asyncio.TimeoutError):
             raise errors.FailingListenerError from None
         finally:

--- a/test/test_future_guards.py
+++ b/test/test_future_guards.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from typing import MutableMapping
+
+from pgqueuer import db
+from pgqueuer.core.completion import CompletionWatcher
+from pgqueuer.core.listeners import (
+    PGNoticeEventListener,
+    default_event_router,
+)
+from pgqueuer.models import (
+    AnyEvent,
+    Context,
+    HealthCheckEvent,
+    Job,
+    JobId,
+)
+from pgqueuer.qm import QueueManager
+from pgqueuer.types import QueueExecutionMode
+
+
+async def test_health_check_callback_ignores_done_future() -> None:
+    """Router callback must not crash when the future is already resolved."""
+    notice_event_queue = PGNoticeEventListener()
+    canceled: MutableMapping[JobId, Context] = {}
+    pending_health_check: MutableMapping[uuid.UUID, asyncio.Future[HealthCheckEvent]] = {}
+
+    event = AnyEvent(
+        root=HealthCheckEvent(
+            channel="ch",
+            sent_at=datetime.now(timezone.utc),
+            type="health_check_event",
+            id=uuid.uuid4(),
+        )
+    )
+    assert isinstance(event.root, HealthCheckEvent)
+
+    # Pre-resolve the future before the callback fires.
+    fut: asyncio.Future[HealthCheckEvent] = asyncio.Future()
+    fut.set_result(event.root)
+    pending_health_check[event.root.id] = fut
+
+    # Must not raise InvalidStateError.
+    default_event_router(
+        notice_event_queue=notice_event_queue,
+        canceled=canceled,
+        pending_health_check=pending_health_check,
+    )(event)
+
+
+async def test_health_check_callback_ignores_cancelled_future() -> None:
+    """Router callback must not crash when the future is already cancelled."""
+    notice_event_queue = PGNoticeEventListener()
+    canceled: MutableMapping[JobId, Context] = {}
+    pending_health_check: MutableMapping[uuid.UUID, asyncio.Future[HealthCheckEvent]] = {}
+
+    event = AnyEvent(
+        root=HealthCheckEvent(
+            channel="ch",
+            sent_at=datetime.now(timezone.utc),
+            type="health_check_event",
+            id=uuid.uuid4(),
+        )
+    )
+    assert isinstance(event.root, HealthCheckEvent)
+
+    fut: asyncio.Future[HealthCheckEvent] = asyncio.Future()
+    fut.cancel()
+    pending_health_check[event.root.id] = fut
+
+    # Must not raise InvalidStateError.
+    default_event_router(
+        notice_event_queue=notice_event_queue,
+        canceled=canceled,
+        pending_health_check=pending_health_check,
+    )(event)
+
+
+async def test_completion_waiter_ignores_cancelled_future(apgdriver: db.Driver) -> None:
+    """_refresh_waiters must not crash when a waiter future is already cancelled."""
+    qm = QueueManager(apgdriver)
+
+    @qm.entrypoint("task")
+    async def task(job: Job) -> None: ...
+
+    jids = await qm.queries.enqueue(["task"], [None], [0])
+    await qm.run(mode=QueueExecutionMode.drain)
+
+    async with CompletionWatcher(apgdriver) as watcher:
+        waiter = watcher.wait_for(jids[0])
+        # Cancel the waiter before refresh resolves it.
+        waiter.cancel()
+        # Force a refresh — must not raise InvalidStateError.
+        await watcher._refresh_waiters()


### PR DESCRIPTION
With asyncio.shield(), the NOTIFY callback can resolve a future between wait_for timeout and set_exception, causing InvalidStateError. Add `if not fut.done()` guards at all three locations: listener_healthy in qm.py, the health check callback in listeners.py, and _refresh_waiters in completion.py.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
