### PR TITLE
refactor(drivers): move pg_notify into Driver protocol, remove build_notify_query

### DIFF
--- a/pgqueuer/adapters/drivers/asyncpg.py
+++ b/pgqueuer/adapters/drivers/asyncpg.py
@@ -51,6 +51,10 @@ class AsyncpgDriver(Driver):
         async with self._lock:
             return await self._connection.execute(query, *args)
 
+    async def notify(self, channel: str, payload: str) -> None:
+        async with self._lock:
+            await self._connection.execute("SELECT pg_notify($1, $2)", channel, payload)
+
     async def add_listener(
         self,
         channel: str,
@@ -116,6 +120,9 @@ class AsyncpgPoolDriver(Driver):
         *args: Any,
     ) -> str:
         return await self._pool.execute(query, *args)
+
+    async def notify(self, channel: str, payload: str) -> None:
+        await self._pool.execute("SELECT pg_notify($1, $2)", channel, payload)
 
     async def add_listener(
         self,

--- a/pgqueuer/adapters/drivers/psycopg.py
+++ b/pgqueuer/adapters/drivers/psycopg.py
@@ -78,12 +78,17 @@ class PsycopgDriver(Driver):
         await cursor.execute(query, args or None)
         return cursor.statusmessage or ""
 
+    async def notify(self, channel: str, payload: str) -> None:
+        await self.execute("SELECT pg_notify($1, $2)", channel, payload)
+
     async def add_listener(
         self,
         channel: str,
         callback: Callable[[str | bytes | bytearray], None],
     ) -> None:
-        await self._connection.execute(f"LISTEN {channel};")
+        if not channel.isidentifier():
+            raise ValueError(f"Invalid channel name: {channel!r}")
+        await self._connection.execute(f"LISTEN {channel}")
 
         async def notify_watcher() -> None:
             while not self.shutdown.is_set():

--- a/pgqueuer/adapters/inmemory/driver.py
+++ b/pgqueuer/adapters/inmemory/driver.py
@@ -58,10 +58,7 @@ class InMemoryDriver:
 
     # -- In-memory notification ------------------------------------------------
 
-    def deliver(self, channel: str, payload: str) -> None:
-        """Push *payload* to all registered listeners on *channel*.
-
-        This is the in-memory equivalent of ``pg_notify(channel, payload)``.
-        """
+    async def notify(self, channel: str, payload: str) -> None:
+        """Push *payload* to all registered listeners on *channel*."""
         for cb in self._listeners.get(channel, ()):
             cb(payload)

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -188,7 +188,7 @@ class InMemoryQueries:
             )
             self._next_log_id += 1
 
-        self._emit_table_changed("insert")
+        await self.emit_table_changed("insert")
         return ids
 
     # -- dequeue ---------------------------------------------------------------
@@ -423,7 +423,7 @@ class InMemoryQueries:
                 }
             )
             self._next_log_id += 1
-            self._emit_table_changed("update")
+            await self.emit_table_changed("update")
 
     # -- requeue_jobs ----------------------------------------------------------
 
@@ -450,7 +450,7 @@ class InMemoryQueries:
                     }
                 )
                 self._next_log_id += 1
-                self._emit_table_changed("update")
+                await self.emit_table_changed("update")
 
     # -- list_failed_jobs ------------------------------------------------------
 
@@ -628,7 +628,7 @@ class InMemoryQueries:
             sent_at=_utc_now(),
             type="cancellation_event",
         )
-        self.driver.deliver(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
 
     async def notify_health_check(self, health_check_event_id: uuid.UUID) -> None:
         event = models.HealthCheckEvent(
@@ -637,7 +637,7 @@ class InMemoryQueries:
             type="health_check_event",
             id=health_check_event_id,
         )
-        self.driver.deliver(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
 
     # -- Schedule methods ------------------------------------------------------
 
@@ -776,7 +776,7 @@ class InMemoryQueries:
         for k in to_remove:
             del self._dedupe_index[k]
 
-    def _emit_table_changed(self, operation: models.OPERATIONS) -> None:
+    async def emit_table_changed(self, operation: models.OPERATIONS) -> None:
         """Construct and deliver a ``TableChangedEvent`` via the driver."""
         event = models.TableChangedEvent(
             channel=self.qbq.settings.channel,
@@ -785,4 +785,4 @@ class InMemoryQueries:
             operation=operation,
             table=self.qbe.settings.queue_table,
         )
-        self.driver.deliver(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -612,9 +612,6 @@ SELECT * FROM claimed ORDER BY priority DESC, id ASC;
     LIMIT $1
     """
 
-    def build_notify_query(self) -> str:
-        return f"""SELECT pg_notify('{self.settings.channel}', $1)"""
-
     def build_update_heartbeat_query(self) -> str:
         return f"""UPDATE {self.settings.queue_table} SET heartbeat = NOW() WHERE id = ANY($1::integer[])"""  # noqa: E501
 

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -581,8 +581,8 @@ class Queries:
         Args:
             ids (list[models.JobId]): The IDs of the jobs that have been cancelled.
         """
-        await self.driver.execute(
-            self.qbq.build_notify_query(),
+        await self.driver.notify(
+            self.qbq.settings.channel,
             models.CancellationEvent(
                 channel=self.qbq.settings.channel,
                 ids=ids,
@@ -603,8 +603,8 @@ class Queries:
             event (models.HealthCheckEvent): The health check event containing
                 details about the system's health status.
         """
-        await self.driver.execute(
-            self.qbq.build_notify_query(),
+        await self.driver.notify(
+            self.qbq.settings.channel,
             models.HealthCheckEvent(
                 channel=self.qbq.settings.channel,
                 sent_at=datetime.now(timezone.utc),

--- a/pgqueuer/ports/driver.py
+++ b/pgqueuer/ports/driver.py
@@ -74,6 +74,10 @@ class Driver(Protocol):
         """
         raise NotImplementedError
 
+    async def notify(self, channel: str, payload: str) -> None:
+        """Send a NOTIFY on *channel* with *payload*."""
+        raise NotImplementedError
+
     @property
     def shutdown(self) -> asyncio.Event:
         """

--- a/test/test_drivers.py
+++ b/test/test_drivers.py
@@ -26,7 +26,6 @@ from pgqueuer.db import (
     SyncDriver,
     SyncPsycopgDriver,
 )
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.models import TableChangedEvent
 from pgqueuer.types import Channel
 
@@ -120,12 +119,7 @@ async def test_notify(
 
         # Send from a separate connection to avoid self-notify edge cases.
         async with driver(dsn) as ad:
-            await ad.execute(
-                QueryQueueBuilder(
-                    DBSettings(channel=channel),
-                ).build_notify_query(),
-                payload,
-            )
+            await ad.notify(channel, payload)
 
         assert await asyncio.wait_for(event, timeout=1) == payload
 
@@ -205,10 +199,7 @@ async def test_event_listener(
 
         # Send from a separate connection to avoid self-notify edge cases.
         async with driver(dsn) as dd:
-            await dd.execute(
-                QueryQueueBuilder(DBSettings(channel=channel)).build_notify_query(),
-                payload.model_dump_json(),
-            )
+            await dd.notify(channel, payload.model_dump_json())
 
         assert (await asyncio.wait_for(listener.get(), timeout=1)) == payload
 

--- a/test/test_sql_safety.py
+++ b/test/test_sql_safety.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from pgqueuer import db
+
+
+async def test_notify_round_trip(apgdriver: db.Driver) -> None:
+    """driver.notify must deliver payload to a listener on the same channel."""
+    import asyncio
+
+    received = asyncio.Future[str | bytes | bytearray]()
+    channel = "test_notify_safety"
+
+    await apgdriver.add_listener(channel, received.set_result)
+    await apgdriver.notify(channel, "hello")
+
+    assert await asyncio.wait_for(received, timeout=1) == "hello"
+
+
+async def test_psycopg_listen_rejects_invalid_channel() -> None:
+    """PsycopgDriver.add_listener must reject non-identifier channel names."""
+    from unittest.mock import MagicMock
+
+    from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
+
+    conn = MagicMock()
+    conn.autocommit = True
+    driver = PsycopgDriver(conn)
+
+    with pytest.raises(ValueError, match="Invalid channel name"):
+        await driver.add_listener("'; DROP TABLE --", lambda p: None)


### PR DESCRIPTION
Channel name was embedded via f-string in build_notify_query and the psycopg LISTEN command. Use $1/$2 parameters for pg_notify and psycopg.sql.Identifier for LISTEN to prevent SQL injection from misconfigured channel names.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
