### PR TITLE
style: drop banner section headers in domain/types

### DIFF
--- a/pgqueuer/domain/types.py
+++ b/pgqueuer/domain/types.py
@@ -4,13 +4,11 @@ from enum import Enum
 from typing import Literal, NewType
 
 
-###### Queue ######
 class QueueExecutionMode(Enum):
     continuous = "continuous"  # Normal queue processing with a continuous worker loop
     drain = "drain"  # Process all jobs until empty, then shut down
 
 
-###### Events ######
 Channel = NewType("Channel", str)
 OPERATIONS = Literal["insert", "update", "delete", "truncate"]
 EVENT_TYPES = Literal[
@@ -20,7 +18,6 @@ EVENT_TYPES = Literal[
 ]
 
 
-###### Jobs ######
 JobId = NewType("JobId", int)
 JOB_STATUS = Literal[
     "queued",
@@ -36,7 +33,6 @@ OnFailure = Literal["delete", "hold"]
 SortOrder = Literal["ASC", "DESC"]
 
 
-###### Schedules ######
 CronEntrypoint = NewType("CronEntrypoint", str)
 CronExpression = NewType("CronExpression", str)
 ScheduleId = NewType("ScheduleId", int)


### PR DESCRIPTION
Per AGENTS.md, banner section headers like `###### Queue ######` are explicitly forbidden — module structure and identifier names should carry the signal, not decorative comments.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
