### PR TITLE
style: drop module-docstring preambles

### DIFF
--- a/pgqueuer/adapters/cli/supervisor.py
+++ b/pgqueuer/adapters/cli/supervisor.py
@@ -1,11 +1,3 @@
-"""
-This module provides functionality to dynamically load and run queue management components.
-It includes the ability to load a factory function for creating instances of
-QueueManager, Scheduler and PgQueuer, manage their lifecycle, and handle graceful shutdowns.
-The module is designed to support asynchronous queue processing and scheduling
-using configurable factory paths.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -1,13 +1,3 @@
-"""
-Database query builder and executor for job queue operations.
-
-This module provides classes and functions to construct and execute SQL queries
-related to job queuing, such as installing the necessary database schema,
-enqueueing and dequeueing jobs, logging job statuses, and managing job statistics.
-It abstracts the SQL details and offers a high-level interface for interacting
-with the database in the context of the pgqueuer application.
-"""
-
 from __future__ import annotations
 
 import dataclasses

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -1,13 +1,3 @@
-"""
-Database query builder and executor for job queue operations.
-
-This module provides classes and functions to construct and execute SQL queries
-related to job queuing, such as installing the necessary database schema,
-enqueueing and dequeueing jobs, logging job statuses, and managing job statistics.
-It abstracts the SQL details and offers a high-level interface for interacting
-with the database in the context of the pgqueuer application.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -1,10 +1,3 @@
-"""
-This module defines the `PgQueuer` class, which orchestrates job scheduling and queue management
-using PostgreSQL as a backend. The `PgQueuer` class is designed to combine the functionalities
-of `QueueManager` and `SchedulerManager` to provide a unified interface for managing job queues
-and scheduling periodic tasks efficiently.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -1,10 +1,3 @@
-"""
-Queue Manager module for handling job queues and dispatching jobs.
-
-This module defines the `QueueManager` class, which manages job queues, dispatches
-jobs to registered entrypoints, and handles database connections and events.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/pgqueuer/core/tm.py
+++ b/pgqueuer/core/tm.py
@@ -1,11 +1,3 @@
-"""
-Task Manager for handling asynchronous tasks.
-
-This module provides the `TaskManager` class, which manages a collection of `asyncio.Task`
-objects. It ensures proper tracking and cleanup of tasks, handles exceptions,
-and supports context management for ease of use.
-"""
-
 from __future__ import annotations
 
 import asyncio

--- a/pgqueuer/domain/models.py
+++ b/pgqueuer/domain/models.py
@@ -1,11 +1,3 @@
-"""
-Models and type definitions for events, jobs, and statistics.
-
-This module defines data classes and types used throughout the application,
-including events received from PostgreSQL channels, job representations,
-and statistical data structures for logging and monitoring.
-"""
-
 from __future__ import annotations
 
 import dataclasses


### PR DESCRIPTION
AGENTS.md §Docstrings disallows "This module defines..." / "This module provides..." preambles in module-level docstrings. Strip them from seven files where the preamble adds nothing beyond the file's name and contents:

- core/qm.py, core/tm.py, core/applications.py
- domain/models.py
- adapters/cli/supervisor.py
- adapters/persistence/queries.py, qb.py

Public class and function docstrings are untouched.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
