### PR TITLE
style: trim module docstring preambles

### DIFF
--- a/pgqueuer/core/buffers.py
+++ b/pgqueuer/core/buffers.py
@@ -1,9 +1,4 @@
-"""
-Batched async buffers for heartbeats and job status logs.
-
-Items accumulate until a size or time threshold triggers a flush
-via the :meth:`~TimedOverflowBuffer.flush_items` template method.
-"""
+"""Batched async buffers for heartbeats and job status logs."""
 
 from __future__ import annotations
 

--- a/pgqueuer/core/listeners.py
+++ b/pgqueuer/core/listeners.py
@@ -1,38 +1,4 @@
-"""PostgreSQL NOTIFY event-handling helpers
-================================================
-
-This module replaces the legacy *if/elif* `handle_event_type` chain with a
-small, type-safe dispatch system based on :class:`EventRouter`.  Public
-components
------------------
-
-``EventRouter``
-    Lightweight dispatcher that maps a single ``event.type`` string to a
-    handler.  Handlers receive the concrete ``models.*Event`` subclass
-    selected by *Pydantic*'s ``discriminator`` and **must** return
-    ``None``.
-
-``build_default_router``
-    Convenience factory that wires handlers for the canonical
-    back-end events (*table-changed*, *cancellation*, *health-check*).
-    It injects application state via closures, avoiding a bulky context
-    object.
-
-``PGNoticeEventListener``
-    A thin ``asyncio.Queue`` subclass used by the default
-    *table-changed* handler to deliver row-level notifications to
-    consumers.
-
-``initialize_notice_event_listener``
-    Glue that attaches any ``Callable[[models.AnyEvent], None]``
-    (typically the router) to a live database connection through
-    ``connection.add_listener``.
-
-Typical usage::
-
-    router = build_default_router(...state injections...)
-    await initialize_notice_event_listener(conn, "mychannel", router)
-"""
+"""PostgreSQL NOTIFY event-routing helpers."""
 
 from __future__ import annotations
 

--- a/pgqueuer/core/logconfig.py
+++ b/pgqueuer/core/logconfig.py
@@ -1,6 +1,4 @@
-"""
-Logging configuration for the pgqueuer application.
-"""
+"""Logging configuration for pgqueuer."""
 
 from __future__ import annotations
 

--- a/pgqueuer/domain/settings.py
+++ b/pgqueuer/domain/settings.py
@@ -1,8 +1,4 @@
-"""Domain configuration types for PgQueuer.
-
-These are pure configuration / value objects with no adapter-specific
-dependencies, so they belong in the domain layer.
-"""
+"""Domain configuration types for PgQueuer."""
 
 from __future__ import annotations
 

--- a/pgqueuer/ports/driver.py
+++ b/pgqueuer/ports/driver.py
@@ -1,7 +1,4 @@
-"""Port protocols for database drivers.
-
-These Protocol classes define the contracts for database access.
-"""
+"""Port protocols for database drivers."""
 
 from __future__ import annotations
 

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -1,10 +1,4 @@
-"""Port protocols for PgQueuer's hexagonal architecture.
-
-These Protocol classes define the contracts that the core domain
-(QueueManager, SchedulerManager) depends on. The existing ``Queries``
-class satisfies all four ports via structural subtyping -- no
-inheritance or registration is required.
-"""
+"""Repository port protocols satisfied by Queries via structural subtyping."""
 
 from __future__ import annotations
 

--- a/pgqueuer/ports/tracing.py
+++ b/pgqueuer/ports/tracing.py
@@ -1,9 +1,4 @@
-"""Port protocol for tracing operations.
-
-This module defines the tracing contract that core code depends on.
-The existing ``LogfireTracing`` and ``SentryTracing`` classes satisfy
-this protocol via structural subtyping.
-"""
+"""Port protocol for tracing operations."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
AGENTS.md forbids 'This module defines...' / multi-paragraph preambles on module docstrings — when present they must be a single sentence. Trim seven modules (ports/driver, ports/repository, ports/tracing, core/buffers, core/listeners, core/logconfig, domain/settings) to one-line summaries.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
