### PR TITLE
perf(core): batch verify_structure into single schema query

### DIFF
--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -84,6 +84,15 @@ class InMemoryQueries:
     async def has_user_defined_enum(self, key: str, enum: str) -> bool:
         return True
 
+    async def verify_schema(
+        self,
+        tables: list[str],
+        columns: list[tuple[str, str]],
+        enums: list[tuple[str, str]],
+        indexes: list[tuple[str, str]],
+    ) -> list[dict[str, str | None]]:
+        return []
+
     async def has_function(self, function: str) -> bool:
         return True
 

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -320,6 +320,72 @@ class QueryBuilderEnvironment:
     FROM pg_enum
     JOIN pg_type ON pg_enum.enumtypid = pg_type.oid"""
 
+    def build_verify_schema_query(self) -> str:
+        return """
+        WITH expected_tables AS (
+            SELECT unnest($1::text[]) AS table_name
+        ),
+        expected_columns AS (
+            SELECT unnest($2::text[]) AS table_name,
+                   unnest($3::text[]) AS column_name
+        ),
+        expected_enums AS (
+            SELECT unnest($4::text[]) AS enum_label,
+                   unnest($5::text[]) AS type_name
+        ),
+        expected_indexes AS (
+            SELECT unnest($6::text[]) AS table_name,
+                   unnest($7::text[]) AS index_name
+        ),
+        missing_tables AS (
+            SELECT et.table_name
+            FROM expected_tables et
+            WHERE NOT EXISTS (
+                SELECT 1 FROM information_schema.columns isc
+                WHERE isc.table_schema = current_schema()
+                  AND isc.table_name = et.table_name
+            )
+        ),
+        missing_columns AS (
+            SELECT ec.table_name, ec.column_name
+            FROM expected_columns ec
+            WHERE NOT EXISTS (
+                SELECT 1 FROM information_schema.columns isc
+                WHERE isc.table_schema = current_schema()
+                  AND isc.table_name = ec.table_name
+                  AND isc.column_name = ec.column_name
+            )
+        ),
+        missing_enums AS (
+            SELECT ee.enum_label, ee.type_name
+            FROM expected_enums ee
+            WHERE NOT EXISTS (
+                SELECT 1 FROM pg_enum pe
+                JOIN pg_type pt ON pe.enumtypid = pt.oid
+                WHERE pe.enumlabel = ee.enum_label
+                  AND pt.typname = ee.type_name
+            )
+        ),
+        missing_indexes AS (
+            SELECT ei.table_name, ei.index_name
+            FROM expected_indexes ei
+            WHERE NOT EXISTS (
+                SELECT 1 FROM pg_indexes pi
+                WHERE pi.tablename = ei.table_name
+                  AND pi.indexname = ei.index_name
+                  AND pi.schemaname = current_schema()
+            )
+        )
+        SELECT 'table' AS check_type, table_name AS name, NULL AS detail
+            FROM missing_tables
+        UNION ALL
+        SELECT 'column', table_name, column_name FROM missing_columns
+        UNION ALL
+        SELECT 'enum', type_name, enum_label FROM missing_enums
+        UNION ALL
+        SELECT 'index', table_name, index_name FROM missing_indexes
+        """
+
     def build_alter_durability_query(self) -> Generator[str, None, None]:
         durability = self.settings.durability.config
         yield f"""ALTER TABLE {self.settings.queue_table} SET {"LOGGED" if durability.queue_table == "" else "UNLOGGED"};"""  # noqa

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -236,6 +236,29 @@ class Queries:
         (row,) = rows
         return row["exists"]
 
+    async def verify_schema(
+        self,
+        tables: list[str],
+        columns: list[tuple[str, str]],
+        enums: list[tuple[str, str]],
+        indexes: list[tuple[str, str]],
+    ) -> list[dict[str, str | None]]:
+        """Check all schema requirements in a single query.
+
+        Returns a list of dicts with keys 'check_type', 'name', 'detail'
+        for each missing item. Empty list means schema is valid.
+        """
+        return await self.driver.fetch(
+            self.qbe.build_verify_schema_query(),
+            tables,
+            [t for t, _ in columns],
+            [c for _, c in columns],
+            [label for label, _ in enums],
+            [typ for _, typ in enums],
+            [t for t, _ in indexes],
+            [i for _, i in indexes],
+        )
+
     async def has_user_defined_enum(self, key: str, enum: str) -> bool:
         """Check if a value exists in a user-defined ENUM type."""
         rows = await self.driver.fetch(self.qbe.build_user_types_query())

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -330,60 +330,48 @@ class QueueManager:
         """
         Verify the required database structure.
 
-        Checks necessary columns and user-defined types. Raises RuntimeError if missing.
+        Checks necessary tables, columns, enum values, and indexes in a
+        single query. Raises RuntimeError if anything is missing.
         """
+        s = self.queries.qbe.settings
+        log_index = f"{s.queue_table_log}_job_id_status"
 
-        for table in (
-            self.queries.qbe.settings.queue_table,
-            self.queries.qbe.settings.statistics_table,
-        ):
-            if not (await self.queries.has_table(table)):
-                raise RuntimeError(
-                    f"The required table '{table}' is missing. "
-                    f"Please run 'pgq install' to set up the necessary tables."
-                )
+        missing = await self.queries.verify_schema(
+            tables=[s.queue_table, s.statistics_table, s.queue_table_log],
+            columns=[
+                (s.queue_table, "updated"),
+                (s.queue_table, "heartbeat"),
+                (s.queue_table, "queue_manager_id"),
+                (s.queue_table, "execute_after"),
+                (s.queue_table, "headers"),
+                (s.queue_table, "attempts"),
+                (s.queue_table_log, "traceback"),
+            ],
+            enums=[
+                ("canceled", s.queue_status_type),
+                ("failed", s.queue_status_type),
+            ],
+            indexes=[
+                (s.queue_table_log, log_index),
+            ],
+        )
 
-        if not (await self.queries.has_table(self.queries.qbe.settings.queue_table_log)):
-            raise RuntimeError(
-                f"The {self.queries.qbe.settings.queue_table_log} table is missing "
-                "please run 'pgq upgrade'"
-            )
+        if not missing:
+            return
 
-        for table, column in (
-            (self.queries.qbe.settings.queue_table, "updated"),
-            (self.queries.qbe.settings.queue_table, "heartbeat"),
-            (self.queries.qbe.settings.queue_table, "queue_manager_id"),
-            (self.queries.qbe.settings.queue_table, "execute_after"),
-            (self.queries.qbe.settings.queue_table, "headers"),
-            (self.queries.qbe.settings.queue_table, "attempts"),
-            (self.queries.qbe.settings.queue_table_log, "traceback"),
-        ):
-            if not (await self.queries.table_has_column(table, column)):
-                raise RuntimeError(
-                    f"The required column '{column}' is missing in the '{table}' table. "
-                    f"Please run 'pgq upgrade' to ensure all schema changes are applied."
-                )
+        messages = {
+            "table": "The required table '{name}' is missing. "
+            "Please run 'pgq install' to set up the necessary tables.",
+            "column": "The required column '{detail}' is missing in the '{name}' table. "
+            "Please run 'pgq upgrade' to ensure all schema changes are applied.",
+            "enum": "The {name} is missing the '{detail}' type, please run 'pgq upgrade'",
+            "index": "The required index '{detail}' is missing in the '{name}' table. "
+            "Please run 'pgq upgrade' to ensure all schema changes are applied.",
+        }
 
-        for key, enum in (
-            ("canceled", self.queries.qbe.settings.queue_status_type),
-            ("failed", self.queries.qbe.settings.queue_status_type),
-        ):
-            if not (await self.queries.has_user_defined_enum(key, enum)):
-                raise RuntimeError(
-                    f"The {enum} is missing the '{key}' type, please run 'pgq upgrade'"
-                )
-
-        for table, index in (
-            (
-                self.queries.qbe.settings.queue_table_log,
-                f"{self.queries.qbe.settings.queue_table_log}_job_id_status",
-            ),
-        ):
-            if not (await self.queries.table_has_index(table, index)):
-                raise RuntimeError(
-                    f"The required index '{index}' is missing in the '{table}' table. "
-                    f"Please run 'pgq upgrade' to ensure all schema changes are applied."
-                )
+        row = missing[0]
+        template = messages.get(row["check_type"] or "", "Schema check failed: {name} {detail}")
+        raise RuntimeError(template.format(name=row["name"], detail=row.get("detail")))
 
     async def _maybe_drain_shutdown(
         self,

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -220,6 +220,14 @@ class SchemaManagementPort(Protocol):
 
     async def has_user_defined_enum(self, key: str, enum: str) -> bool: ...
 
+    async def verify_schema(
+        self,
+        tables: list[str],
+        columns: list[tuple[str, str]],
+        enums: list[tuple[str, str]],
+        indexes: list[tuple[str, str]],
+    ) -> list[dict[str, str | None]]: ...
+
     async def has_function(self, function: str) -> bool: ...
 
     async def has_trigger(self, trigger: str) -> bool: ...

--- a/test/test_verify_structure.py
+++ b/test/test_verify_structure.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from pgqueuer import db
+from pgqueuer.qm import QueueManager
+
+
+async def test_verify_structure_passes_with_schema(apgdriver: db.Driver) -> None:
+    """verify_structure must pass when the schema is installed."""
+    qm = QueueManager(apgdriver)
+    # Should not raise — schema is installed by the dsn fixture.
+    await qm.verify_structure()
+
+
+async def test_verify_structure_fails_missing_column(apgdriver: db.Driver) -> None:
+    """verify_structure must raise when a required column is missing."""
+    qm = QueueManager(apgdriver)
+    table = qm.queries.qbe.settings.queue_table
+
+    await apgdriver.execute(f"ALTER TABLE {table} DROP COLUMN heartbeat")
+
+    with pytest.raises(RuntimeError, match="heartbeat"):
+        await qm.verify_structure()
+
+
+async def test_verify_structure_fails_missing_table(apgdriver: db.Driver) -> None:
+    """verify_structure must raise when a required table is missing."""
+    qm = QueueManager(apgdriver)
+    table = qm.queries.qbe.settings.queue_table_log
+
+    await apgdriver.execute(f"DROP TABLE {table}")
+
+    with pytest.raises(RuntimeError, match=table):
+        await qm.verify_structure()


### PR DESCRIPTION
Replace ~15 individual DB round-trips (has_table, table_has_column, has_user_defined_enum, table_has_index) with a single CTE-based query that returns all missing items at once. Adds verify_schema to the SchemaManagementPort protocol and both Queries and InMemoryQueries.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
