### PR TITLE
style: drop banner section headers

### DIFF
--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -42,8 +42,6 @@ class InMemoryQueries:
 
     tracer: TracingProtocol | None = None
 
-    # -- internal state --------------------------------------------------------
-
     _jobs: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
     _log: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
     _statistics: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
@@ -53,8 +51,6 @@ class InMemoryQueries:
     _next_log_id: int = dataclasses.field(default=1, init=False)
     _next_schedule_id: int = dataclasses.field(default=1, init=False)
     _next_stats_id: int = dataclasses.field(default=1, init=False)
-
-    # -- SchemaManagementPort --------------------------------------------------
 
     async def install(self) -> None:
         pass
@@ -86,8 +82,6 @@ class InMemoryQueries:
 
     async def has_trigger(self, trigger: str) -> bool:
         return True
-
-    # -- enqueue ---------------------------------------------------------------
 
     @overload
     async def enqueue(
@@ -187,8 +181,6 @@ class InMemoryQueries:
 
         await self.emit_table_changed("insert")
         return ids
-
-    # -- dequeue ---------------------------------------------------------------
 
     def _count_picked_jobs(
         self,
@@ -354,8 +346,6 @@ class InMemoryQueries:
 
         return [models.Job.model_validate(j) for j in selected]
 
-    # -- log_jobs --------------------------------------------------------------
-
     async def log_jobs(
         self,
         job_status: list[
@@ -393,8 +383,6 @@ class InMemoryQueries:
             )
             self._next_log_id += 1
 
-    # -- retry_job -------------------------------------------------------------
-
     async def retry_job(
         self,
         job: models.Job,
@@ -425,8 +413,6 @@ class InMemoryQueries:
             self._next_log_id += 1
             await self.emit_table_changed("update")
 
-    # -- requeue_jobs ----------------------------------------------------------
-
     async def requeue_jobs(self, ids: list[JobId]) -> None:
         now = utc_now()
         for jid in ids:
@@ -452,8 +438,6 @@ class InMemoryQueries:
                 self._next_log_id += 1
                 await self.emit_table_changed("update")
 
-    # -- list_failed_jobs ------------------------------------------------------
-
     async def list_failed_jobs(
         self,
         limit: int = 100,
@@ -462,8 +446,6 @@ class InMemoryQueries:
         failed = [j for j in self._jobs.values() if j["status"] == "failed"]
         failed.sort(key=lambda j: j["created"], reverse=(order != "ASC"))
         return [models.Job.model_validate(j) for j in failed[:limit]]
-
-    # -- mark_job_as_cancelled -------------------------------------------------
 
     async def mark_job_as_cancelled(self, ids: list[JobId]) -> None:
         now = utc_now()
@@ -486,8 +468,6 @@ class InMemoryQueries:
                 self._next_log_id += 1
 
         await self.notify_job_cancellation(ids)
-
-    # -- clear_queue -----------------------------------------------------------
 
     async def clear_queue(self, entrypoint: str | list[str] | None = None) -> None:
         if entrypoint:
@@ -515,8 +495,6 @@ class InMemoryQueries:
             self._jobs.clear()
             self._dedupe_index.clear()
 
-    # -- queue_size ------------------------------------------------------------
-
     async def queue_size(self) -> list[models.QueueStatistics]:
         counts: dict[tuple[str, int, str], int] = {}
         for j in self._jobs.values():
@@ -532,20 +510,14 @@ class InMemoryQueries:
             for (ep, pri, st), count in sorted(counts.items())
         ]
 
-    # -- queued_work -----------------------------------------------------------
-
     async def queued_work(self, entrypoints: list[str]) -> int:
         ep_set = set(entrypoints)
         return sum(
             1 for j in self._jobs.values() if j["status"] == "queued" and j["entrypoint"] in ep_set
         )
 
-    # -- queue_log -------------------------------------------------------------
-
     async def queue_log(self) -> list[models.Log]:
         return [models.Log.model_validate(entry) for entry in self._log]
-
-    # -- update_heartbeat ------------------------------------------------------
 
     async def update_heartbeat(self, job_ids: list[JobId]) -> None:
         now = utc_now()
@@ -553,8 +525,6 @@ class InMemoryQueries:
         for jid in unique_ids:
             if jid in self._jobs:
                 self._jobs[jid]["heartbeat"] = now
-
-    # -- job_status ------------------------------------------------------------
 
     async def job_status(
         self,
@@ -568,8 +538,6 @@ class InMemoryQueries:
             if jid in id_set and jid not in latest:
                 latest[jid] = entry["status"]
         return [(JobId(jid), st) for jid, st in latest.items()]
-
-    # -- log_statistics --------------------------------------------------------
 
     async def log_statistics(
         self,
@@ -619,8 +587,6 @@ class InMemoryQueries:
 
         return [models.LogStatistics.model_validate(r) for r in result]
 
-    # -- Notification methods --------------------------------------------------
-
     async def notify_job_cancellation(self, ids: list[JobId]) -> None:
         event = models.CancellationEvent(
             channel=self.qbq.settings.channel,
@@ -638,8 +604,6 @@ class InMemoryQueries:
             id=health_check_event_id,
         )
         await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
-
-    # -- Schedule methods ------------------------------------------------------
 
     async def insert_schedule(
         self,
@@ -735,8 +699,6 @@ class InMemoryQueries:
     async def clear_schedule(self) -> None:
         self._schedules.clear()
 
-    # -- Extra utility methods -------------------------------------------------
-
     async def clear_statistics_log(self, entrypoint: str | list[str] | None = None) -> None:
         if entrypoint:
             eps = [entrypoint] if isinstance(entrypoint, str) else entrypoint
@@ -753,8 +715,6 @@ class InMemoryQueries:
         else:
             self._log.clear()
 
-    # -- next_deferred_eta -----------------------------------------------------
-
     async def next_deferred_eta(self, entrypoints: list[str]) -> timedelta | None:
         """Return time until the soonest deferred job becomes eligible, or None."""
         now = utc_now()
@@ -767,8 +727,6 @@ class InMemoryQueries:
         if candidates:
             return min(candidates) - now
         return None
-
-    # -- Private helpers -------------------------------------------------------
 
     def _remove_dedupe_for_job(self, job_id: int) -> None:
         """Remove dedupe_index entry pointing to *job_id*."""

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -36,11 +36,8 @@ class PgQueuerDatabase:
 
 Ctx = Context[ServerSession, PgQueuerDatabase, object]
 
-# ---------------------------------------------------------------------------
 # Annotated parameter types — descriptions surface in the MCP tool schema.
-# These are the ONLY knobs an agent can turn; keep them simple and bounded.
-# ---------------------------------------------------------------------------
-
+# Keep simple and bounded; these are the only knobs an agent can turn.
 Tail = Annotated[
     int,
     "Maximum number of rows to return. Must be a positive integer. "
@@ -89,10 +86,6 @@ def _db(ctx: Ctx) -> PgQueuerDatabase:
 
 def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
     """Register all read-only insight tools onto the given FastMCP instance."""
-
-    # ===================================================================
-    # QUEUE OVERVIEW
-    # ===================================================================
 
     @mcp.tool()
     async def queue_size(ctx: Ctx) -> list[dict[str, object]]:
@@ -156,10 +149,6 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
         """
         d = _db(ctx)
         return await d.fetch(d.qbq.build_queue_table_browse_query(), limit, offset)
-
-    # ===================================================================
-    # STATISTICS & THROUGHPUT
-    # ===================================================================
 
     @mcp.tool()
     async def queue_stats(
@@ -229,10 +218,6 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
         interval = _parse_interval(period)
         return await d.fetch(d.qbq.build_throughput_summary_query(), interval)
 
-    # ===================================================================
-    # FAILURE INVESTIGATION
-    # ===================================================================
-
     @mcp.tool()
     async def failed_jobs(
         ctx: Ctx,
@@ -270,10 +255,6 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
         d = _db(ctx)
         return await d.fetch(d.qbq.build_failed_jobs_query(), limit)
 
-    # ===================================================================
-    # EVENT LOG
-    # ===================================================================
-
     @mcp.tool()
     async def queue_log(
         ctx: Ctx,
@@ -307,10 +288,6 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
         d = _db(ctx)
         return await d.fetch(d.qbq.build_queue_log_query(), limit)
 
-    # ===================================================================
-    # SCHEDULES (CRON)
-    # ===================================================================
-
     @mcp.tool()
     async def schedules(ctx: Ctx) -> list[dict[str, object]]:
         """All cron-based recurring task definitions and their current state.
@@ -340,10 +317,6 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
         """
         d = _db(ctx)
         return await d.fetch(d.qbs.build_peek_schedule_query())
-
-    # ===================================================================
-    # WORKER HEALTH
-    # ===================================================================
 
     @mcp.tool()
     async def stale_jobs(
@@ -446,10 +419,6 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
         """
         d = _db(ctx)
         return await d.fetch(d.qbq.build_queue_age_query())
-
-    # ===================================================================
-    # SCHEMA & SETUP
-    # ===================================================================
 
     @mcp.tool()
     async def schema_info(ctx: Ctx) -> list[dict[str, object]]:

--- a/pgqueuer/core/buffers.py
+++ b/pgqueuer/core/buffers.py
@@ -126,11 +126,6 @@ class TimedOverflowBuffer(Generic[T]):
                 )
 
 
-# ---------------------------------------------------------------------------
-# Narrow sink protocols (ISP)
-# ---------------------------------------------------------------------------
-
-
 class JobLogSink(Protocol):
     """Narrow port: accepts batched job status log entries."""
 
@@ -150,11 +145,6 @@ class HeartbeatSink(Protocol):
     """Narrow port: accepts batched heartbeat updates."""
 
     async def update_heartbeat(self, job_ids: list[models.JobId]) -> None: ...
-
-
-# ---------------------------------------------------------------------------
-# Concrete buffers
-# ---------------------------------------------------------------------------
 
 
 @dataclasses.dataclass

--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -119,8 +119,6 @@ class CompletionWatcher:
         repr=False,
     )
 
-    # ----------------------------- life-cycle --------------------------------
-
     async def __aenter__(self) -> "CompletionWatcher":
         """
         Enter async context:
@@ -148,7 +146,6 @@ class CompletionWatcher:
         await self.task_manager.gather_tasks()
         return False
 
-    # ----------------------------- public API --------------------------------
     def wait_for(self, jid: models.JobId) -> asyncio.Future[models.JOB_STATUS]:
         """
         Return a Future that resolves when *jid* reaches a terminal state.
@@ -164,7 +161,6 @@ class CompletionWatcher:
         self._schedule_refresh_waiters()
         return fut
 
-    # -------------------- debounce / scheduling helpers --------------------
     def _schedule_refresh_waiters(self) -> None:
         """
         (Re)arm the debounce timer so that `_on_change` is executed at most once
@@ -187,7 +183,6 @@ class CompletionWatcher:
             self.debounce_task = None
         await self._refresh_waiters()
 
-    # -------------------- event handlers & polling -------------------------
     def _is_relevant_event(self, payload: str | bytes | bytearray) -> None:
         """LISTEN/NOTIFY callback -- schedules a debounced change check."""
         try:
@@ -225,7 +220,6 @@ class CompletionWatcher:
                         if not waiter.done():
                             waiter.set_result(status)
 
-    # ----------------------------- helper methods ---------------------------
     def _is_terminal(self, status: models.JOB_STATUS) -> bool:
         """Return ``True`` if *status* is terminal."""
         return status in ("canceled", "deleted", "exception", "successful")

--- a/pgqueuer/core/executors.py
+++ b/pgqueuer/core/executors.py
@@ -1,5 +1,3 @@
-# executors.py
-
 from __future__ import annotations
 
 import dataclasses
@@ -146,9 +144,6 @@ class DatabaseRetryEntrypointExecutor(EntrypointExecutor):
                 self.max_delay,
             )
             raise errors.RetryRequested(delay=delay, reason=str(e)) from e
-
-
-######## Schedulers ########
 
 
 @dataclasses.dataclass

--- a/pgqueuer/core/heartbeat.py
+++ b/pgqueuer/core/heartbeat.py
@@ -1,5 +1,3 @@
-# heartbeat.py
-
 from __future__ import annotations
 
 import asyncio

--- a/pgqueuer/domain/models.py
+++ b/pgqueuer/domain/models.py
@@ -36,9 +36,6 @@ def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-###### Events ######
-
-
 class Event(BaseModel):
     """
     A class representing an event in a PostgreSQL channel.
@@ -117,9 +114,6 @@ class AnyEvent(
 ): ...
 
 
-###### Jobs ######
-
-
 class Job(BaseModel):
     """
     Represents a job with attributes such as ID, priority,
@@ -161,9 +155,6 @@ class Job(BaseModel):
         return None if self.headers is None else self.headers.get("otel")
 
 
-###### Log ######
-
-
 class Log(BaseModel):
     """Represents a job status log entry recording a state transition."""
 
@@ -179,7 +170,6 @@ class Log(BaseModel):
     aggregated: bool
 
 
-###### Statistics ######
 class QueueStatistics(BaseModel):
     """
     Represents the number of jobs per entrypoint and priority in the queue.
@@ -233,9 +223,6 @@ class ScheduleContext:
     resources: MutableMapping = dataclasses.field(default_factory=dict)
 
 
-###### Schedules ######
-
-
 class CronExpressionEntrypoint(NamedTuple):
     entrypoint: CronEntrypoint
     expression: CronExpression
@@ -251,9 +238,6 @@ class Schedule(BaseModel):
     last_run: AwareDatetime | None = None
     status: JOB_STATUS
     entrypoint: CronEntrypoint
-
-
-###### Tracebacks ######
 
 
 class TracebackRecord(BaseModel):

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -37,11 +37,6 @@ class EntrypointExecutionParameter:
     concurrency_limit: int
 
 
-# ---------------------------------------------------------------------------
-# Queue persistence
-# ---------------------------------------------------------------------------
-
-
 class QueueRepositoryPort(Protocol):
     """Persistence operations for the job queue."""
 
@@ -147,11 +142,6 @@ class QueueRepositoryPort(Protocol):
         ...
 
 
-# ---------------------------------------------------------------------------
-# Schedule persistence
-# ---------------------------------------------------------------------------
-
-
 class ScheduleRepositoryPort(Protocol):
     """Persistence operations for cron schedules."""
 
@@ -180,22 +170,12 @@ class ScheduleRepositoryPort(Protocol):
     async def clear_schedule(self) -> None: ...
 
 
-# ---------------------------------------------------------------------------
-# Notifications
-# ---------------------------------------------------------------------------
-
-
 class NotificationPort(Protocol):
     """Abstraction over PostgreSQL NOTIFY for inter-process signalling."""
 
     async def notify_job_cancellation(self, ids: list[models.JobId]) -> None: ...
 
     async def notify_health_check(self, health_check_event_id: uuid.UUID) -> None: ...
-
-
-# ---------------------------------------------------------------------------
-# Schema management (DDL)
-# ---------------------------------------------------------------------------
 
 
 class SchemaManagementPort(Protocol):


### PR DESCRIPTION
AGENTS.md §Comments forbids banner section headers (\`# ===== X =====\`, \`# --- X ---\`, \`###### X ######\`, \`# filename.py\`). Strip every instance across the codebase.

Files / counts:
- adapters/inmemory/queries.py — 21 dash-style section banners
- adapters/mcp/server.py — 8 \`# === SECTION ===\` blocks + 1 dashed banner around the parameter-types preamble
- domain/models.py — 6 \`###### Section ######\` banners
- ports/repository.py — 4 dashed section banners
- core/completion.py — 5 dashed life-cycle/API banners
- core/buffers.py — 2 dashed sink/buffer banners
- core/executors.py — 1 \`######## Schedulers ########\` banner + filename banner
- core/heartbeat.py — filename banner

Pure code-comment removals; no behavioural change.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
