### PR TITLE
chore: add 'from __future__ import annotations' to all modules

### DIFF
--- a/pgqueuer/__init__.py
+++ b/pgqueuer/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.applications import PgQueuer
 from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, PsycopgDriver

--- a/pgqueuer/__main__.py
+++ b/pgqueuer/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 
 from pgqueuer.adapters.cli import cli

--- a/pgqueuer/adapters/__init__.py
+++ b/pgqueuer/adapters/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pgqueuer/adapters/cli/__init__.py
+++ b/pgqueuer/adapters/cli/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pgqueuer/adapters/inmemory/__init__.py
+++ b/pgqueuer/adapters/inmemory/__init__.py
@@ -1,5 +1,7 @@
 """In-memory adapter — drop-in replacement for the PostgreSQL backend."""
 
+from __future__ import annotations
+
 from pgqueuer.adapters.inmemory.driver import InMemoryDriver
 from pgqueuer.adapters.inmemory.queries import InMemoryQueries
 

--- a/pgqueuer/adapters/mcp/__init__.py
+++ b/pgqueuer/adapters/mcp/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pgqueuer/adapters/mcp/__main__.py
+++ b/pgqueuer/adapters/mcp/__main__.py
@@ -1,5 +1,7 @@
 """Entry point: python -m pgqueuer.adapters.mcp"""
 
+from __future__ import annotations
+
 from pgqueuer.adapters.mcp.server import create_mcp_server
 
 

--- a/pgqueuer/adapters/persistence/__init__.py
+++ b/pgqueuer/adapters/persistence/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pgqueuer/applications.py
+++ b/pgqueuer/applications.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.core.applications"""
 
+from __future__ import annotations
+
 from pgqueuer.core.applications import PgQueuer
 
 __all__ = ["PgQueuer"]

--- a/pgqueuer/core/__init__.py
+++ b/pgqueuer/core/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pgqueuer/db.py
+++ b/pgqueuer/db.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.ports.driver + pgqueuer.adapters.drivers.*"""
 
+from __future__ import annotations
+
 from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver, AsyncpgPoolDriver
 from pgqueuer.adapters.drivers.psycopg import PsycopgDriver, SyncPsycopgDriver
 from pgqueuer.ports.driver import Driver, SyncDriver

--- a/pgqueuer/domain/__init__.py
+++ b/pgqueuer/domain/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pgqueuer/errors.py
+++ b/pgqueuer/errors.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.domain.errors"""
 
+from __future__ import annotations
+
 from pgqueuer.domain.errors import (
     DuplicateJobError,
     FailingListenerError,

--- a/pgqueuer/executors.py
+++ b/pgqueuer/executors.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.core.executors"""
 
+from __future__ import annotations
+
 from pgqueuer.core.executors import (
     AbstractEntrypointExecutor,
     AbstractScheduleExecutor,

--- a/pgqueuer/factories.py
+++ b/pgqueuer/factories.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.adapters.cli.factories"""
 
+from __future__ import annotations
+
 from pgqueuer.adapters.cli.factories import (
     load_factory,
     validate_factory_result,

--- a/pgqueuer/metrics/__init__.py
+++ b/pgqueuer/metrics/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pgqueuer/models.py
+++ b/pgqueuer/models.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.domain.models"""
 
+from __future__ import annotations
+
 from pgqueuer.domain.models import (
     AnyEvent,
     CancellationEvent,

--- a/pgqueuer/qm.py
+++ b/pgqueuer/qm.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.core.qm"""
 
+from __future__ import annotations
+
 from pgqueuer.core.qm import QueueManager
 
 __all__ = ["QueueManager"]

--- a/pgqueuer/queries.py
+++ b/pgqueuer/queries.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.adapters.persistence.queries"""
 
+from __future__ import annotations
+
 from pgqueuer.adapters.persistence.queries import (
     Queries,
     SyncQueries,

--- a/pgqueuer/sm.py
+++ b/pgqueuer/sm.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.core.sm"""
 
+from __future__ import annotations
+
 from pgqueuer.core.sm import SchedulerManager
 
 __all__ = ["SchedulerManager"]

--- a/pgqueuer/types.py
+++ b/pgqueuer/types.py
@@ -1,5 +1,7 @@
 """Backward-compatibility shim. Canonical: pgqueuer.domain.types"""
 
+from __future__ import annotations
+
 from pgqueuer.domain.types import (
     EVENT_TYPES,
     JOB_STATUS,


### PR DESCRIPTION
AGENTS.md requires `from __future__ import annotations` in every file. This commit adds it to the 21 modules that were missing it: 12 top-level backward-compatibility shims, the package entry points, and 7 empty `__init__.py` markers. No runtime behaviour change.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
