### PR TITLE
chore(queries): drop stale issue ref + commented-out fallback

### DIFF
--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -181,12 +181,8 @@ class Queries:
         This method should be called when updating the application to a new version
         that requires schema changes.
         """
-
-        # This is a workaround until issue #311 is resolved.
         for query in self.qbe.build_upgrade_queries():
             await self.driver.execute(query)
-
-        # await self.driver.execute("\n\n".join(self.qbe.build_upgrade_queries()))
 
     async def alter_durability(self) -> None:
         """


### PR DESCRIPTION
The upgrade() loop is the canonical implementation, not a temporary workaround tracking issue #311. The accompanying commented-out batched alternative has rotted with each schema migration since.

AGENTS.md §Comments forbids inline issue refs and commented-out code in production paths; remove both.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
