### PR TITLE
fix(ports): import Job from domain, not shim

### DIFF
--- a/pgqueuer/ports/tracing.py
+++ b/pgqueuer/ports/tracing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import AsyncContextManager, Final, Generator, Protocol
 
-from pgqueuer.models import Job
+from pgqueuer.domain.models import Job
 
 
 class TracingProtocol(Protocol):


### PR DESCRIPTION
ports layer must not depend on top-level re-export shims. Import Job directly from pgqueuer.domain.models to keep the ports module aligned with the hexagonal layering documented in AGENTS.md.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
