### PR TITLE
docs: rename rate-limiting guide to concurrency-control

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -1,7 +1,6 @@
 # Core Concepts
 
-This page explains the key abstractions in PgQueuer. Understanding these will help you
-make the most of every feature.
+This page explains the key abstractions in PgQueuer.
 
 ---
 
@@ -206,6 +205,6 @@ See [Database Setup](../reference/database-setup.md) for full schema details and
 Now that you understand the building blocks:
 
 - **[Scheduling](../guides/scheduling.md)** -- set up cron-style recurring tasks
-- **[Concurrency Control](../guides/rate-limiting.md)** -- limit parallel job execution
+- **[Concurrency Control](../guides/concurrency-control.md)** -- limit parallel job execution
 - **[Reliability](../guides/reliability.md)** -- retries, idempotency, and audit trails
 - **[Deployment](../guides/deployment.md)** -- run workers in production

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -202,7 +202,7 @@ You now have a working PgQueuer setup. Here's where to go from here:
 | Goal | Page |
 |------|------|
 | Understand the mental model | [Core Concepts](core-concepts.md) |
-| Add concurrency caps | [Concurrency Control](../guides/rate-limiting.md) |
+| Add concurrency caps | [Concurrency Control](../guides/concurrency-control.md) |
 | Set up cron-style recurring tasks | [Scheduling](../guides/scheduling.md) |
 | Handle transient failures with retries | [Database-Level Retry](../guides/retry.md) |
 | Park failed jobs for human review | [Holding Failed Jobs](../guides/hold-failed-jobs.md) |

--- a/docs/guides/concurrency-control.md
+++ b/docs/guides/concurrency-control.md
@@ -1,7 +1,7 @@
 # Concurrency Control
 
-PgQueuer provides fine-grained control over job execution concurrency at the
-entrypoint level. Concurrency limits are enforced **globally** at the database
+PgQueuer controls job execution concurrency at the entrypoint level.
+Concurrency limits are enforced **globally** at the database
 level via the dequeue SQL query, not per-worker. If you set `concurrency_limit=5`,
 at most 5 jobs run across your entire fleet.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ nav:
       - Upgrading from 0.x: getting-started/upgrading.md
   - Guides:
       - Job Processing:
-          - Concurrency Control: guides/rate-limiting.md
+          - Concurrency Control: guides/concurrency-control.md
           - Custom Executors: guides/custom-executors.md
           - Job Cancellation: guides/job-cancellation.md
           - Completion Tracking: guides/completion-tracking.md


### PR DESCRIPTION
The page is titled "Concurrency Control" in the nav, body, and every cross-reference, and there is no rate-limiting API — the `rate-limiting.md` filename was misleading.

- Rename `docs/guides/rate-limiting.md` -> `docs/guides/concurrency-control.md`.
- Update inbound links: `mkdocs.yml` nav, `quickstart.md`, `core-concepts.md`.