### PR TITLE
fix(qm): mark canceled jobs canceled on SIGTERM

### DIFF
--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -591,9 +591,7 @@ class QueueManager:
                     job.entrypoint,
                     job.id,
                 )
-                # Shield the log write: the same CancelledError that landed us
-                # here would otherwise abort jbuff.add, leaving the row stuck
-                # at 'picked' (see GH #630).
+                # shield: same cancel would otherwise abort the log write.
                 await asyncio.shield(jbuff.add((job, "canceled", None)))
                 raise
             except Exception as e:

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -585,6 +585,17 @@ class QueueManager:
                     },
                 )
                 await self.queries.retry_job(job, retry_exc.delay, tbr)
+            except asyncio.CancelledError:
+                logconfig.logger.info(
+                    "Job canceled mid-flight for entrypoint/id: %s/%s",
+                    job.entrypoint,
+                    job.id,
+                )
+                # Shield the log write: the same CancelledError that landed us
+                # here would otherwise abort jbuff.add, leaving the row stuck
+                # at 'picked' (see GH #630).
+                await asyncio.shield(jbuff.add((job, "canceled", None)))
+                raise
             except Exception as e:
                 logconfig.logger.exception(
                     "Exception while processing entrypoint/job-id: %s/%s",

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -586,7 +586,7 @@ class QueueManager:
                 )
                 await self.queries.retry_job(job, retry_exc.delay, tbr)
             except asyncio.CancelledError:
-                logconfig.logger.info(
+                logconfig.logger.debug(
                     "Job canceled mid-flight for entrypoint/id: %s/%s",
                     job.entrypoint,
                     job.id,

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -163,8 +163,15 @@ async def test_varying_retry_timers(apgdriver: db.Driver) -> None:
     assert all(v == 1 for v in calls.values())
 
 
-async def test_retry_with_cancellation(apgdriver: db.Driver) -> None:
-    N = 4
+async def test_cancellation_marks_canceled_no_retry(apgdriver: db.Driver) -> None:
+    """CancelledError from a handler is terminal — job marked 'canceled', not retried.
+
+    Regression test for GH #630. Prior to the fix, ``CancelledError``
+    (BaseException) bypassed the dispatcher's ``except Exception`` clause and
+    left the row at ``'picked'``. Heartbeat staleness then re-picked it,
+    producing accidental retries. The dispatcher now catches it explicitly,
+    writes ``'canceled'``, and re-raises.
+    """
     retry_timer = timedelta(seconds=0.100)
     qm = QueueManager(queries.Queries(apgdriver))
     calls = Counter[JobId]()
@@ -172,18 +179,18 @@ async def test_retry_with_cancellation(apgdriver: db.Driver) -> None:
     @qm.entrypoint("fetch")
     async def fetch(context: Job) -> None:
         calls[context.id] += 1
-        if calls[context.id] < N:
-            raise asyncio.CancelledError("Simulated cancellation")
-        # Nth attempt succeeds — signal shutdown from inside the handler
-        # so no additional retry can sneak in before shutdown takes effect.
         qm.shutdown.set()
+        raise asyncio.CancelledError("Simulated cancellation")
 
     await qm.queries.enqueue(["fetch"], [None], [0])
 
     await qm.run(dequeue_timeout=timedelta(seconds=0), heartbeat_timeout=retry_timer)
 
-    assert len(calls) == 1
-    assert sum(v for v in calls.values()) == N
+    assert sum(calls.values()) == 1, f"Expected one call, got {dict(calls)}"
+
+    log = await qm.queries.queue_log()
+    canceled = [e for e in log if e.status == "canceled"]
+    assert len(canceled) == 1, f"Expected one 'canceled' log entry, got {log}"
 
 
 async def test_heartbeat_db_datetime(apgdriver: db.Driver) -> None:

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -164,14 +164,7 @@ async def test_varying_retry_timers(apgdriver: db.Driver) -> None:
 
 
 async def test_cancellation_marks_canceled_no_retry(apgdriver: db.Driver) -> None:
-    """CancelledError from a handler is terminal — job marked 'canceled', not retried.
-
-    Regression test for GH #630. Prior to the fix, ``CancelledError``
-    (BaseException) bypassed the dispatcher's ``except Exception`` clause and
-    left the row at ``'picked'``. Heartbeat staleness then re-picked it,
-    producing accidental retries. The dispatcher now catches it explicitly,
-    writes ``'canceled'``, and re-raises.
-    """
+    """CancelledError in a handler marks the job 'canceled' and is not retried (GH #630)."""
     retry_timer = timedelta(seconds=0.100)
     qm = QueueManager(queries.Queries(apgdriver))
     calls = Counter[JobId]()

--- a/test/test_sigterm_cancellation.py
+++ b/test/test_sigterm_cancellation.py
@@ -48,9 +48,7 @@ async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> Non
     await queries.log_jobs([(job, "canceled", None)])
 
     log = await queries.queue_log()
-    assert [e.status for e in log if e.job_id == job.id and e.status == "canceled"] == [
-        "canceled"
-    ]
+    assert [e.status for e in log if e.job_id == job.id and e.status == "canceled"] == ["canceled"]
     # The row is no longer pickable.
     again = await queries.dequeue(
         10,
@@ -99,9 +97,7 @@ async def test_dispatch_cancellation_error_logs_canceled(
             repository=queries,
         ) as hbuff,
     ):
-        dispatch = asyncio.create_task(
-            qm._dispatch(job, jbuff, hbuff, timedelta(seconds=30))
-        )
+        dispatch = asyncio.create_task(qm._dispatch(job, jbuff, hbuff, timedelta(seconds=30)))
         await asyncio.wait_for(started.wait(), timeout=2)
 
         dispatch.cancel()
@@ -155,9 +151,7 @@ async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
             repository=queries,
         ) as hbuff,
     ):
-        dispatch = asyncio.create_task(
-            qm._dispatch(job, jbuff, hbuff, timedelta(seconds=30))
-        )
+        dispatch = asyncio.create_task(qm._dispatch(job, jbuff, hbuff, timedelta(seconds=30)))
         await asyncio.wait_for(started.wait(), timeout=2)
         dispatch.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -174,6 +168,63 @@ async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
     )
     assert [j.payload for j in next_jobs] == [b"second"], (
         f"Concurrency slot deadlocked — could not pick next job: {next_jobs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: stale recovery must bypass the concurrency gate (GH #630, problem 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason="GH #630 problem 2: stale recovery deadlocked by concurrency gate. "
+    "Fix lands in follow-up PR.",
+    strict=True,
+)
+async def test_stale_recovery_bypasses_concurrency_limit(
+    queries: InMemoryQueries,
+) -> None:
+    """A new worker must recover stale 'picked' rows even when the slot is full.
+
+    Reproduces the recovery deadlock from GH #630: with concurrency_limit=1,
+    a leaked 'picked' row from a dead worker occupies the slot. The recovery
+    path (stale-heartbeat re-pick) currently applies the same concurrency gate
+    as new dequeues, so it sees ``picked >= limit`` and returns nothing —
+    permanent deadlock with no self-healing.
+
+    Re-picking just transfers ownership; live execution is unchanged.
+    The gate should be dropped from the stale branch.
+    """
+    heartbeat_timeout = timedelta(milliseconds=20)
+
+    # Worker A picks the job, then "dies" without logging — row stays 'picked'.
+    qm_a = uuid.uuid4()
+    await queries.enqueue("ep", b"x", priority=1)
+    jobs_a = await queries.dequeue(
+        10,
+        {"ep": EP_SERIAL},
+        qm_a,
+        None,
+        heartbeat_timeout=heartbeat_timeout,
+    )
+    assert len(jobs_a) == 1
+    leaked = jobs_a[0]
+
+    # Wait for the heartbeat to go stale.
+    await asyncio.sleep(heartbeat_timeout.total_seconds() * 3)
+
+    # Worker B arrives. The slot looks full (concurrency_limit=1, one row
+    # at status='picked'), but the row is stale and must be recoverable.
+    qm_b = uuid.uuid4()
+    jobs_b = await queries.dequeue(
+        10,
+        {"ep": EP_SERIAL},
+        qm_b,
+        None,
+        heartbeat_timeout=heartbeat_timeout,
+    )
+    assert [j.id for j in jobs_b] == [leaked.id], (
+        f"Stale row not recovered — recovery path blocked by concurrency gate. Got: {jobs_b}"
     )
 
 

--- a/test/test_sigterm_cancellation.py
+++ b/test/test_sigterm_cancellation.py
@@ -1,0 +1,181 @@
+"""
+Regression tests for GitHub issue #630.
+
+When a dispatched job is interrupted by ``asyncio.CancelledError`` (e.g. SIGTERM
+during a pod rollout), the row must transition out of ``'picked'`` with a
+``'canceled'`` log entry so it does not block the queue's concurrency slot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from datetime import timedelta
+
+import anyio
+import pytest
+
+from pgqueuer.adapters.inmemory import InMemoryQueries
+from pgqueuer.core import buffers
+from pgqueuer.core.qm import QueueManager
+from pgqueuer.domain import models
+from pgqueuer.ports.repository import EntrypointExecutionParameter
+
+EP_UNLIMITED = EntrypointExecutionParameter(0)
+EP_SERIAL = EntrypointExecutionParameter(1)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: contract — log_jobs('canceled') releases a picked row
+# ---------------------------------------------------------------------------
+
+
+async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> None:
+    """Logging a picked job with status='canceled' frees the slot."""
+    await queries.enqueue("ep", b"x", priority=1)
+    qm_id = uuid.uuid4()
+    jobs = await queries.dequeue(
+        10,
+        {"ep": EP_UNLIMITED},
+        qm_id,
+        None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert len(jobs) == 1
+    job = jobs[0]
+
+    await queries.log_jobs([(job, "canceled", None)])
+
+    log = await queries.queue_log()
+    assert [e.status for e in log if e.job_id == job.id and e.status == "canceled"] == [
+        "canceled"
+    ]
+    # The row is no longer pickable.
+    again = await queries.dequeue(
+        10,
+        {"ep": EP_UNLIMITED},
+        qm_id,
+        None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert again == []
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: regression — dispatcher CancelledError writes a 'canceled' log
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_cancellation_error_logs_canceled(
+    queries: InMemoryQueries,
+) -> None:
+    """Cancelling an in-flight dispatch must mark the row 'canceled', not leave it 'picked'."""
+    qm = QueueManager(queries=queries)
+    started = asyncio.Event()
+
+    @qm.entrypoint("hang")
+    async def handler(job: models.Job) -> None:
+        started.set()
+        await asyncio.sleep(3600)  # blocked until cancelled — simulates SIGTERM
+
+    await queries.enqueue("hang", b"payload", priority=1)
+    jobs = await queries.dequeue(
+        10,
+        {"hang": EP_UNLIMITED},
+        qm.queue_manager_id,
+        None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert len(jobs) == 1
+    job = jobs[0]
+    qm.job_context[job.id] = models.Context(cancellation=anyio.CancelScope())
+
+    async with (
+        buffers.JobStatusLogBuffer(max_size=1, repository=queries) as jbuff,
+        buffers.HeartbeatBuffer(
+            max_size=10,
+            timeout=timedelta(seconds=1),
+            repository=queries,
+        ) as hbuff,
+    ):
+        dispatch = asyncio.create_task(
+            qm._dispatch(job, jbuff, hbuff, timedelta(seconds=30))
+        )
+        await asyncio.wait_for(started.wait(), timeout=2)
+
+        dispatch.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await dispatch
+
+    # Bug condition: row stays at 'picked' forever.
+    statuses = await queries.job_status([job.id])
+    assert statuses == [] or all(st != "picked" for _, st in statuses), (
+        f"Job stuck in 'picked' state after cancellation: {statuses}"
+    )
+
+    log = await queries.queue_log()
+    canceled = [e for e in log if e.job_id == job.id and e.status == "canceled"]
+    assert len(canceled) == 1, (
+        f"Expected one 'canceled' log entry, got {[(e.job_id, e.status) for e in log]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: deadlock — concurrency slot is freed after cancel
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
+    """With concurrency_limit=1, a cancelled job must not block the next one."""
+    qm = QueueManager(queries=queries)
+    started = asyncio.Event()
+
+    @qm.entrypoint("serial", concurrency_limit=1)
+    async def handler(job: models.Job) -> None:
+        started.set()
+        await asyncio.sleep(3600)
+
+    await queries.enqueue("serial", b"first", priority=1)
+    jobs = await queries.dequeue(
+        10,
+        {"serial": EP_SERIAL},
+        qm.queue_manager_id,
+        None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    job = jobs[0]
+    qm.job_context[job.id] = models.Context(cancellation=anyio.CancelScope())
+
+    async with (
+        buffers.JobStatusLogBuffer(max_size=1, repository=queries) as jbuff,
+        buffers.HeartbeatBuffer(
+            max_size=10,
+            timeout=timedelta(seconds=1),
+            repository=queries,
+        ) as hbuff,
+    ):
+        dispatch = asyncio.create_task(
+            qm._dispatch(job, jbuff, hbuff, timedelta(seconds=30))
+        )
+        await asyncio.wait_for(started.wait(), timeout=2)
+        dispatch.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await dispatch
+
+    # Concurrency slot must now be free.
+    await queries.enqueue("serial", b"second", priority=1)
+    next_jobs = await queries.dequeue(
+        10,
+        {"serial": EP_SERIAL},
+        qm.queue_manager_id,
+        None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert [j.payload for j in next_jobs] == [b"second"], (
+        f"Concurrency slot deadlocked — could not pick next job: {next_jobs}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/test_sigterm_cancellation.py
+++ b/test/test_sigterm_cancellation.py
@@ -1,10 +1,4 @@
-"""
-Regression tests for GitHub issue #630.
-
-When a dispatched job is interrupted by ``asyncio.CancelledError`` (e.g. SIGTERM
-during a pod rollout), the row must transition out of ``'picked'`` with a
-``'canceled'`` log entry so it does not block the queue's concurrency slot.
-"""
+"""Regression tests for GH #630: CancelledError must mark a job 'canceled'."""
 
 from __future__ import annotations
 
@@ -26,13 +20,8 @@ EP_UNLIMITED = EntrypointExecutionParameter(0)
 EP_SERIAL = EntrypointExecutionParameter(1)
 
 
-# ---------------------------------------------------------------------------
-# Layer 1: contract — log_jobs('canceled') releases a picked row
-# ---------------------------------------------------------------------------
-
-
 async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> None:
-    """Logging a picked job with status='canceled' frees the slot."""
+    """log_jobs('canceled') removes the row and frees the slot."""
     await queries.enqueue("ep", b"x", priority=1)
     qm_id = uuid.uuid4()
     jobs = await queries.dequeue(
@@ -49,7 +38,6 @@ async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> Non
 
     log = await queries.queue_log()
     assert [e.status for e in log if e.job_id == job.id and e.status == "canceled"] == ["canceled"]
-    # The row is no longer pickable.
     again = await queries.dequeue(
         10,
         {"ep": EP_UNLIMITED},
@@ -60,22 +48,17 @@ async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> Non
     assert again == []
 
 
-# ---------------------------------------------------------------------------
-# Layer 2: regression — dispatcher CancelledError writes a 'canceled' log
-# ---------------------------------------------------------------------------
-
-
 async def test_dispatch_cancellation_error_logs_canceled(
     queries: InMemoryQueries,
 ) -> None:
-    """Cancelling an in-flight dispatch must mark the row 'canceled', not leave it 'picked'."""
+    """Cancelling an in-flight dispatch writes a 'canceled' log entry."""
     qm = QueueManager(queries=queries)
     started = asyncio.Event()
 
     @qm.entrypoint("hang")
     async def handler(job: models.Job) -> None:
         started.set()
-        await asyncio.sleep(3600)  # blocked until cancelled — simulates SIGTERM
+        await asyncio.sleep(3600)
 
     await queries.enqueue("hang", b"payload", priority=1)
     jobs = await queries.dequeue(
@@ -104,7 +87,6 @@ async def test_dispatch_cancellation_error_logs_canceled(
         with contextlib.suppress(asyncio.CancelledError):
             await dispatch
 
-    # Bug condition: row stays at 'picked' forever.
     statuses = await queries.job_status([job.id])
     assert statuses == [] or all(st != "picked" for _, st in statuses), (
         f"Job stuck in 'picked' state after cancellation: {statuses}"
@@ -117,13 +99,8 @@ async def test_dispatch_cancellation_error_logs_canceled(
     )
 
 
-# ---------------------------------------------------------------------------
-# Layer 3: deadlock — concurrency slot is freed after cancel
-# ---------------------------------------------------------------------------
-
-
 async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
-    """With concurrency_limit=1, a cancelled job must not block the next one."""
+    """Cancelled job releases its concurrency slot."""
     qm = QueueManager(queries=queries)
     started = asyncio.Event()
 
@@ -157,7 +134,6 @@ async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
         with contextlib.suppress(asyncio.CancelledError):
             await dispatch
 
-    # Concurrency slot must now be free.
     await queries.enqueue("serial", b"second", priority=1)
     next_jobs = await queries.dequeue(
         10,
@@ -171,33 +147,16 @@ async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
     )
 
 
-# ---------------------------------------------------------------------------
-# Layer 4: stale recovery must bypass the concurrency gate (GH #630, problem 2)
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.xfail(
-    reason="GH #630 problem 2: stale recovery deadlocked by concurrency gate. "
-    "Fix lands in follow-up PR.",
+    reason="GH #630 problem 2: stale recovery blocked by concurrency gate.",
     strict=True,
 )
 async def test_stale_recovery_bypasses_concurrency_limit(
     queries: InMemoryQueries,
 ) -> None:
-    """A new worker must recover stale 'picked' rows even when the slot is full.
-
-    Reproduces the recovery deadlock from GH #630: with concurrency_limit=1,
-    a leaked 'picked' row from a dead worker occupies the slot. The recovery
-    path (stale-heartbeat re-pick) currently applies the same concurrency gate
-    as new dequeues, so it sees ``picked >= limit`` and returns nothing —
-    permanent deadlock with no self-healing.
-
-    Re-picking just transfers ownership; live execution is unchanged.
-    The gate should be dropped from the stale branch.
-    """
+    """Stale rows are recoverable even when picked count == concurrency_limit."""
     heartbeat_timeout = timedelta(milliseconds=20)
 
-    # Worker A picks the job, then "dies" without logging — row stays 'picked'.
     qm_a = uuid.uuid4()
     await queries.enqueue("ep", b"x", priority=1)
     jobs_a = await queries.dequeue(
@@ -210,11 +169,8 @@ async def test_stale_recovery_bypasses_concurrency_limit(
     assert len(jobs_a) == 1
     leaked = jobs_a[0]
 
-    # Wait for the heartbeat to go stale.
     await asyncio.sleep(heartbeat_timeout.total_seconds() * 3)
 
-    # Worker B arrives. The slot looks full (concurrency_limit=1, one row
-    # at status='picked'), but the row is stale and must be recoverable.
     qm_b = uuid.uuid4()
     jobs_b = await queries.dequeue(
         10,


### PR DESCRIPTION
CancelledError inherits from BaseException, so the dispatcher's except Exception clause never caught it. Rows stayed at 'picked' with no terminal log, blocking concurrency slots indefinitely.

Catch CancelledError explicitly, shield the log write against the same cancellation, then re-raise.

Closes #630

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [x] `make check` passed
- [x] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [x] I have updated documentation if necessary
