### PR TITLE
docs: fix performance, deployment, and comparison accuracy

### DIFF
--- a/docs/comparisons/benchmarks.md
+++ b/docs/comparisons/benchmarks.md
@@ -23,20 +23,23 @@ Continuously enqueues and dequeues jobs for a fixed duration:
 python3 tools/benchmark.py --dequeue 5 --dequeue-batch-size 10
 ```
 
-Example output:
+Example output — the tool prints a settings table, a live `tqdm` progress bar, then a
+results table (exact numbers depend on your environment):
 
 ```
-Settings:
-Timer:                  15.0 seconds
-Dequeue:                5
-Dequeue Batch Size:     10
-Enqueue:                1
-Enqueue Batch Size:     10
-
-Queue size: 0
-Queue size: 114
-...
-Jobs per Second: 18.35k
++--------------------+------------+
+| Field              | Value      |
++--------------------+------------+
+| Driver             | apg        |
+| Strategy           | throughput |
+| Timer (s)          | 30.0       |
+| Dequeue Tasks      | 5          |
+| Dequeue Batch Size | 10         |
+| Enqueue Tasks      | 1          |
+| Enqueue Batch Size | 10         |
+| Output JSON        | None       |
++--------------------+------------+
+550k job [00:30, 18.3k job/s]
 ```
 
 ### Drain Strategy
@@ -51,8 +54,10 @@ Use this when evaluating batch processing performance rather than sustained thro
 
 ## asyncpg vs psycopg
 
-Both tests use identical settings: 10-second timer, 5 dequeue workers (batch size 10),
-1 enqueue worker (batch size 10).
+The figures below come from a single reference run on one machine and are illustrative
+only — run the tool in your own environment for numbers that mean anything. Both tests use
+identical settings: 10-second timer, 5 dequeue workers (batch size 10), 1 enqueue worker
+(batch size 10).
 
 ### asyncpg
 

--- a/docs/comparisons/celery-comparison.md
+++ b/docs/comparisons/celery-comparison.md
@@ -9,7 +9,7 @@ right tool for your situation.
 | Feature | Celery | PgQueuer |
 |---------|--------|---------|
 | Message broker | Redis, RabbitMQ, SQS, etc. | PostgreSQL |
-| Recurring tasks | Separate `celery-beat` process | Built-in `@schedule` decorator |
+| Recurring tasks | Separate `celery-beat` process | Built-in `@pgq.schedule` decorator |
 | Architecture | App + broker + optional beat | App + PostgreSQL |
 | Job delivery | Broker-dependent | Real-time via `LISTEN/NOTIFY` |
 | Transactional enqueue | Separate from app data | Same PostgreSQL transaction |
@@ -39,6 +39,7 @@ celery -A celery_app worker -l info
 
 ```python
 # pgqueuer_app.py
+import json
 import asyncpg
 from contextlib import asynccontextmanager
 from pgqueuer import PgQueuer
@@ -53,8 +54,8 @@ async def create_pgq():
 
     @pgq.entrypoint("add")
     async def add(job: Job):
-        x, y = job.payload
-        return x + y
+        data = json.loads(job.payload)
+        return data["x"] + data["y"]
 
     yield pgq
 ```

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -151,7 +151,8 @@ LISTEN connection causes a clean restart rather than silent degradation:
 `pgq run` handles `SIGTERM` and `SIGINT`. On receiving a signal:
 
 1. Stop accepting new jobs from the queue.
-2. Wait for in-flight jobs to complete (up to a configurable drain period).
+2. Wait for in-flight jobs to finish. PgQueuer has no built-in drain timeout — it awaits
+   running jobs to completion, so bound the wait via your orchestrator (see below).
 3. Exit cleanly.
 
 Container orchestrators (Kubernetes, Fly.io, ECS) send `SIGTERM` before `SIGKILL`, so
@@ -185,7 +186,7 @@ PgQueuer reads standard PostgreSQL environment variables:
 | `PGUSER` | Database user |
 | `PGPASSWORD` | Database password |
 | `PGDATABASE` | Database name |
-| `PGQUEUER_PREFIX` | Prefix for table/channel names (default `pgqueuer`) |
+| `PGQUEUER_PREFIX` | Prefix prepended to table/channel names (default: empty — names default to `pgqueuer`, `ch_pgqueuer`, etc.) |
 
 Use `PGQUEUER_PREFIX` to run multiple isolated PgQueuer instances in the same database:
 

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -35,8 +35,10 @@ async def resize_image(job: Job) -> None:
     ...
 ```
 
-Use per-entrypoint limits when specific tasks share a scarce external resource (e.g., an API
-with rate limits). Use `max_concurrent_tasks` as a safety ceiling on total asyncio tasks.
+`concurrency_limit` is enforced **globally at the database level** across every worker — set
+`concurrency_limit=4` and at most 4 such jobs run across your entire fleet. Use it when tasks
+share a scarce external resource (e.g., an API with rate limits). `max_concurrent_tasks`, by
+contrast, is a per-process safety ceiling on total asyncio tasks.
 
 ## Connection Pooling
 
@@ -98,8 +100,8 @@ What this sets on `pgqueuer` and `pgqueuer_schedules` (high-churn tables):
 | `autovacuum_vacuum_cost_delay` | `0` | No throttling |
 | `fillfactor` | `70` | Leave 30% free for HOT updates |
 
-`pgqueuer_log` uses conservative settings (vacuum at 95% dead-tuple ratio) since it is
-append-only.
+`pgqueuer_log` and `pgqueuer_statistics` use conservative settings (vacuum at 95% dead-tuple
+ratio) since they are append-only.
 
 Revert to system defaults:
 
@@ -109,7 +111,7 @@ pgq autovac --rollback
 
 ## NOTIFY Channel and Polling Fallback
 
-PgQueuer uses `LISTEN/NOTIFY` for near-instant job pickup. A trigger fires on every insert
+PgQueuer uses `LISTEN/NOTIFY` for low-latency job pickup. A trigger fires on every insert
 into `pgqueuer` and sends a notification on the `ch_pgqueuer` channel.
 
 **What can go wrong:** pgBouncer in transaction-pooling mode drops `LISTEN` subscriptions
@@ -137,12 +139,14 @@ PgQueuer installs all required indexes automatically. The most important for thr
 CREATE INDEX ON pgqueuer (priority ASC, id DESC)
 INCLUDE (id) WHERE status = 'queued';
 
--- Used for heartbeat-based retry detection
-CREATE INDEX ON pgqueuer (heartbeat ASC, id DESC)
+-- Used to find stale 'picked' jobs for crash/retry recovery
+CREATE INDEX ON pgqueuer (updated ASC, id DESC)
 INCLUDE (id) WHERE status = 'picked';
 ```
 
 These partial indexes are maintained by `pgq install` and `pgq upgrade`. Do not drop them.
+(`pgq upgrade` additionally adds a `heartbeat`-based picked index on databases created by
+older versions.)
 
 ## Quick-Reference Checklist
 


### PR DESCRIPTION
- `performance-tuning.md`: `pgq install` creates the `(updated, id)` picked index, not a `heartbeat` one (the heartbeat index is upgrade-only); `pgqueuer_statistics` also receives the conservative autovacuum settings; `concurrency_limit` is a global DB-level cap across workers.
- `deployment.md`: there is no built-in drain timeout — in-flight jobs are awaited to completion; `PGQUEUER_PREFIX` defaults to empty, not `pgqueuer`.
- `benchmarks.md`: replace the fabricated output block with the real `tabulate`/`tqdm` output; mark the throughput figures as illustrative.
- `celery-comparison.md`: use `@pgq.schedule`; parse the JSON payload in the `add()` example so it runs.