### PR TITLE
refactor(tracing): drop type: ignore on optional-import sentinels

### DIFF
--- a/pgqueuer/adapters/tracing/logfire.py
+++ b/pgqueuer/adapters/tracing/logfire.py
@@ -7,7 +7,7 @@ try:
     import logfire
     import logfire.propagate
 except ImportError:
-    logfire = None  # type: ignore[assignment]
+    logfire = None
 
 from pgqueuer.domain.models import Job
 from pgqueuer.ports.tracing import TracingProtocol

--- a/pgqueuer/adapters/tracing/logfire.py
+++ b/pgqueuer/adapters/tracing/logfire.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Generator
+from typing import TYPE_CHECKING, AsyncIterator, Generator
 
-try:
+if TYPE_CHECKING:
     import logfire
     import logfire.propagate
+
+try:
+    import logfire  # noqa: F811
+    import logfire.propagate  # noqa: F811
+
+    HAS_LOGFIRE = True
 except ImportError:
-    logfire = None
+    HAS_LOGFIRE = False
 
 from pgqueuer.domain.models import Job
 from pgqueuer.ports.tracing import TracingProtocol
@@ -15,7 +21,7 @@ from pgqueuer.ports.tracing import TracingProtocol
 
 class LogfireTracing(TracingProtocol):
     def trace_publish(self, entrypoints: list[str]) -> Generator[dict, None, None]:
-        if logfire is None:
+        if not HAS_LOGFIRE:
             # One header per entrypoint: merge_tracing_headers zips against
             # the entrypoint list with strict=True.
             for _ in entrypoints:
@@ -30,7 +36,7 @@ class LogfireTracing(TracingProtocol):
     @asynccontextmanager
     async def trace_process(self, job: Job) -> AsyncIterator[None]:
         """Wrap consumer processing of *job* in a Logfire span when SDK + headers present."""
-        if logfire is None or job.headers is None:
+        if not HAS_LOGFIRE or job.headers is None:
             yield
             return
 

--- a/pgqueuer/adapters/tracing/opentelemetry.py
+++ b/pgqueuer/adapters/tracing/opentelemetry.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import Any, Generator
+from typing import TYPE_CHECKING, Any, Generator
 
-try:
+if TYPE_CHECKING:
     import opentelemetry
     import opentelemetry.context
     import opentelemetry.propagate
     import opentelemetry.semconv.trace
     import opentelemetry.trace
+
+try:
+    import opentelemetry  # noqa: F811
+    import opentelemetry.context  # noqa: F811
+    import opentelemetry.propagate  # noqa: F811
+    import opentelemetry.semconv.trace  # noqa: F811
+    import opentelemetry.trace  # noqa: F811
+
+    HAS_OTEL = True
 except ImportError:
-    opentelemetry = None  # type: ignore[assignment]
+    HAS_OTEL = False
 
 from pgqueuer.domain.models import Job
 from pgqueuer.ports.tracing import TracingProtocol
@@ -65,7 +74,7 @@ class OpenTelemetryTracing(TracingProtocol):
         self._instrumentation_name = instrumentation_name
 
     def _get_tracer(self) -> Any:
-        if opentelemetry is None:
+        if not HAS_OTEL:
             return None
         if self._tracer_arg is not None:
             return self._tracer_arg

--- a/pgqueuer/adapters/tracing/sentry.py
+++ b/pgqueuer/adapters/tracing/sentry.py
@@ -6,7 +6,7 @@ from typing import AsyncIterator, Generator
 try:
     import sentry_sdk
 except ImportError:
-    sentry_sdk = None  # type: ignore[assignment]
+    sentry_sdk = None
 
 from pgqueuer.domain.models import Job
 from pgqueuer.ports.tracing import TracingProtocol

--- a/pgqueuer/adapters/tracing/sentry.py
+++ b/pgqueuer/adapters/tracing/sentry.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Generator
+from typing import TYPE_CHECKING, AsyncIterator, Generator
+
+if TYPE_CHECKING:
+    import sentry_sdk
 
 try:
-    import sentry_sdk
+    import sentry_sdk  # noqa: F811
+
+    HAS_SENTRY = True
 except ImportError:
-    sentry_sdk = None
+    HAS_SENTRY = False
 
 from pgqueuer.domain.models import Job
 from pgqueuer.ports.tracing import TracingProtocol
@@ -14,7 +19,7 @@ from pgqueuer.ports.tracing import TracingProtocol
 
 class SentryTracing(TracingProtocol):
     def trace_publish(self, entrypoints: list[str]) -> Generator[dict, None, None]:
-        if sentry_sdk is None:
+        if not HAS_SENTRY:
             # One header per entrypoint: merge_tracing_headers zips against
             # the entrypoint list with strict=True.
             for _ in entrypoints:
@@ -42,7 +47,7 @@ class SentryTracing(TracingProtocol):
     @asynccontextmanager
     async def trace_process(self, job: Job) -> AsyncIterator[None]:
         """Wrap consumer processing of *job* in a Sentry transaction + span."""
-        if sentry_sdk is None or job.headers is None:
+        if not HAS_SENTRY or job.headers is None:
             yield
             return
 

--- a/test/test_tracing_graceful_degradation.py
+++ b/test/test_tracing_graceful_degradation.py
@@ -35,18 +35,18 @@ def _make_job(headers: dict) -> Job:
 
 
 def test_sentry_publish_yields_one_header_per_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(sentry_mod, "sentry_sdk", None)
+    monkeypatch.setattr(sentry_mod, "HAS_SENTRY", False)
     assert list(SentryTracing().trace_publish(["a", "b"])) == [{}, {}]
 
 
 def test_logfire_publish_yields_one_header_per_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(logfire_mod, "logfire", None)
+    monkeypatch.setattr(logfire_mod, "HAS_LOGFIRE", False)
     assert list(LogfireTracing().trace_publish(["a", "b"])) == [{}, {}]
 
 
 async def test_sentry_batch_enqueue_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without this, merge_tracing_headers' strict zip raises on batch enqueue."""
-    monkeypatch.setattr(sentry_mod, "sentry_sdk", None)
+    monkeypatch.setattr(sentry_mod, "HAS_SENTRY", False)
     queries = InMemoryQueries(driver=InMemoryDriver(), tracer=SentryTracing())
     ids = await queries.enqueue(["a", "b", "c"], [None, None, None], [0, 0, 0])
     assert len(ids) == 3
@@ -54,14 +54,14 @@ async def test_sentry_batch_enqueue_does_not_crash(monkeypatch: pytest.MonkeyPat
 
 async def test_logfire_batch_enqueue_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without this, merge_tracing_headers' strict zip raises on batch enqueue."""
-    monkeypatch.setattr(logfire_mod, "logfire", None)
+    monkeypatch.setattr(logfire_mod, "HAS_LOGFIRE", False)
     queries = InMemoryQueries(driver=InMemoryDriver(), tracer=LogfireTracing())
     ids = await queries.enqueue(["a", "b", "c"], [None, None, None], [0, 0, 0])
     assert len(ids) == 3
 
 
 async def test_sentry_process_yields_without_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(sentry_mod, "sentry_sdk", None)
+    monkeypatch.setattr(sentry_mod, "HAS_SENTRY", False)
     ran = False
     async with SentryTracing().trace_process(_make_job({"sentry": {"sentry-trace": "x"}})):
         ran = True
@@ -69,7 +69,7 @@ async def test_sentry_process_yields_without_sdk(monkeypatch: pytest.MonkeyPatch
 
 
 async def test_logfire_process_yields_without_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(logfire_mod, "logfire", None)
+    monkeypatch.setattr(logfire_mod, "HAS_LOGFIRE", False)
     ran = False
     async with LogfireTracing().trace_process(_make_job({"logfire": {"traceparent": "x"}})):
         ran = True

--- a/test/test_tracing_opentelemetry.py
+++ b/test/test_tracing_opentelemetry.py
@@ -350,7 +350,7 @@ async def test_trace_process_missing_otel_key_is_noop(
 def test_trace_publish_graceful_without_otel(monkeypatch: pytest.MonkeyPatch) -> None:
     import pgqueuer.adapters.tracing.opentelemetry as otel_mod
 
-    monkeypatch.setattr(otel_mod, "opentelemetry", None)
+    monkeypatch.setattr(otel_mod, "HAS_OTEL", False)
     t = OpenTelemetryTracing()
     headers = list(t.trace_publish(["ep_a", "ep_b"]))
     assert headers == [{}, {}]
@@ -359,7 +359,7 @@ def test_trace_publish_graceful_without_otel(monkeypatch: pytest.MonkeyPatch) ->
 async def test_trace_process_graceful_without_otel(monkeypatch: pytest.MonkeyPatch) -> None:
     import pgqueuer.adapters.tracing.opentelemetry as otel_mod
 
-    monkeypatch.setattr(otel_mod, "opentelemetry", None)
+    monkeypatch.setattr(otel_mod, "HAS_OTEL", False)
     t = OpenTelemetryTracing()
     job = _make_job(headers={"otel": {"traceparent": "00-abc-def-01"}})
 


### PR DESCRIPTION
AGENTS.md forbids `# type: ignore` in pgqueuer/. The sentry and logfire fallbacks were already redundant (mypy reported unused-ignore once the package was missing from the type-check environment); drop them.

For opentelemetry, type stubs ship with the package so the `opentelemetry = None` fallback genuinely violated the Module type. Replace with a `HAS_OTEL` boolean flag plus a `TYPE_CHECKING` import that gives mypy the real Module type without an ignore.

Update the graceful-degradation tests to monkeypatch the new HAS_OTEL flag instead of the module reference.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
