### PR TITLE
style(completion): trim verbose docstrings

### DIFF
--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -16,70 +16,20 @@ from pgqueuer.ports.repository import QueueRepositoryPort
 
 @dataclass
 class CompletionWatcher:
-    """
-    Watches a set of PostgreSQL-backed jobs and resolves user Futures as soon as
-    each job lands in a *terminal* state.
+    """Resolve per-job Futures when a job lands in a terminal state.
 
-    ----------
-    How it works
-    ----------
-    1. **Instant updates via LISTEN/NOTIFY**
+    Combines LISTEN/NOTIFY for instant updates with a periodic safety-net
+    poll (``refresh_interval``) for missed notifications. NOTIFY bursts are
+    coalesced into a single status query per ``debounce`` window.
+    Terminal states: ``canceled``, ``deleted``, ``exception``, ``successful``.
 
-       The watcher listens on the ``table_changed_event`` channel emitted by the
-       job table.  Whenever a notification arrives it *schedules* (but does not
-       immediately run) a status query.
+    Usage example::
 
-    2. **Safety-net polling (`refresh_interval`)**
-
-       Lost NOTIFY messages can happen -- network blips, a pooled connection
-       being swapped out, or events that occurred *before* the listener was
-       attached.  To cover these gaps a lightweight polling task runs every
-
-       ``refresh_interval`` (default **5 s**).  Set this parameter to
-       ``None`` to disable polling entirely if LISTEN reliability is good
-       enough for your deployment.
-
-    3. **Event coalescing (`debounce`)**
-
-       Bursts of NOTIFYs (for example when 100 rows are updated in one
-       transaction) could otherwise trigger 100 identical queries.  Instead, a
-       debouncing timer is used:
-
-       * On the **first** trigger a timer is (re)armed for the length of
-         ``debounce`` (default **50 ms**).
-       * Any further triggers that arrive while the timer is running are *ignored*.
-       * When the timer fires a single consolidated query is executed.
-
-       This keeps load predictable without delaying feedback beyond the small
-       debounce window.
-
-    ----------
-    Parameters
-    ----------
-    driver : `db.Driver`
-        An async DB driver that can both execute queries and register LISTEN
-        callbacks.
-    refresh_interval : `datetime.timedelta | None`
-        Cadence of the periodic safety-net query.  ``None`` disables polling.
-    debounce : `datetime.timedelta`
-        Length of the coalescing window that limits how often the expensive
-        status query is run.
-
-    ----------
-    Usage example
-    ----------
-    ```python
-    async with CompletionWatcher(driver,
-                                 refresh_interval=timedelta(seconds=2),
-                                 debounce=timedelta(milliseconds=100)) as w:
-        status = await w.wait_for(job_id)
-        print("final status ->", status)
-    ```
-
-    ----------
-    Terminal states recognised
-    ----------
-    ``canceled``, ``deleted``, ``exception``, ``successful``.
+        async with CompletionWatcher(driver,
+                                     refresh_interval=timedelta(seconds=2),
+                                     debounce=timedelta(milliseconds=100)) as w:
+            status = await w.wait_for(job_id)
+            print("final status ->", status)
     """
 
     driver: Driver
@@ -88,7 +38,6 @@ class CompletionWatcher:
         default_factory=lambda: timedelta(seconds=5),
     )
 
-    """Time-window in which multiple change triggers are coalesced into one."""
     debounce: timedelta = field(
         default_factory=lambda: timedelta(milliseconds=50),
         repr=False,
@@ -120,26 +69,12 @@ class CompletionWatcher:
     )
 
     async def __aenter__(self) -> "CompletionWatcher":
-        """
-        Enter async context:
-
-        * start periodic polling (if enabled);
-        * register LISTEN/NOTIFY callback;
-        * schedule an immediate status probe.
-        """
         self.task_manager.add(asyncio.create_task(self._poll_for_change()))
         await self.driver.add_listener(DBSettings().channel, self._is_relevant_event)
         self._schedule_refresh_waiters()
         return self
 
     async def __aexit__(self, *_: object) -> bool:
-        """
-        Exit async context:
-
-        * stop background tasks;
-        * flush a final change check;
-        * wait for all user Futures to resolve.
-        """
         self.shutdown.set()
         self._schedule_refresh_waiters()
         await asyncio.gather(*chain.from_iterable(self.waiters.values()))
@@ -147,25 +82,14 @@ class CompletionWatcher:
         return False
 
     def wait_for(self, jid: models.JobId) -> asyncio.Future[models.JOB_STATUS]:
-        """
-        Return a Future that resolves when *jid* reaches a terminal state.
-
-        Args:
-            jid: ``JobId`` to watch.
-
-        Returns:
-            An ``asyncio.Future`` yielding the final ``JOB_STATUS``.
-        """
+        """Return a Future that resolves when *jid* reaches a terminal state."""
         fut: asyncio.Future[models.JOB_STATUS] = asyncio.get_running_loop().create_future()
         self.waiters[jid].append(fut)
         self._schedule_refresh_waiters()
         return fut
 
     def _schedule_refresh_waiters(self) -> None:
-        """
-        (Re)arm the debounce timer so that `_on_change` is executed at most once
-        in every ``debounce`` window irrespective of how many triggers arrive.
-        """
+        """(Re)arm debounce timer; coalesces multiple triggers into one query."""
         if self.debounce_task and not self.debounce_task.done():
             return  # timer already running
         self.debounce_task = asyncio.create_task(self._debounced())
@@ -193,10 +117,7 @@ class CompletionWatcher:
             self._schedule_refresh_waiters()
 
     async def _poll_for_change(self) -> None:
-        """
-        Periodic safety-net that re-checks outstanding jobs every
-        ``refresh_interval``.  Disabled when ``refresh_interval`` is ``None``.
-        """
+        """Safety-net poller for missed NOTIFY events."""
         while not self.shutdown.is_set():
             try:
                 await asyncio.wait_for(
@@ -209,10 +130,7 @@ class CompletionWatcher:
                 break
 
     async def _refresh_waiters(self) -> None:
-        """
-        Query the current status for all waiting jobs and resolve Futures whose
-        job has reached a terminal state.
-        """
+        """Resolve Futures for waiting jobs that have reached a terminal state."""
         async with self.lock:
             for jid, status in await self.queries.job_status(list(self.waiters.keys())):
                 if self._is_terminal(status):


### PR DESCRIPTION
The CompletionWatcher class and its methods used multi-section docstrings that restated parameters and behaviours already captured by the type annotations and method names. Collapse them to single-sentence summaries that retain only the non-obvious 'why' (debounce coalescing, LISTEN/NOTIFY + safety-net poll combination).

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
