### PR TITLE
docs: correct setup, integration, and dev details

### DIFF
--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -1,6 +1,6 @@
 # Contributing
 
-PGQueuer's integration tests use [Testcontainers](https://testcontainers.com/) to launch
+PgQueuer's integration tests use [Testcontainers](https://testcontainers.com/) to launch
 an ephemeral PostgreSQL instance automatically. You no longer need to run or manage a local
 database manually — just have a container runtime available (Docker Desktop, Colima,
 Rancher Desktop, etc.).
@@ -36,7 +36,7 @@ during test setup.
 make check
 ```
 
-Runs lint, type, dependency, and test steps in sequence.
+Runs `sync`, `lint`, `import-lint`, `typecheck`, and `pytest` in sequence.
 
 ## Test Structure & Tips
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,8 +10,8 @@ PgQueuer supports two PostgreSQL drivers. Choose the one that fits your stack:
     pip install pgqueuer[asyncpg]
     ```
 
-    [asyncpg](https://github.com/MagicStack/asyncpg) is a high-performance async driver
-    written in Cython. It provides the best throughput for PgQueuer workloads.
+    [asyncpg](https://github.com/MagicStack/asyncpg) is an async PostgreSQL driver
+    written in Cython.
 
 === "psycopg"
 
@@ -39,6 +39,7 @@ PgQueuer supports two PostgreSQL drivers. Choose the one that fits your stack:
     | `psycopg` | psycopg async + sync driver |
     | `logfire` | [Logfire](https://logfire.pydantic.dev/) distributed tracing |
     | `sentry` | [Sentry](https://sentry.io/) distributed tracing |
+    | `opentelemetry` | [OpenTelemetry](../integrations/tracing.md) distributed tracing |
     | `mcp` | [MCP server](../integrations/mcp-server.md) for AI agent access |
     | `fastapi` | FastAPI Prometheus metrics router |
 
@@ -65,7 +66,7 @@ This creates the following objects in your database:
 | `pgqueuer_statistics` | Table | Job processing statistics |
 | `pgqueuer_schedules` | Table | Cron schedule definitions |
 | `pgqueuer_status` | Enum | Job status values (`queued`, `picked`, `successful`, `exception`, `canceled`, `deleted`, `failed`) |
-| `pgqueuer_changed` | Function | PL/pgSQL function that sends `pg_notify()` on queue changes |
+| `fn_pgqueuer_changed` | Function | PL/pgSQL function that sends `pg_notify()` on queue changes |
 | `tg_pgqueuer_changed` | Trigger | Fires the notify function on INSERT/UPDATE/DELETE/TRUNCATE |
 
 !!! note "Preview before applying"

--- a/docs/integrations/tracing.md
+++ b/docs/integrations/tracing.md
@@ -21,7 +21,7 @@ You can install multiple extras simultaneously if you need to switch between the
 ## Using Logfire
 
 Configure Logfire before running your producers and consumers, then register the tracer
-with PGQueuer:
+with PgQueuer:
 
 ```python
 import logfire
@@ -63,7 +63,7 @@ for advanced configuration options.
 
 ## Using OpenTelemetry
 
-Configure your `TracerProvider`, then register the tracer with PGQueuer:
+Configure your `TracerProvider`, then register the tracer with PgQueuer:
 
 ```python
 from opentelemetry import trace

--- a/docs/integrations/tracing.md
+++ b/docs/integrations/tracing.md
@@ -1,6 +1,6 @@
 # Distributed Tracing
 
-PGQueuer supports distributed tracing through optional integrations with
+PgQueuer supports distributed tracing through optional integrations with
 [Logfire](https://logfire.pydantic.dev/), [Sentry](https://docs.sentry.io/),
 and [OpenTelemetry](https://opentelemetry.io/).
 These tools allow you to visualize job execution and measure performance across
@@ -84,5 +84,5 @@ Jaeger, Datadog, and any OTel-compatible backend.
 ## Switching Tracers
 
 Only one tracer can be active at a time. Call `set_tracing_class()` from
-`pgqueuer.adapters.tracing` with the desired tracer implementation before starting
+`pgqueuer.ports.tracing` with the desired tracer implementation before starting
 producers or consumers.


### PR DESCRIPTION
- `installation.md`: notify function is `fn_pgqueuer_changed` (not `pgqueuer_changed`); add the `opentelemetry` extra to the table.
- `tracing.md`: `set_tracing_class` is imported from `pgqueuer.ports.tracing` (the body contradicted its own code samples).
- `development.md`: `make check` runs `sync`, `lint`, `import-lint`, `typecheck`, `pytest`.
- Fix `PGQueuer` -> `PgQueuer` capitalization in `tracing.md` and `development.md`.