### PR TITLE
docs(agents): exempt MCP tool/prompt docstrings from verbosity rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ Follow [PEP 257](https://peps.python.org/pep-0257/) for format. Keep them tight.
 - **Skip docstrings on trivial or private helpers.** A descriptive name beats a docstring that repeats it.
 - **Test docstrings**: one line describing the behavior under test. Skip when the test name is self-evident.
 - **Module docstrings**: optional. When present, one sentence. No "This module defines..." preambles.
+- **External-schema docstrings exempt.** Where a docstring is the canonical, externally-published description of a function -- specifically `@mcp.tool()` and `@mcp.prompt()` handlers in `pgqueuer/adapters/mcp/`, whose docstrings are surfaced verbatim to MCP clients as the tool's schema -- the verbosity rules above do not apply. Document return columns, parameter semantics, and usage patterns at whatever length the consumer needs.
 
 ### Comments
 


### PR DESCRIPTION
The @mcp.tool() and @mcp.prompt() handlers in pgqueuer/adapters/mcp/ surface their docstrings verbatim to MCP clients as the tool's schema. Trimming them to a one-liner would degrade the agent-facing API.

Carve out an explicit exemption under §Docstrings so the existing verbose docstrings stop reading as violations of AGENTS.md.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
