### PR TITLE
fix(cli): use selector loop on Windows for psycopg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,11 @@ jobs:
       PYTHONASYNCIODEBUG: 1
       PYTHONDEBUG: 1
       PYTHONFAULTHANDLER: 1
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: root
+      PGDATABASE: pgq
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -198,8 +203,28 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Install PGQueuer
         run: uv sync --all-extras --frozen
-      - name: Run Windows Shutdown Test
-        run: uv run pytest test/windows/test_shutdown.py --durations=10
+      - name: Start preinstalled PostgreSQL
+        shell: pwsh
+        run: |
+          $svc = Get-Service -Name "postgresql*" | Select-Object -First 1
+          if (-not $svc) { throw "PostgreSQL service not found on windows-latest runner" }
+          Set-Service -Name $svc.Name -StartupType Manual
+          Start-Service -Name $svc.Name
+          & "$env:PGBIN\pg_isready" -h $env:PGHOST -p $env:PGPORT
+      - name: Provision test database
+        shell: pwsh
+        run: |
+          & "$env:PGBIN\psql" -U $env:PGUSER -h $env:PGHOST -p $env:PGPORT -d postgres -c "CREATE DATABASE $env:PGDATABASE;"
+      - name: Run Windows Tests
+        run: uv run pytest test/windows/ --durations=10
+      - name: Force psycopg backend (drop asyncpg)
+        run: uv pip uninstall asyncpg
+      - name: Smoke `pgq install` / `pgq uninstall` against psycopg
+        run: |
+          uv run pgq install
+          uv run pgq verify --expect present
+          uv run pgq uninstall
+          uv run pgq verify --expect absent
   run-checks:
     if: github.event_name != 'schedule'
     name: Lint, Typecheck & Architecture

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -39,6 +39,10 @@ the questions that quickly separate configuration issues from bugs.
 - Mixing `%s` and `$1` placeholders breaks prepared statement caching.
 - Async connections must be `await conn.close()`; sync connections should stay out of asyncio
   event loops.
+- **Windows event loop** — async psycopg rejects the default `ProactorEventLoop`. Use
+  `SelectorEventLoop` (e.g. `asyncio.run(main, loop_factory=asyncio.SelectorEventLoop)` on
+  3.12+). The `pgq` CLI does this for you; embedded use must opt in. See
+  [drivers reference](../reference/drivers.md#psycopgdriver) for full snippets.
 
 ## 4. PGQueuer Expectations
 

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -82,6 +82,21 @@ conn.autocommit = True
 driver = PsycopgDriver(conn)
 ```
 
+!!! note "Windows event loop"
+    psycopg's async driver is not compatible with Python's default
+    `ProactorEventLoop` on Windows. Run your application under
+    `SelectorEventLoop` instead. On Python 3.12+ this is a one-liner:
+
+    ```python
+    import asyncio
+    asyncio.run(main(), loop_factory=asyncio.SelectorEventLoop)
+    ```
+
+    On 3.11 use `asyncio.Runner(loop_factory=asyncio.SelectorEventLoop)`;
+    on 3.10 set `WindowsSelectorEventLoopPolicy` before `asyncio.run`.
+    The `pgq` CLI handles this automatically. See the
+    [psycopg async docs](https://www.psycopg.org/psycopg3/docs/advanced/async.html).
+
 ## Synchronous Driver
 
 ### `SyncPsycopgDriver`

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -4,10 +4,11 @@ import asyncio
 import contextlib
 import functools
 import os
+import sys
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable
+from typing import Callable, Coroutine
 
 import typer
 from tabulate import tabulate
@@ -21,9 +22,30 @@ from pgqueuer.domain import models, types
 from pgqueuer.ports.driver import Driver
 
 try:
-    from uvloop import run as asyncio_run
+    from uvloop import run as _asyncio_run
 except ImportError:
-    from asyncio import run as asyncio_run  # type: ignore[assignment]
+    from asyncio import run as _asyncio_run  # type: ignore[assignment]
+
+
+def asyncio_run(coro: Coroutine[object, object, object]) -> None:
+    if sys.platform != "win32":
+        _asyncio_run(coro)
+        return
+
+    # psycopg async rejects ProactorEventLoop (Windows default).
+    if sys.version_info >= (3, 12):
+        asyncio.run(coro, loop_factory=asyncio.SelectorEventLoop)
+        return
+
+    if sys.version_info >= (3, 11):
+        with asyncio.Runner(loop_factory=asyncio.SelectorEventLoop) as runner:
+            runner.run(coro)
+        return
+
+    # Python 3.10: no Runner, no loop_factory; mutate policy.
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    _asyncio_run(coro)
+
 
 app = typer.Typer(
     help=(

--- a/test/windows/test_cli_event_loop_policy.py
+++ b/test/windows/test_cli_event_loop_policy.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Coroutine
+
+import pytest
+
+from pgqueuer.adapters.cli import cli
+
+
+def test_off_windows_delegates_to_inner_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+
+    calls: list[Coroutine[object, object, None]] = []
+
+    def fake_run(coro: Coroutine[object, object, None]) -> None:
+        calls.append(coro)
+        coro.close()
+
+    monkeypatch.setattr(cli, "_asyncio_run", fake_run)
+
+    async def noop() -> None:
+        return None
+
+    coro = noop()
+    cli.asyncio_run(coro)
+
+    assert calls == [coro]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="asyncio.Runner is 3.11+")
+def test_windows_path_runs_under_selector_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+
+    captured: list[type[asyncio.AbstractEventLoop]] = []
+
+    async def probe() -> None:
+        captured.append(type(asyncio.get_running_loop()))
+
+    cli.asyncio_run(probe())
+
+    assert len(captured) == 1
+    assert issubclass(captured[0], asyncio.SelectorEventLoop)
+
+
+@pytest.mark.skipif(
+    not hasattr(asyncio, "WindowsSelectorEventLoopPolicy"),
+    reason="WindowsSelectorEventLoopPolicy only exists on Windows",
+)
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_python_310_path_installs_selector_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(cli.sys, "version_info", (3, 10, 0))
+
+    seen: list[asyncio.AbstractEventLoopPolicy] = []
+
+    def fake_run(coro: Coroutine[object, object, None]) -> None:
+        seen.append(asyncio.get_event_loop_policy())
+        coro.close()
+
+    monkeypatch.setattr(cli, "_asyncio_run", fake_run)
+
+    original_policy = asyncio.get_event_loop_policy()
+    asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+    try:
+
+        async def noop() -> None:
+            return None
+
+        cli.asyncio_run(noop())
+    finally:
+        asyncio.set_event_loop_policy(original_policy)
+
+    assert len(seen) == 1
+    assert isinstance(seen[0], asyncio.WindowsSelectorEventLoopPolicy)  # type: ignore[attr-defined]

--- a/test/windows/test_psycopg_async_loop.py
+++ b/test/windows/test_psycopg_async_loop.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from pgqueuer.adapters.cli import cli
+
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="ProactorEventLoop is only the default on Windows",
+    ),
+    pytest.mark.skipif(
+        "PGHOST" not in os.environ,
+        reason="No PostgreSQL configured (set PGHOST/PGUSER/PGDATABASE to run)",
+    ),
+]
+
+
+def _conninfo() -> str:
+    from psycopg.conninfo import make_conninfo
+
+    return make_conninfo(
+        host=os.environ["PGHOST"],
+        port=os.environ.get("PGPORT", "5432"),
+        user=os.environ.get("PGUSER", "postgres"),
+        password=os.environ.get("PGPASSWORD", ""),
+        dbname=os.environ.get("PGDATABASE", "postgres"),
+    )
+
+
+def test_asyncio_run_drives_psycopg_async_connection() -> None:
+    psycopg = pytest.importorskip("psycopg")
+
+    conninfo = _conninfo()
+    captured: list[int] = []
+
+    async def roundtrip() -> None:
+        async with (
+            await psycopg.AsyncConnection.connect(conninfo) as conn,
+            conn.cursor() as cur,
+        ):
+            await cur.execute("SELECT 1")
+            row = await cur.fetchone()
+        assert row is not None
+        captured.append(int(row[0]))
+
+    cli.asyncio_run(roundtrip())
+
+    assert captured == [1]


### PR DESCRIPTION
Closes #628

- Fixes #628: psycopg's async driver rejects Windows' default `ProactorEventLoop`, so every CLI command that opens a psycopg `AsyncConnection` (`pgq install`, `verify`, `uninstall`, ...) hangs or errors on win32.
- `pgq` CLI now runs under `SelectorEventLoop` on Windows. asyncpg and uvloop paths are untouched.

## Testing
- [x] `make check` passed
- [x] Additional testing steps

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have added or updated tests
- [x] I have updated documentation if necessary
