### PR TITLE
fix(drivers): catch exceptions in psycopg notify watcher callback

### DIFF
--- a/pgqueuer/adapters/drivers/psycopg.py
+++ b/pgqueuer/adapters/drivers/psycopg.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from typing_extensions import Self
 
+from pgqueuer.core import logconfig
 from pgqueuer.core.tm import TaskManager
 from pgqueuer.ports.driver import Driver, SyncDriver
 
@@ -91,7 +92,13 @@ class PsycopgDriver(Driver):
                     timeout=1.0,
                     stop_after=1,
                 ):
-                    callback(note.payload)
+                    try:
+                        callback(note.payload)
+                    except Exception:
+                        logconfig.logger.exception(
+                            "Unhandled error in NOTIFY callback for channel %s",
+                            channel,
+                        )
 
         self._tm.add(
             asyncio.create_task(

--- a/test/test_psycopg_notify_resilience.py
+++ b/test/test_psycopg_notify_resilience.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+
+import psycopg
+
+from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
+
+
+async def test_notify_watcher_survives_callback_exception(dsn: str) -> None:
+    """If a listener callback raises, the watcher must keep running."""
+    received: list[str] = []
+    call_count = 0
+
+    def callback(payload: str | bytes | bytearray) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("deliberate test error")
+        received.append(str(payload))
+
+    channel = "test_resilience"
+
+    async with (
+        await psycopg.AsyncConnection.connect(conninfo=dsn, autocommit=True) as listener_conn,
+        PsycopgDriver(listener_conn) as driver,
+        await psycopg.AsyncConnection.connect(conninfo=dsn, autocommit=True) as sender_conn,
+    ):
+        await driver.add_listener(channel, callback)
+        # Small delay to let the watcher task start.
+        await asyncio.sleep(0.1)
+
+        # First notification — callback will raise.
+        await sender_conn.execute(f"NOTIFY {channel}, 'msg1'")
+        await asyncio.sleep(0.5)
+
+        # Second notification — callback should succeed if watcher survived.
+        await sender_conn.execute(f"NOTIFY {channel}, 'msg2'")
+        await asyncio.sleep(0.5)
+
+    assert call_count == 2, f"Expected 2 calls, got {call_count}"
+    assert received == ["msg2"], f"Expected ['msg2'], got {received}"


### PR DESCRIPTION
If the listener callback raises, the notify_watcher loop dies and all subsequent notifications are lost. Wrap the callback invocation in try/except with logger.exception so the watcher keeps running.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
