### PR TITLE
fix: correct stale docstrings

### DIFF
--- a/pgqueuer/adapters/cli/supervisor.py
+++ b/pgqueuer/adapters/cli/supervisor.py
@@ -24,10 +24,10 @@ ManagerFactory: TypeAlias = Callable[[], AbstractAsyncContextManager[Manager]]
 
 def setup_shutdown_handlers(manager: Manager, shutdown: asyncio.Event) -> Manager:
     """
-    Create and configure a queue management instance.
+    Wire shutdown into the manager instance.
 
     Args:
-        factory_fn (FactoryType): The factory function to create the instance.
+        manager (Manager): The instance to configure.
         shutdown (asyncio.Event): The event used to signal shutdown.
 
     Returns:
@@ -35,7 +35,7 @@ def setup_shutdown_handlers(manager: Manager, shutdown: asyncio.Event) -> Manage
             The configured instance.
 
     Raises:
-        Exception: If an error occurs during instance creation or configuration.
+        NotImplementedError: If the manager type is unsupported.
     """
 
     if isinstance(manager, qm.QueueManager | sm.SchedulerManager):
@@ -150,6 +150,10 @@ async def run_manager(
         manager: The instance to run (QueueManager, SchedulerManager, or PgQueuer).
         dequeue_timeout: Timeout duration for dequeuing jobs.
         batch_size: Number of jobs to process per batch.
+        mode: Queue execution mode (continuous or drain).
+        max_concurrent_tasks: Optional global cap on concurrent dispatch tasks.
+        shutdown_on_listener_failure: If True, set shutdown when a listener
+            health-check fails (QueueManager / PgQueuer only).
 
     Raises:
         NotImplementedError: If the instance type is unsupported.

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -222,10 +222,10 @@ class Queries:
 
     async def table_has_index(self, table: str, index: str) -> bool:
         """
-        Check if the column exists in table.
+        Check if the index exists on table.
 
         Returns:
-            bool: True if the column exists, False otherwise.
+            bool: True if the index exists, False otherwise.
         """
         rows = await self.driver.fetch(
             self.qbe.build_table_has_index_query(),
@@ -600,8 +600,8 @@ class Queries:
         This can be used for monitoring and ensuring the system is functioning as expected.
 
         Args:
-            event (models.HealthCheckEvent): The health check event containing
-                details about the system's health status.
+            health_check_event_id (uuid.UUID): Unique identifier for matching the
+                response to the originating probe.
         """
         await self.driver.notify(
             self.qbq.settings.channel,

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -137,8 +137,8 @@ class QueueManager:
         Periodically perform a health check by calling `listener_healthy`.
 
         Args:
-            interval (timedelta): Time interval between health checks.
-            shutdown_on_failure (bool): Whether to set the shutdown event if a health check fails.
+            interval (timedelta): Time interval between health checks; also used
+                as the per-probe timeout.
         """
 
         while not self.shutdown.is_set():


### PR DESCRIPTION
Four docstrings drifted out of sync with their signatures:

- queries.py table_has_index() claimed it checks "column exists in table" — copy-paste from table_has_column(). It checks an index.
- queries.py notify_health_check() listed an `event` parameter that does not exist. The real parameter is `health_check_event_id`.
- supervisor.py setup_shutdown_handlers() listed a `factory_fn` parameter that does not exist. The real parameter is `manager`.
- supervisor.py run_manager() Args block omitted `mode`, `max_concurrent_tasks`, and `shutdown_on_listener_failure`.
- qm.py _run_periodic_health_check() listed `shutdown_on_failure`, which is not a parameter.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
