### PR TITLE
docs: update all guides for v1.0.0 API changes

### DIFF
--- a/docs/comparisons/celery-comparison.md
+++ b/docs/comparisons/celery-comparison.md
@@ -162,8 +162,9 @@ async def wait_for_job() -> None:
     driver = AsyncpgDriver(conn)
     pgq = PgQueuer(driver)
 
-    job_ids = await Queries(driver).enqueue("add", b'{"x": 2, "y": 3}')
-    async with CompletionWatcher(driver) as watcher:
+    queries = Queries(driver)
+    job_ids = await queries.enqueue("add", b'{"x": 2, "y": 3}')
+    async with CompletionWatcher(driver, queries=queries) as watcher:
         status = await watcher.wait_for(job_ids[0])
         print(status)
 ```

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -58,9 +58,7 @@ The `@entrypoint()` decorator accepts several parameters that control how jobs a
 | Parameter | Type | Default | Effect |
 |-----------|------|---------|--------|
 | `name` | `str` | (required) | Entrypoint name -- must match what producers enqueue |
-| `concurrency_limit` | `int` | `0` (unlimited) | Max simultaneous jobs for this entrypoint |
-| `serialized_dispatch` | `bool` | `False` | Process jobs one at a time (equivalent to `concurrency_limit=1`) |
-| `retry_timer` | `timedelta` | `0` (disabled) | Re-queue jobs whose heartbeat has gone stale |
+| `concurrency_limit` | `int` | `0` (unlimited) | Max simultaneous jobs for this entrypoint (database-enforced globally). Use `1` for serialized processing |
 | `accepts_context` | `bool` | `False` | Pass a `Context` object as the second argument |
 | `on_failure` | `"delete" \| "hold"` | `"delete"` | Hold failed jobs for manual re-queue instead of deleting |
 | `executor_factory` | callable | `None` | Custom executor class for retry logic, etc. |

--- a/docs/guides/completion-tracking.md
+++ b/docs/guides/completion-tracking.md
@@ -14,8 +14,11 @@ PostgreSQL `LISTEN/NOTIFY`, with zero manual polling.
 
 ```python
 from pgqueuer.core.completion import CompletionWatcher
+from pgqueuer.queries import Queries
 
-async with CompletionWatcher(driver) as watcher:
+queries = Queries(driver)
+
+async with CompletionWatcher(driver, queries=queries) as watcher:
     status = await watcher.wait_for(job_id)
     # status: "successful", "exception", "canceled", or "deleted"
 ```
@@ -57,7 +60,7 @@ image_ids   = await qm.queries.enqueue(["render_img"]   * 20, [b"..."] * 20, [0]
 report_ids  = await qm.queries.enqueue(["generate_pdf"] * 10, [b"..."] * 10, [0] * 10)
 cleanup_ids = await qm.queries.enqueue(["cleanup"]      *  5, [b"..."] *  5, [0] *  5)
 
-async with CompletionWatcher(driver) as w:
+async with CompletionWatcher(driver, queries=queries) as w:
     img_statuses, pdf_statuses, clean_statuses = await gather(
         gather(*[w.wait_for(j) for j in image_ids]),
         gather(*[w.wait_for(j) for j in report_ids]),
@@ -81,6 +84,7 @@ import asyncio
 from datetime import timedelta
 from pgqueuer import db, models
 from pgqueuer.core.completion import CompletionWatcher
+from pgqueuer.queries import Queries
 
 
 async def wait_for_all(
@@ -91,6 +95,7 @@ async def wait_for_all(
 ) -> list[models.JOB_STATUS]:
     async with CompletionWatcher(
         driver,
+        queries=Queries(driver),
         refresh_interval=refresh_interval,
         debounce=debounce,
     ) as watcher:
@@ -111,6 +116,7 @@ async def wait_for_first(
 ) -> models.JOB_STATUS:
     async with CompletionWatcher(
         driver,
+        queries=Queries(driver),
         refresh_interval=refresh_interval,
         debounce=debounce,
     ) as watcher:
@@ -135,6 +141,6 @@ To maximise reliability without heavy polling:
    notifications when your channel is stable:
 
     ```python
-    async with CompletionWatcher(driver, refresh_interval=timedelta(minutes=5)) as w:
+    async with CompletionWatcher(driver, queries=Queries(driver), refresh_interval=timedelta(minutes=5)) as w:
         status = await w.wait_for(job_id)
     ```

--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -26,24 +26,25 @@ WHERE status = 'picked'
   AND heartbeat < NOW() - INTERVAL '5 minutes';
 ```
 
-## Retry Timer
+## Heartbeat Timeout
 
-The `retry_timer` parameter on the `@entrypoint()` decorator sets an interval after which
-jobs with a stale heartbeat are eligible to be re-picked by any available worker. This
-enables automatic recovery from crashed or stalled workers:
+The `heartbeat_timeout` parameter on `pgq.run()` / `QueueManager.run()` sets the
+duration after which a picked job with a stale heartbeat becomes eligible for
+re-pickup by any available worker. Heartbeats are sent automatically at half
+this interval. This enables automatic recovery from crashed or stalled workers:
 
 ```python
 from datetime import timedelta
 
-@pgq.entrypoint("my_task", retry_timer=timedelta(minutes=5))
-async def my_task(job: Job) -> None:
-    await do_work(job.payload)
+await pgq.run(
+    heartbeat_timeout=timedelta(minutes=5),
+)
 ```
 
-With `retry_timer` set, a job that stops updating its heartbeat for the specified duration
-will be retried by the next available worker.
+With `heartbeat_timeout` set, a job that stops updating its heartbeat for the
+specified duration will be retried by the next available worker.
 
 !!! note
-    The default `retry_timer` is `0` (disabled). Set it per entrypoint to match your
-    expected maximum job runtime plus a safety margin to avoid prematurely re-queuing
+    The default `heartbeat_timeout` is 30 seconds. Set it to match your expected
+    maximum job runtime plus a safety margin to avoid prematurely re-queuing
     legitimately long-running jobs.

--- a/docs/guides/rate-limiting.md
+++ b/docs/guides/rate-limiting.md
@@ -1,7 +1,9 @@
 # Concurrency Control
 
 PgQueuer provides fine-grained control over job execution concurrency at the
-entrypoint level.
+entrypoint level. Concurrency limits are enforced **globally** at the database
+level via the dequeue SQL query, not per-worker. If you set `concurrency_limit=5`,
+at most 5 jobs run across your entire fleet.
 
 ## Concurrency Limiting
 
@@ -16,17 +18,18 @@ async def process_data(job: Job) -> None:
 This is useful for protecting external services with connection pool limits or
 memory-intensive operations.
 
-## Serialized Dispatch
+## Serialized Processing
 
 Ensure jobs of the same type are processed strictly one at a time:
 
 ```python
-@pgq.entrypoint("shared_resource", serialized_dispatch=True)
+@pgq.entrypoint("shared_resource", concurrency_limit=1)
 async def process_shared_resource(job: Job) -> None:
     pass
 ```
 
-`serialized_dispatch=True` is equivalent to `concurrency_limit=1`.
+Setting `concurrency_limit=1` guarantees that only one job of this entrypoint runs
+at a time across all workers.
 
 ## Global Concurrency Limit
 
@@ -41,12 +44,13 @@ This limits the total across all entrypoints regardless of individual entrypoint
 
 ## Combining Controls
 
-You can combine multiple controls on a single entrypoint:
+You can combine concurrency limits with other entrypoint options:
 
 ```python
 @pgq.entrypoint(
     "api_call",
     concurrency_limit=3,
+    on_failure="hold",
 )
 async def call_external_api(job: Job) -> None:
     pass
@@ -54,9 +58,10 @@ async def call_external_api(job: Job) -> None:
 
 ## Configuring Timeouts
 
-Two additional parameters control job processing timing:
+Two parameters on `pgq.run()` control job processing timing:
 
-- **`dequeue_timeout`**: Maximum time (in seconds) to wait for new jobs before returning an
-  empty batch. Default: 30 seconds. Set at the `QueueManager` / `PgQueuer` level.
-- **`retry_timer`**: Interval to retry unprocessed jobs. Default: 0 (no retry timer).
-  Set per entrypoint via the `@entrypoint()` decorator.
+- **`dequeue_timeout`**: Maximum time to wait for new jobs before re-checking.
+  Default: 30 seconds.
+- **`heartbeat_timeout`**: Duration after which a picked job with a stale heartbeat
+  becomes eligible for re-pickup by another worker. Heartbeats are sent automatically
+  at half this interval. Default: 30 seconds.

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,8 @@ That's it. Just PostgreSQL and your application code.
     ---
 
     Per-entrypoint `concurrency_limit` protects downstream services.
-    Or use `serialized_dispatch` to process jobs strictly one at a time.
+    Use `concurrency_limit=1` to process jobs strictly one at a time.
+    Limits are enforced globally at the database level across all workers.
 
 -   **Built-In Scheduler**
 

--- a/docs/integrations/tracing.md
+++ b/docs/integrations/tracing.md
@@ -25,11 +25,11 @@ with PGQueuer:
 
 ```python
 import logfire
-from pgqueuer.adapters import tracing
 from pgqueuer.adapters.tracing.logfire import LogfireTracing
+from pgqueuer.ports.tracing import set_tracing_class
 
 logfire.configure()
-tracing.set_tracing_class(LogfireTracing())
+set_tracing_class(LogfireTracing())
 ```
 
 With this setup, trace context is added to job headers when you enqueue messages.
@@ -46,14 +46,14 @@ Initialise the Sentry SDK with your DSN, then set the tracer class:
 
 ```python
 import sentry_sdk
-from pgqueuer.adapters import tracing
 from pgqueuer.adapters.tracing.sentry import SentryTracing
+from pgqueuer.ports.tracing import set_tracing_class
 
 sentry_sdk.init(
     dsn="https://<key>@o1.ingest.sentry.io/<project>",
     traces_sample_rate=1.0,
 )
-tracing.set_tracing_class(SentryTracing())
+set_tracing_class(SentryTracing())
 ```
 
 Job headers will include Sentry tracing information so that consumer spans are linked to
@@ -68,11 +68,11 @@ Configure your `TracerProvider`, then register the tracer with PGQueuer:
 ```python
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
-from pgqueuer.adapters import tracing
 from pgqueuer.adapters.tracing.opentelemetry import OpenTelemetryTracing
+from pgqueuer.ports.tracing import set_tracing_class
 
 trace.set_tracer_provider(TracerProvider())
-tracing.set_tracing_class(OpenTelemetryTracing())
+set_tracing_class(OpenTelemetryTracing())
 ```
 
 The adapter follows OTel


### PR DESCRIPTION
- Remove serialized_dispatch references (use concurrency_limit=1)
- Replace retry_timer with heartbeat_timeout on run()
- Update CompletionWatcher examples to pass queries= kwarg
- Fix tracing imports: adapters.tracing → ports.tracing
- Note concurrency_limit is database-enforced globally
- Update entrypoint parameters table in core-concepts

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
