### PR TITLE
refactor(ports): introduce TaskManagerPort, remove ports→core exception

### DIFF
--- a/pgqueuer/ports/driver.py
+++ b/pgqueuer/ports/driver.py
@@ -10,7 +10,19 @@ from typing import Any, Callable, Protocol
 
 from typing_extensions import Self
 
-from pgqueuer.core.tm import TaskManager
+
+class TaskManagerPort(Protocol):
+    """Protocol for managing background asyncio tasks."""
+
+    tasks: set[asyncio.Task]
+
+    def add(self, task: asyncio.Task) -> None: ...
+
+    async def gather_tasks(self, return_exceptions: bool = True) -> list[BaseException | None]: ...
+
+    async def __aenter__(self) -> "TaskManagerPort": ...
+
+    async def __aexit__(self, *_: object) -> None: ...
 
 
 class Driver(Protocol):
@@ -88,7 +100,7 @@ class Driver(Protocol):
         raise NotImplementedError
 
     @property
-    def tm(self) -> TaskManager:
+    def tm(self) -> TaskManagerPort:
         """
         TaskManager instance for managing background tasks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,10 +173,6 @@ name = "Ports must not import from adapters or core"
 type = "forbidden"
 source_modules = ["pgqueuer.ports"]
 forbidden_modules = ["pgqueuer.adapters", "pgqueuer.core"]
-ignore_imports = [
-    # ports/driver.py needs TaskManager from core for the protocol definition
-    "pgqueuer.ports.driver -> pgqueuer.core.tm",
-]
 
 [[tool.importlinter.contracts]]
 name = "Core must not import from adapters"


### PR DESCRIPTION
Replace the concrete `TaskManager` import in `ports/driver.py` with a structural `TaskManagerPort` protocol defined in the ports layer itself. This eliminates the last `ports → core` import-linter exception while preserving full structural subtyping compatibility — `TaskManager` satisfies the protocol without any changes.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
