### PR TITLE
test(tracing): cover sentry and logfire adapter behaviour

### DIFF
--- a/test/test_tracing_logfire.py
+++ b/test/test_tracing_logfire.py
@@ -1,0 +1,105 @@
+"""Behavioral coverage for the Logfire tracing adapter."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Iterator
+
+import logfire
+import pytest
+from logfire.testing import TestExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from pydantic_core import to_json
+
+from pgqueuer.adapters.tracing.logfire import LogfireTracing
+from pgqueuer.domain.models import Job
+from pgqueuer.domain.types import JobId
+
+
+def _make_job(headers: dict | None, *, entrypoint: str = "say_hello") -> Job:
+    now = datetime.now(timezone.utc)
+    return Job(
+        id=JobId(7),
+        priority=0,
+        created=now,
+        updated=now,
+        heartbeat=now,
+        execute_after=now,
+        status="queued",
+        entrypoint=entrypoint,
+        payload=b"hello",
+        queue_manager_id=uuid.uuid4(),
+        headers=to_json(headers) if headers is not None else None,
+    )
+
+
+@pytest.fixture()
+def exporter() -> Iterator[TestExporter]:
+    exp = TestExporter()
+    logfire.configure(
+        send_to_logfire=False,
+        additional_span_processors=[SimpleSpanProcessor(exp)],
+    )
+    yield exp
+
+
+def _spans(exporter: TestExporter) -> list[dict[str, Any]]:
+    return exporter.exported_spans_as_dict()
+
+
+def _by_name(exporter: TestExporter, needle: str) -> dict[str, Any]:
+    matches = [s for s in _spans(exporter) if needle in s["name"]]
+    assert len(matches) == 1, [s["name"] for s in _spans(exporter)]
+    return matches[0]
+
+
+def test_publish_injects_traceparent(exporter: TestExporter) -> None:
+    (headers,) = list(LogfireTracing().trace_publish(["say_hello"]))
+    assert "traceparent" in headers["logfire"]
+
+
+def test_publish_emits_span_per_entrypoint(exporter: TestExporter) -> None:
+    headers = list(LogfireTracing().trace_publish(["a", "b"]))
+    assert len(headers) == 2
+    enqueued = [s for s in _spans(exporter) if "Enqueued" in s["name"]]
+    assert len(enqueued) == 2
+
+
+async def test_consumer_continues_producer_trace(exporter: TestExporter) -> None:
+    tracing = LogfireTracing()
+    (headers,) = list(tracing.trace_publish(["say_hello"]))
+    publish_trace_ids = {s["context"]["trace_id"] for s in _spans(exporter)}
+    assert len(publish_trace_ids) == 1
+
+    async with tracing.trace_process(_make_job(headers)):
+        pass
+
+    processing = _by_name(exporter, "Processing job")
+    assert processing["context"]["trace_id"] in publish_trace_ids
+
+
+async def test_consumer_records_job_metadata(exporter: TestExporter) -> None:
+    tracing = LogfireTracing()
+    (headers,) = list(tracing.trace_publish(["say_hello"]))
+    job = _make_job(headers)
+
+    async with tracing.trace_process(job):
+        pass
+
+    attrs = _by_name(exporter, "Processing job")["attributes"]
+    assert attrs["job_id"] == job.id
+    assert attrs["entrypoint"] == job.entrypoint
+    assert attrs["payload_size"] == len(job.payload or b"")
+
+
+async def test_process_is_noop_without_headers(exporter: TestExporter) -> None:
+    async with LogfireTracing().trace_process(_make_job(None)):
+        pass
+    assert not [s for s in _spans(exporter) if "Processing job" in s["name"]]
+
+
+async def test_process_is_noop_without_logfire_key(exporter: TestExporter) -> None:
+    async with LogfireTracing().trace_process(_make_job({"otel": {"traceparent": "x"}})):
+        pass
+    assert not [s for s in _spans(exporter) if "Processing job" in s["name"]]

--- a/test/test_tracing_sentry.py
+++ b/test/test_tracing_sentry.py
@@ -1,0 +1,116 @@
+"""Behavioral coverage for the Sentry tracing adapter."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Iterator
+
+import pytest
+import sentry_sdk
+from pydantic_core import to_json
+from sentry_sdk.transport import Transport
+
+from pgqueuer.adapters.tracing.sentry import SentryTracing
+from pgqueuer.domain.models import Job
+from pgqueuer.domain.types import JobId
+
+
+def _make_job(headers: dict | None, *, entrypoint: str = "say_hello") -> Job:
+    now = datetime.now(timezone.utc)
+    return Job(
+        id=JobId(1),
+        priority=0,
+        created=now,
+        updated=now,
+        heartbeat=now,
+        execute_after=now,
+        status="queued",
+        entrypoint=entrypoint,
+        payload=b"hello",
+        queue_manager_id=uuid.uuid4(),
+        headers=to_json(headers) if headers is not None else None,
+    )
+
+
+class _RecordingTransport(Transport):
+    def __init__(self) -> None:
+        self.transactions: list[dict[str, Any]] = []
+
+    def capture_envelope(self, envelope: Any) -> None:
+        for item in envelope.items:
+            if item.type == "transaction":
+                self.transactions.append(item.payload.json)
+
+
+@pytest.fixture()
+def transactions() -> Iterator[list[dict[str, Any]]]:
+    transport = _RecordingTransport()
+    previous = sentry_sdk.get_global_scope().client
+    sentry_sdk.init(
+        dsn="https://public@example.com/1",
+        traces_sample_rate=1.0,
+        transport=transport,
+    )
+    try:
+        yield transport.transactions
+    finally:
+        sentry_sdk.get_global_scope().set_client(previous)
+
+
+def _consumer(transactions: list[dict[str, Any]]) -> dict[str, Any]:
+    matches = [t for t in transactions if t.get("transaction") == "queue_consumer_transaction"]
+    assert len(matches) == 1, [t.get("transaction") for t in transactions]
+    return matches[0]
+
+
+def test_publish_injects_sentry_headers(transactions: list[dict[str, Any]]) -> None:
+    (headers,) = list(SentryTracing().trace_publish(["say_hello"]))
+    assert set(headers["sentry"]) == {"sentry-trace", "baggage"}
+    # sentry-trace = "{trace_id}-{span_id}-{sampled}"; trace_id is 16 bytes hex.
+    assert len(headers["sentry"]["sentry-trace"].split("-")[0]) == 32
+
+
+def test_publish_emits_one_span_per_entrypoint(transactions: list[dict[str, Any]]) -> None:
+    headers = list(SentryTracing().trace_publish(["a", "b", "c"]))
+    assert len(headers) == 3
+    producer = next(t for t in transactions if t.get("transaction") == "queue_producer_transaction")
+    span_destinations = [s["data"]["messaging.destination.name"] for s in producer.get("spans", [])]
+    assert span_destinations == ["a", "b", "c"]
+
+
+async def test_consumer_continues_producer_trace(transactions: list[dict[str, Any]]) -> None:
+    tracing = SentryTracing()
+    (headers,) = list(tracing.trace_publish(["say_hello"]))
+    publish_trace_id = headers["sentry"]["sentry-trace"].split("-")[0]
+
+    async with tracing.trace_process(_make_job(headers)):
+        pass
+
+    assert _consumer(transactions)["contexts"]["trace"]["trace_id"] == publish_trace_id
+
+
+async def test_consumer_records_job_metadata(transactions: list[dict[str, Any]]) -> None:
+    tracing = SentryTracing()
+    (headers,) = list(tracing.trace_publish(["say_hello"]))
+    job = _make_job(headers)
+
+    async with tracing.trace_process(job):
+        pass
+
+    (span,) = [s for s in _consumer(transactions)["spans"] if s["op"] == "queue.process"]
+    assert span["data"]["messaging.message.id"] == job.id
+    assert span["data"]["messaging.destination.name"] == job.entrypoint
+    assert span["data"]["messaging.message.body.size"] == len(job.payload or b"")
+
+
+async def test_process_is_noop_without_headers(transactions: list[dict[str, Any]]) -> None:
+    async with SentryTracing().trace_process(_make_job(None)):
+        pass
+    assert not [t for t in transactions if t.get("transaction") == "queue_consumer_transaction"]
+
+
+async def test_process_is_noop_without_sentry_key(transactions: list[dict[str, Any]]) -> None:
+    async with SentryTracing().trace_process(_make_job({"otel": {"traceparent": "x"}})):
+        pass
+    assert not [t for t in transactions if t.get("transaction") == "queue_consumer_transaction"]


### PR DESCRIPTION
Adds behavioral coverage for the Sentry and Logfire tracing adapters, capturing spans/transactions with a recording transport and the OTel `TestExporter` (no network):

- `trace_publish` injects propagation headers (`sentry-trace`/`baggage`, `traceparent`) and emits one span per entrypoint
- the consumer transaction/span shares the producer's trace id (propagation works end to end)
- the consumer records job id, entrypoint, and payload size
- `trace_process` is a no-op when the job carries no headers for that adapter

Test-only; no database required. Complements the OpenTelemetry adapter's existing suite.