### PR TITLE
feat(core): auto-detect context injection from handler signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Initialize heavyweight objects once and inject them into all jobs:
 import asyncpg
 from pgqueuer import PgQueuer
 from pgqueuer.db import AsyncpgDriver
-from pgqueuer.models import Job
+from pgqueuer.models import Context, Job
 
 async def create_pgqueuer() -> PgQueuer:
     conn = await asyncpg.connect()
@@ -251,10 +251,9 @@ async def create_pgqueuer() -> PgQueuer:
 
     pgq = PgQueuer(driver, resources=resources)
 
+    # Annotate a parameter as Context and PGQueuer injects the job's Context.
     @pgq.entrypoint("process_user")
-    async def process_user(job: Job) -> None:
-        ctx = pgq.qm.get_context(job.id)
-
+    async def process_user(job: Job, ctx: Context) -> None:
         # Access shared resources
         pool = ctx.resources["db_pool"]
         http = ctx.resources["http_client"]
@@ -266,6 +265,11 @@ async def create_pgqueuer() -> PgQueuer:
 
     return pgq
 ```
+
+PGQueuer auto-detects the `Context` from the handler signature: a parameter
+annotated `Context` receives it, while `async def process_user(job: Job)` does
+not. Pass `accepts_context=True`/`False` to the decorator to override the
+detection.
 
 ## Web Framework Integration
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -59,7 +59,7 @@ The `@entrypoint()` decorator accepts several parameters that control how jobs a
 |-----------|------|---------|--------|
 | `name` | `str` | (required) | Entrypoint name -- must match what producers enqueue |
 | `concurrency_limit` | `int` | `0` (unlimited) | Max simultaneous jobs for this entrypoint (database-enforced globally). Use `1` for serialized processing |
-| `accepts_context` | `bool` | `False` | Pass a `Context` object as the second argument |
+| `accepts_context` | `bool \| None` | `None` (auto-detect) | Whether to pass a `Context` to the handler. When `None`, auto-detected from the signature (a parameter annotated `Context` receives it); set `True`/`False` to override |
 | `on_failure` | `"delete" \| "hold"` | `"delete"` | Hold failed jobs for manual re-queue instead of deleting |
 | `executor_factory` | callable | `None` | Custom executor class for retry logic, etc. |
 

--- a/docs/guides/job-cancellation.md
+++ b/docs/guides/job-cancellation.md
@@ -34,10 +34,14 @@ unaffected.
 
 Use the job's cancellation scope to stop processing when a cancel request arrives:
 
+Declare a `Context` parameter and PgQueuer injects the job's cancellation scope:
+
 ```python
+from pgqueuer.models import Context, Job
+
 @pgq.entrypoint("task_entrypoint")
-async def process_job(job: Job) -> None:
-    with pgq.qm.get_context(job.id).cancellation:
+async def process_job(job: Job, ctx: Context) -> None:
+    with ctx.cancellation:
         await perform_task(job.payload)
 ```
 

--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -96,14 +96,14 @@ seconds"; use `* * * * * */3` instead.
 
 ## Accessing Shared Resources
 
-Scheduled tasks can access shared resources (HTTP clients, database pools, etc.)
-by setting `accepts_context=True`. The handler then receives a second argument,
-`ScheduleContext`, whose `.resources` mapping mirrors the one passed to `PgQueuer`:
+Scheduled tasks can access shared resources (HTTP clients, database pools, etc.) by annotating a
+parameter as `ScheduleContext`. PgQueuer auto-detects it and injects the context, whose
+`.resources` mapping mirrors the one passed to `PgQueuer`:
 
 ```python
 from pgqueuer.models import Schedule, ScheduleContext
 
-@pgq.schedule("sync_data", "0 * * * *", accepts_context=True)
+@pgq.schedule("sync_data", "0 * * * *")
 async def sync_data(schedule: Schedule, ctx: ScheduleContext) -> None:
     db = ctx.resources["db_pool"]
     await db.execute("SELECT 1")

--- a/docs/guides/shared-resources.md
+++ b/docs/guides/shared-resources.md
@@ -21,7 +21,7 @@ import asyncpg
 from contextlib import asynccontextmanager
 from pgqueuer import PgQueuer
 from pgqueuer.db import AsyncpgDriver
-from pgqueuer.models import Job
+from pgqueuer.models import Context, Job
 
 @asynccontextmanager
 async def build_pgqueuer():
@@ -36,9 +36,9 @@ async def build_pgqueuer():
 
     pgq = PgQueuer(driver, resources=resources)
 
+    # Annotating a parameter as Context is enough — PgQueuer injects it.
     @pgq.entrypoint("process_user")
-    async def process_user(job: Job) -> None:
-        ctx = pgq.qm.get_context(job.id)
+    async def process_user(job: Job, ctx: Context) -> None:
         http = ctx.resources["http_client"]
         flags = ctx.resources["feature_flags"]
         # Use shared objects without recreating them
@@ -81,16 +81,19 @@ a custom registry class; the public contract is simply "object with mapping sema
 
 ## Enabling Context Injection
 
-Entry points only receive the runtime `Context` when registered with `accepts_context=True`.
+Context injection is **auto-detected from the handler signature**. Annotate a parameter as
+`Context` and PgQueuer passes the runtime `Context`:
 
 ```python
-@pgq.entrypoint("process_with_context", accepts_context=True)
+@pgq.entrypoint("process_with_context")
 async def process_with_context(job: Job, ctx: Context) -> None:
     logger = ctx.resources.get("logger")
     ...
 ```
 
-Entry points registered without the flag are invoked with the job only:
+Detection is annotation-driven, so a handler with an unrelated extra parameter
+(`async def f(job: Job, config: dict | None = None)`) is left untouched—no `Context` is injected
+into it. Entry points that declare only the job are invoked with the job alone:
 
 ```python
 @pgq.entrypoint("process_without_context")
@@ -98,21 +101,30 @@ async def process_without_context(job: Job) -> None:
     ...
 ```
 
+If you need to override the detection (for example, a wrapped callable whose signature does not
+reflect how it is invoked), pass `accepts_context=True` or `accepts_context=False` explicitly:
+
+```python
+@pgq.entrypoint("forced", accepts_context=True)
+async def forced(job: Job, ctx: Context) -> None:
+    ...
+```
+
 ## Scheduled Tasks
 
-Scheduled tasks can receive a `ScheduleContext` with shared resources by setting
-`accepts_context=True`:
+Scheduled tasks follow the same rule: annotate a parameter as `ScheduleContext` and it is
+injected automatically.
 
 ```python
 from pgqueuer.models import Schedule, ScheduleContext
 
-@pgq.schedule("refresh_cache", "*/5 * * * *", accepts_context=True)
+@pgq.schedule("refresh_cache", "*/5 * * * *")
 async def refresh_cache(schedule: Schedule, ctx: ScheduleContext) -> None:
     http = ctx.resources["http"]
     await http.get("https://api.example.com/ping")
 ```
 
-Tasks registered without `accepts_context` continue to work with just the schedule argument:
+Tasks that declare only the schedule argument continue to work unchanged:
 
 ```python
 @pgq.schedule("simple_task", "*/5 * * * *")
@@ -128,8 +140,8 @@ from pgqueuer.queries import Queries
 qm = QueueManager(Queries(driver), resources={"flag": "test"})
 
 @qm.entrypoint("demo")
-async def demo(job: Job) -> None:
-    assert qm.get_context(job.id).resources["flag"] == "test"
+async def demo(job: Job, ctx: Context) -> None:
+    assert ctx.resources["flag"] == "test"
 ```
 
 ## Summary
@@ -139,5 +151,6 @@ async def demo(job: Job) -> None:
 | Initialization | Passed at construction: `PgQueuer(..., resources=...)` |
 | Scope | Shared across all jobs in the same process |
 | Mutation | Visible to subsequent jobs |
-| Scheduled jobs | `accepts_context=True` for `ScheduleContext` |
+| Context injection | Auto-detected from a `Context`-annotated parameter; override with `accepts_context` |
+| Scheduled jobs | Annotate a `ScheduleContext` parameter to receive resources |
 | Custom executors | Receive via `context.resources` |

--- a/examples/consumer.py
+++ b/examples/consumer.py
@@ -9,7 +9,7 @@ import asyncpg
 from pgqueuer import PgQueuer
 from pgqueuer.core.logconfig import logger
 from pgqueuer.db import AsyncpgDriver
-from pgqueuer.models import Job, Schedule
+from pgqueuer.models import Context, Job, Schedule
 
 
 async def create_pgqueuer() -> PgQueuer:
@@ -25,11 +25,10 @@ async def create_pgqueuer() -> PgQueuer:
 
     pgq = PgQueuer(driver, resources=resources)
 
-    # Setup the 'fetch' entrypoint
+    # Setup the 'fetch' entrypoint. Declaring a Context parameter makes PgQueuer
+    # inject the job's Context (auto-detected from the signature).
     @pgq.entrypoint("fetch")
-    async def process_message(job: Job) -> None:
-        # Access the shared resources via the Context
-        ctx = pgq.qm.get_context(job.id)
+    async def process_message(job: Job, ctx: Context) -> None:
         processed = ctx.resources.setdefault("processed_jobs", 0) + 1
         ctx.resources["processed_jobs"] = processed
         print(

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -231,7 +231,7 @@ class PgQueuer:
         name: str,
         *,
         concurrency_limit: int = 0,
-        accepts_context: bool = False,
+        accepts_context: bool | None = None,
         on_failure: OnFailure = "delete",
         executor_factory: Callable[
             [EntrypointExecutorParameters],
@@ -257,7 +257,7 @@ class PgQueuer:
         ]
         | None = None,
         clean_old: bool = False,
-        accepts_context: bool = False,
+        accepts_context: bool | None = None,
     ) -> Callable[[ScheduleCrontab], ScheduleCrontab]:
         return self.sm.schedule(
             entrypoint=entrypoint,

--- a/pgqueuer/core/executors.py
+++ b/pgqueuer/core/executors.py
@@ -39,6 +39,26 @@ def is_async_callable(obj: Callable[..., object] | object) -> bool:
     )
 
 
+def wants_context(func: Callable[..., object], context_type: type) -> bool:
+    """Return True if func declares a positionally-bindable parameter annotated context_type."""
+    # eval_str resolves string/forward-ref annotations (PEP 563) to real types.
+    try:
+        signature = inspect.signature(func, eval_str=True)
+    except (TypeError, ValueError, NameError):
+        return False
+
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    for parameter in signature.parameters.values():
+        if parameter.kind not in positional_kinds:
+            continue
+        if parameter.annotation is context_type:
+            return True
+    return False
+
+
 @dataclasses.dataclass
 class EntrypointExecutorParameters:
     concurrency_limit: int

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -186,7 +186,7 @@ class QueueManager:
         name: str,
         *,
         concurrency_limit: int = 0,
-        accepts_context: bool = False,
+        accepts_context: bool | None = None,
         on_failure: types.OnFailure = "delete",
         executor_factory: Callable[
             [executors.EntrypointExecutorParameters],
@@ -204,7 +204,10 @@ class QueueManager:
             concurrency_limit (int): Max number of concurrent jobs allowed for this
                 entrypoint across all workers. Enforced at the database level.
                 0 means unlimited. Use 1 for serialized (one-at-a-time) dispatch.
-            accepts_context (bool): When True, invoke the entrypoint with both job and context.
+            accepts_context (bool | None): Whether to invoke the entrypoint with both job and
+                context. When None (default), it is auto-detected from the signature: a handler
+                that annotates a parameter as ``Context`` (``async def f(job, ctx: Context)``)
+                receives it. Pass True/False to override the detection.
             on_failure (OnFailure): What to do when a job fails terminally. ``"delete"``
                 removes the job (default); ``"hold"`` parks it with status ``'failed'``
                 so it can be inspected and manually re-queued.
@@ -226,8 +229,8 @@ class QueueManager:
         if concurrency_limit < 0:
             raise ValueError("Concurrency limit must be greater or eq. to zero.")
 
-        if not isinstance(accepts_context, bool):
-            raise ValueError("accepts_context must be boolean")
+        if accepts_context is not None and not isinstance(accepts_context, bool):
+            raise ValueError("accepts_context must be boolean or None")
 
         if on_failure not in get_args(types.OnFailure):
             raise ValueError(f"on_failure must be one of {get_args(types.OnFailure)}.")
@@ -235,13 +238,18 @@ class QueueManager:
         executor_factory = executor_factory or executors.EntrypointExecutor
 
         def register(func: executors.EntrypointTypeVar) -> executors.EntrypointTypeVar:
+            resolved_context = (
+                executors.wants_context(func, models.Context)
+                if accepts_context is None
+                else accepts_context
+            )
             self.register_executor(
                 name,
                 executor_factory(
                     executors.EntrypointExecutorParameters(
                         func=func,
                         concurrency_limit=concurrency_limit,
-                        accepts_context=accepts_context,
+                        accepts_context=resolved_context,
                         on_failure=on_failure,
                     )
                 ),

--- a/pgqueuer/core/sm.py
+++ b/pgqueuer/core/sm.py
@@ -55,7 +55,7 @@ class SchedulerManager:
         ]
         | None = None,
         clean_old: bool = False,
-        accepts_context: bool = False,
+        accepts_context: bool | None = None,
     ) -> Callable[[executors.ScheduleCrontab], executors.ScheduleCrontab]:
         """
         Register a new job with a cron schedule.
@@ -94,13 +94,18 @@ class SchedulerManager:
         executor_factory = executor_factory or executors.ScheduleExecutor
 
         def register(func: executors.ScheduleCrontab) -> executors.ScheduleCrontab:
+            resolved_context = (
+                executors.wants_context(func, models.ScheduleContext)
+                if accepts_context is None
+                else accepts_context
+            )
             self.registry[key] = executor_factory(
                 executors.ScheduleExecutorFactoryParameters(
                     entrypoint=entrypoint,
                     expression=expression,
                     func=func,
                     clean_old=clean_old,
-                    accepts_context=accepts_context,
+                    accepts_context=resolved_context,
                 )
             )
             return func

--- a/pgqueuer/executors.py
+++ b/pgqueuer/executors.py
@@ -16,6 +16,7 @@ from pgqueuer.core.executors import (
     ScheduleExecutor,
     ScheduleExecutorFactoryParameters,
     is_async_callable,
+    wants_context,
 )
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "ScheduleExecutor",
     "ScheduleExecutorFactoryParameters",
     "is_async_callable",
+    "wants_context",
 ]

--- a/test/test_executors.py
+++ b/test/test_executors.py
@@ -3,7 +3,8 @@ import functools
 import inspect
 from datetime import timedelta
 from multiprocessing import Process, Queue as MPQueue
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, cast
+from unittest.mock import Mock
 
 import anyio
 import pytest
@@ -14,8 +15,9 @@ from pgqueuer.executors import (
     EntrypointExecutor,
     EntrypointExecutorParameters,
     is_async_callable,
+    wants_context,
 )
-from pgqueuer.models import Context, Job
+from pgqueuer.models import Context, Job, ScheduleContext
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
 from test.helpers import mocked_job
@@ -141,6 +143,109 @@ async def test_entrypoint_executor_without_context_detection(apgdriver: Driver) 
 
     await executor.execute(job, job_context)
     assert calls == [(job, None)]
+
+
+async def handler_no_context(job: Job) -> None: ...
+async def handler_positional_context(job: Job, ctx: Context) -> None: ...
+async def handler_positional_only_context(job: Job, ctx: Context, /) -> None: ...
+async def handler_string_context(job: Job, ctx: "Context") -> None: ...
+async def handler_context_first(ctx: Context) -> None: ...
+async def handler_unannotated_second(job: Job, ctx) -> None: ...  # type: ignore[no-untyped-def]
+async def handler_unrelated_second(job: Job, config: dict | None = None) -> None: ...
+async def handler_keyword_only_context(job: Job, *, ctx: Context) -> None: ...
+async def handler_var_positional(job: Job, *args: object) -> None: ...
+async def handler_var_keyword(job: Job, **kwargs: object) -> None: ...
+async def handler_no_params() -> None: ...
+async def handler_schedule_context(job: Job, ctx: ScheduleContext) -> None: ...
+
+
+@pytest.mark.parametrize(
+    ("func", "context_type", "expected"),
+    [
+        pytest.param(handler_no_context, Context, False, id="no-second-param"),
+        pytest.param(handler_positional_context, Context, True, id="positional-or-keyword"),
+        pytest.param(handler_positional_only_context, Context, True, id="positional-only"),
+        pytest.param(handler_string_context, Context, True, id="string-forward-ref"),
+        pytest.param(handler_context_first, Context, True, id="context-in-first-slot"),
+        pytest.param(handler_unannotated_second, Context, False, id="unannotated-second"),
+        pytest.param(handler_unrelated_second, Context, False, id="unrelated-second"),
+        pytest.param(handler_keyword_only_context, Context, False, id="keyword-only-excluded"),
+        pytest.param(handler_var_positional, Context, False, id="var-positional-excluded"),
+        pytest.param(handler_var_keyword, Context, False, id="var-keyword-excluded"),
+        pytest.param(handler_no_params, Context, False, id="no-params"),
+        pytest.param(handler_schedule_context, ScheduleContext, True, id="schedulecontext-match"),
+        pytest.param(handler_schedule_context, Context, False, id="schedulecontext-not-context"),
+        pytest.param(handler_positional_context, ScheduleContext, False, id="context-not-schedule"),
+    ],
+)
+def test_wants_context_matrix(
+    func: Callable[..., Awaitable[None]],
+    context_type: type,
+    expected: bool,
+) -> None:
+    assert wants_context(func, context_type) is expected
+
+
+def test_wants_context_unwraps_partial() -> None:
+    async def handler(prefix: str, job: Job, ctx: Context) -> None: ...
+
+    # functools.partial drops the bound leading argument; ctx stays positional.
+    assert wants_context(functools.partial(handler, "prefix"), Context)
+
+
+def test_wants_context_partial_keyword_binding_excludes_context() -> None:
+    async def handler(job: Job, ctx: Context) -> None: ...
+
+    # Binding ctx by keyword turns it keyword-only, so it is no longer positionally bindable.
+    # The bound value is never used — wants_context only inspects the signature.
+    bound = functools.partial(handler, ctx=cast(Context, object()))
+    assert not wants_context(bound, Context)
+
+
+def test_wants_context_detects_callable_object() -> None:
+    class Handler:
+        async def __call__(self, job: Job, ctx: Context) -> None: ...
+
+    assert wants_context(Handler(), Context)
+
+
+def test_wants_context_false_when_annotations_unresolvable() -> None:
+    async def handler(job: Job, ctx: Context, extra: object) -> None: ...
+
+    # eval_str fails on the unresolvable ref, so detection degrades to False even though a
+    # Context parameter is present (documents the all-or-nothing fallback in the except branch).
+    handler.__annotations__["extra"] = "Undefined_Name_For_Test"
+    assert not wants_context(handler, Context)
+
+
+def test_entrypoint_auto_detects_context() -> None:
+    qm = QueueManager(Mock())
+
+    @qm.entrypoint("with_context")
+    async def with_context(job: Job, ctx: Context) -> None: ...
+
+    @qm.entrypoint("without_context")
+    async def without_context(job: Job) -> None: ...
+
+    @qm.entrypoint("unrelated_second")
+    async def unrelated_second(job: Job, config: dict | None = None) -> None: ...
+
+    assert qm.entrypoint_registry["with_context"].parameters.accepts_context
+    assert not qm.entrypoint_registry["without_context"].parameters.accepts_context
+    assert not qm.entrypoint_registry["unrelated_second"].parameters.accepts_context
+
+
+def test_entrypoint_explicit_flag_overrides_detection() -> None:
+    qm = QueueManager(Mock())
+
+    @qm.entrypoint("forced_off", accepts_context=False)
+    async def forced_off(job: Job, ctx: Context) -> None: ...
+
+    @qm.entrypoint("forced_on", accepts_context=True)
+    async def forced_on(job: Job) -> None: ...
+
+    assert not qm.entrypoint_registry["forced_off"].parameters.accepts_context
+    assert qm.entrypoint_registry["forced_on"].parameters.accepts_context
 
 
 async def test_custom_threading_executor() -> None:

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -59,6 +59,35 @@ async def test_scheduler_register(scheduler: SchedulerManager) -> None:
     assert scheduler.registry[key].parameters.expression == "2 * * * *"
 
 
+def test_scheduler_auto_detects_context() -> None:
+    scheduler = SchedulerManager(Mock())
+
+    async def with_context(schedule: Schedule, ctx: ScheduleContext) -> None:
+        pass
+
+    async def without_context(schedule: Schedule) -> None:
+        pass
+
+    scheduler.schedule("with_context", "1 * * * *")(with_context)
+    scheduler.schedule("without_context", "2 * * * *")(without_context)
+
+    by_entrypoint = {str(key.entrypoint): ex for key, ex in scheduler.registry.items()}
+    assert by_entrypoint["with_context"].parameters.accepts_context
+    assert not by_entrypoint["without_context"].parameters.accepts_context
+
+
+def test_scheduler_explicit_flag_overrides_detection() -> None:
+    scheduler = SchedulerManager(Mock())
+
+    async def with_context(schedule: Schedule, ctx: ScheduleContext) -> None:
+        pass
+
+    scheduler.schedule("forced_off", "1 * * * *", accepts_context=False)(with_context)
+
+    key = next(iter(scheduler.registry.keys()))
+    assert not scheduler.registry[key].parameters.accepts_context
+
+
 async def test_scheduler_register_raises_invalid_expression(scheduler: SchedulerManager) -> None:
     async def sample_task(schedule: Schedule) -> None:
         pass


### PR DESCRIPTION
Entrypoints and scheduled tasks previously required accepts_context=True
to receive the runtime Context, and the docs steered users toward
pgq.qm.get_context(job.id) — a reach-through into QueueManager internals
that round-trips the job's own id through a per-job dict and breaks
outside the in-flight window.

Auto-detect it from the signature instead: a handler that annotates a
parameter as Context / ScheduleContext now receives it. accepts_context
becomes bool | None; None auto-detects while an explicit True/False
still overrides. Detection is annotation-driven (not arity-based) so an
unrelated second parameter such as (job, config=None) is left untouched.

Backward compatible: handlers keep their existing behavior unless they
opt in via the Context annotation or the explicit flag. Docs and
examples drop get_context in favor of the injected parameter.