### PR TITLE
fix(core): simplify listener_healthy timeout to raise directly

### DIFF
--- a/pgqueuer/core/listeners.py
+++ b/pgqueuer/core/listeners.py
@@ -103,7 +103,7 @@ def default_event_router(
 
     @router.register("health_check_event")
     def _health_check_event(evt: models.HealthCheckEvent) -> None:
-        if fut := pending_health_check.get(evt.id):
+        if (fut := pending_health_check.get(evt.id)) and not fut.done():
             fut.set_result(evt)
 
     return router

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -122,6 +122,9 @@ class QueueManager:
 
         Returns:
             models.HealthCheckEvent: The received health check event.
+
+        Raises:
+            FailingListenerError: If the health check times out.
         """
         health_check_event_id = uuid.uuid4()
         fut = asyncio.Future[models.HealthCheckEvent]()
@@ -134,11 +137,7 @@ class QueueManager:
                 timeout.total_seconds(),
             )
         except (TimeoutError, asyncio.TimeoutError):
-            fut.set_exception(errors.FailingListenerError)
-            return await fut
-        except Exception as e:
-            fut.set_exception(e)
-            return await fut
+            raise errors.FailingListenerError from None
         finally:
             self.pending_health_check.pop(health_check_event_id, None)
 

--- a/test/test_listener_healthy_contract.py
+++ b/test/test_listener_healthy_contract.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from pgqueuer import db
+from pgqueuer.domain.errors import FailingListenerError
+from pgqueuer.qm import QueueManager
+
+
+async def test_listener_healthy_raises_on_timeout(apgdriver: db.Driver) -> None:
+    """listener_healthy must raise FailingListenerError directly on timeout."""
+    qm = QueueManager(apgdriver)
+
+    # No listener set up, so the health check notification will never arrive.
+    with pytest.raises(FailingListenerError):
+        await qm.listener_healthy(timeout=timedelta(milliseconds=100))


### PR DESCRIPTION
The previous pattern set an exception on the future then awaited it, which was confusing and created a race window with the NOTIFY callback. Now raise FailingListenerError directly on timeout. Also guard the health check callback with fut.done() check and add Raises docstring.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
