### PR TITLE
test: assert dequeue keeps global priority order across entrypoints

### DIFF
--- a/test/test_execute_after.py
+++ b/test/test_execute_after.py
@@ -136,8 +136,7 @@ async def test_next_deferred_eta_returns_timedelta(apgdriver: Driver) -> None:
 
 
 async def test_next_deferred_eta_returns_soonest_of_many(apgdriver: Driver) -> None:
-    """ORDER BY execute_after LIMIT 1 must return the soonest deferred job
-    (equivalent to the previous MIN(execute_after)), not an arbitrary one."""
+    """next_deferred_eta returns the soonest of several deferred jobs (MIN equivalence) (#668)."""
     q = Queries(apgdriver)
     await q.enqueue(
         ["foo", "foo", "foo"],
@@ -147,7 +146,6 @@ async def test_next_deferred_eta_returns_soonest_of_many(apgdriver: Driver) -> N
     )
     eta = await q.next_deferred_eta(["foo"])
     assert eta is not None
-    # Soonest deferred job is the 30s one; not the 300s/120s ones.
     assert 20 < eta.total_seconds() <= 30
 
 

--- a/test/test_execute_after.py
+++ b/test/test_execute_after.py
@@ -135,6 +135,22 @@ async def test_next_deferred_eta_returns_timedelta(apgdriver: Driver) -> None:
     assert eta.total_seconds() > 5
 
 
+async def test_next_deferred_eta_returns_soonest_of_many(apgdriver: Driver) -> None:
+    """ORDER BY execute_after LIMIT 1 must return the soonest deferred job
+    (equivalent to the previous MIN(execute_after)), not an arbitrary one."""
+    q = Queries(apgdriver)
+    await q.enqueue(
+        ["foo", "foo", "foo"],
+        [None, None, None],
+        [0, 0, 0],
+        [timedelta(seconds=300), timedelta(seconds=30), timedelta(seconds=120)],
+    )
+    eta = await q.next_deferred_eta(["foo"])
+    assert eta is not None
+    # Soonest deferred job is the 30s one; not the 300s/120s ones.
+    assert 20 < eta.total_seconds() <= 30
+
+
 async def test_next_deferred_eta_inmemory(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, 0, timedelta(seconds=10))
     eta = await queries.next_deferred_eta(["ep"])

--- a/test/test_qb_upgrade_migration.py
+++ b/test/test_qb_upgrade_migration.py
@@ -52,3 +52,42 @@ def test_every_upgrade_statement_is_idempotent() -> None:
         if "ALTER COLUMN status TYPE" in stmt:
             continue
         assert any(m in stmt for m in idempotent_markers), f"non-idempotent upgrade stmt: {head}"
+
+
+# --- Performance-DDL guards (regression cover for #668 / commit e58ff3c) ---
+#
+# The dequeue speedup depends entirely on these indexes existing. A purely
+# functional test cannot see them disappear: drop the DDL and every behaviour
+# test still passes while the planner silently reverts to a Seq Scan (this is
+# exactly how #667 happened). These string-level guards fail the moment the
+# index DDL is removed or downgraded, in both install and upgrade paths.
+
+INSTALL_SQL = QueryBuilderEnvironment(settings=CUSTOM).build_install_query()
+
+
+def test_install_creates_entrypoint_leading_dequeue_indexes() -> None:
+    """The per-entrypoint LATERAL lookup requires these partial indexes."""
+    assert f"{CUSTOM.queue_table}_ep_prio_id_idx" in INSTALL_SQL
+    assert f"{CUSTOM.queue_table}_ep_ea_idx" in INSTALL_SQL
+    # The ordered shape is load-bearing: ORDER BY priority DESC, id ASC LIMIT 1
+    # is only a single index read when the index is sorted this way.
+    assert "(entrypoint, priority DESC, id ASC)" in INSTALL_SQL
+    assert "(entrypoint, execute_after)" in INSTALL_SQL
+    # Partial on the hot status keeps the indexes small.
+    assert INSTALL_SQL.count("WHERE status = 'queued'") >= 2
+
+
+def test_install_aggregation_index_is_functional_not_placeholder() -> None:
+    """The log aggregation index must carry real columns, not the ((1)) stub
+    that forced a Seq Scan for ``WHERE NOT aggregated`` queries."""
+    assert "((1))" not in INSTALL_SQL
+    assert "(entrypoint, priority, status, created) WHERE not aggregated" in INSTALL_SQL
+
+
+def test_upgrade_creates_performance_indexes() -> None:
+    """Existing deployments must gain the same indexes via ``pgq upgrade``."""
+    upgrade_sql = _upgrade_sql()
+    assert f"{CUSTOM.queue_table}_ep_prio_id_idx" in upgrade_sql
+    assert f"{CUSTOM.queue_table}_ep_ea_idx" in upgrade_sql
+    assert "((1))" not in upgrade_sql
+    assert "(entrypoint, priority, status, created) WHERE not aggregated" in upgrade_sql

--- a/test/test_qb_upgrade_migration.py
+++ b/test/test_qb_upgrade_migration.py
@@ -54,38 +54,26 @@ def test_every_upgrade_statement_is_idempotent() -> None:
         assert any(m in stmt for m in idempotent_markers), f"non-idempotent upgrade stmt: {head}"
 
 
-# --- Performance-DDL guards (regression cover for #668 / commit e58ff3c) ---
-#
-# The dequeue speedup depends entirely on these indexes existing. A purely
-# functional test cannot see them disappear: drop the DDL and every behaviour
-# test still passes while the planner silently reverts to a Seq Scan (this is
-# exactly how #667 happened). These string-level guards fail the moment the
-# index DDL is removed or downgraded, in both install and upgrade paths.
-
 INSTALL_SQL = QueryBuilderEnvironment(settings=CUSTOM).build_install_query()
 
 
 def test_install_creates_entrypoint_leading_dequeue_indexes() -> None:
-    """The per-entrypoint LATERAL lookup requires these partial indexes."""
+    """Install creates the partial indexes the dequeue LATERAL relies on (#668)."""
     assert f"{CUSTOM.queue_table}_ep_prio_id_idx" in INSTALL_SQL
     assert f"{CUSTOM.queue_table}_ep_ea_idx" in INSTALL_SQL
-    # The ordered shape is load-bearing: ORDER BY priority DESC, id ASC LIMIT 1
-    # is only a single index read when the index is sorted this way.
     assert "(entrypoint, priority DESC, id ASC)" in INSTALL_SQL
     assert "(entrypoint, execute_after)" in INSTALL_SQL
-    # Partial on the hot status keeps the indexes small.
     assert INSTALL_SQL.count("WHERE status = 'queued'") >= 2
 
 
 def test_install_aggregation_index_is_functional_not_placeholder() -> None:
-    """The log aggregation index must carry real columns, not the ((1)) stub
-    that forced a Seq Scan for ``WHERE NOT aggregated`` queries."""
+    """Log aggregation index is the real composite, not the ((1)) placeholder (#668)."""
     assert "((1))" not in INSTALL_SQL
     assert "(entrypoint, priority, status, created) WHERE not aggregated" in INSTALL_SQL
 
 
 def test_upgrade_creates_performance_indexes() -> None:
-    """Existing deployments must gain the same indexes via ``pgq upgrade``."""
+    """pgq upgrade adds the same dequeue and aggregation indexes (#668)."""
     upgrade_sql = _upgrade_sql()
     assert f"{CUSTOM.queue_table}_ep_prio_id_idx" in upgrade_sql
     assert f"{CUSTOM.queue_table}_ep_ea_idx" in upgrade_sql

--- a/test/test_qb_upgrade_migration.py
+++ b/test/test_qb_upgrade_migration.py
@@ -52,30 +52,3 @@ def test_every_upgrade_statement_is_idempotent() -> None:
         if "ALTER COLUMN status TYPE" in stmt:
             continue
         assert any(m in stmt for m in idempotent_markers), f"non-idempotent upgrade stmt: {head}"
-
-
-INSTALL_SQL = QueryBuilderEnvironment(settings=CUSTOM).build_install_query()
-
-
-def test_install_creates_entrypoint_leading_dequeue_indexes() -> None:
-    """Install creates the partial indexes the dequeue LATERAL relies on (#668)."""
-    assert f"{CUSTOM.queue_table}_ep_prio_id_idx" in INSTALL_SQL
-    assert f"{CUSTOM.queue_table}_ep_ea_idx" in INSTALL_SQL
-    assert "(entrypoint, priority DESC, id ASC)" in INSTALL_SQL
-    assert "(entrypoint, execute_after)" in INSTALL_SQL
-    assert INSTALL_SQL.count("WHERE status = 'queued'") >= 2
-
-
-def test_install_aggregation_index_is_functional_not_placeholder() -> None:
-    """Log aggregation index is the real composite, not the ((1)) placeholder (#668)."""
-    assert "((1))" not in INSTALL_SQL
-    assert "(entrypoint, priority, status, created) WHERE not aggregated" in INSTALL_SQL
-
-
-def test_upgrade_creates_performance_indexes() -> None:
-    """pgq upgrade adds the same dequeue and aggregation indexes (#668)."""
-    upgrade_sql = _upgrade_sql()
-    assert f"{CUSTOM.queue_table}_ep_prio_id_idx" in upgrade_sql
-    assert f"{CUSTOM.queue_table}_ep_ea_idx" in upgrade_sql
-    assert "((1))" not in upgrade_sql
-    assert "(entrypoint, priority, status, created) WHERE not aggregated" in upgrade_sql

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -204,6 +204,56 @@ async def test_queue_priority(
     assert jobs == sorted(jobs, key=lambda x: x.priority, reverse=True)
 
 
+@pytest.mark.parametrize("batch_size", (1, 3, 10))
+async def test_queue_priority_across_entrypoints(
+    apgdriver: db.Driver,
+    batch_size: int,
+) -> None:
+    """Draining several entrypoints at once must yield a single global
+    ``priority DESC, id ASC`` order, not a per-entrypoint order.
+
+    Exercises the per-entrypoint ``CROSS JOIN LATERAL`` lookup plus the
+    cross-entrypoint merge in build_dequeue_query: each entrypoint is probed
+    independently, then the picks are merged. Priorities are interleaved and
+    tied across entrypoints so the ``id ASC`` tiebreak is exercised between
+    different entrypoints, not just within one.
+    """
+    q = queries.Queries(apgdriver)
+
+    entrypoints = ["alpha", "beta", "gamma"]
+    # Interleave entrypoints with repeating priorities so equal priorities
+    # land on different entrypoints (forces a cross-entrypoint id tiebreak).
+    enqueue_ep = [entrypoints[n % len(entrypoints)] for n in range(60)]
+    enqueue_prio = [n % 5 for n in range(60)]
+
+    await q.enqueue(
+        enqueue_ep,
+        [f"{n}".encode() for n in range(60)],
+        enqueue_prio,
+    )
+
+    drained = list[models.Job]()
+    while next_jobs := await q.dequeue(
+        entrypoints={ep: queries.EntrypointExecutionParameter(0) for ep in entrypoints},
+        batch_size=batch_size,
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=1000,
+        heartbeat_timeout=timedelta(seconds=30),
+    ):
+        # Each individual batch is globally ordered.
+        assert next_jobs == sorted(next_jobs, key=lambda j: (-j.priority, j.id))
+        for job in next_jobs:
+            drained.append(job)
+            await q.log_jobs([(job, "successful", None)])
+
+    # Every job drained exactly once.
+    assert len(drained) == 60
+    assert len({job.id for job in drained}) == 60
+    # Full drain order is the global priority DESC, id ASC order, spanning
+    # all entrypoints (not segmented by entrypoint).
+    assert drained == sorted(drained, key=lambda j: (-j.priority, j.id))
+
+
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_retry_timer(
     apgdriver: db.Driver,

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -209,20 +209,11 @@ async def test_queue_priority_across_entrypoints(
     apgdriver: db.Driver,
     batch_size: int,
 ) -> None:
-    """Draining several entrypoints at once must yield a single global
-    ``priority DESC, id ASC`` order, not a per-entrypoint order.
-
-    Exercises the per-entrypoint ``CROSS JOIN LATERAL`` lookup plus the
-    cross-entrypoint merge in build_dequeue_query: each entrypoint is probed
-    independently, then the picks are merged. Priorities are interleaved and
-    tied across entrypoints so the ``id ASC`` tiebreak is exercised between
-    different entrypoints, not just within one.
-    """
+    """Draining several entrypoints yields one global priority DESC, id ASC order (#668)."""
     q = queries.Queries(apgdriver)
 
     entrypoints = ["alpha", "beta", "gamma"]
-    # Interleave entrypoints with repeating priorities so equal priorities
-    # land on different entrypoints (forces a cross-entrypoint id tiebreak).
+    # Tie priorities across entrypoints so the id tiebreak spans entrypoints.
     enqueue_ep = [entrypoints[n % len(entrypoints)] for n in range(60)]
     enqueue_prio = [n % 5 for n in range(60)]
 
@@ -240,17 +231,13 @@ async def test_queue_priority_across_entrypoints(
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
-        # Each individual batch is globally ordered.
         assert next_jobs == sorted(next_jobs, key=lambda j: (-j.priority, j.id))
         for job in next_jobs:
             drained.append(job)
             await q.log_jobs([(job, "successful", None)])
 
-    # Every job drained exactly once.
     assert len(drained) == 60
     assert len({job.id for job in drained}) == 60
-    # Full drain order is the global priority DESC, id ASC order, spanning
-    # all entrypoints (not segmented by entrypoint).
     assert drained == sorted(drained, key=lambda j: (-j.priority, j.id))
 
 
@@ -259,14 +246,7 @@ async def test_dequeue_caps_at_batch_size_across_entrypoints(
     apgdriver: db.Driver,
     batch_size: int,
 ) -> None:
-    """A single dequeue must return at most ``batch_size`` jobs total, even
-    when many entrypoints each have eligible work.
-
-    build_dequeue_query fans out one ``LIMIT $1`` lookup per entrypoint via
-    CROSS JOIN LATERAL; only the outer cap stops a single call from claiming
-    ``batch_size * n_entrypoints`` rows. Regression guard for that cap (the
-    per-entrypoint-slots churn in #668).
-    """
+    """A single dequeue returns at most batch_size jobs total across all entrypoints (#668)."""
     q = queries.Queries(apgdriver)
 
     entrypoints = ["a", "b", "c", "d"]
@@ -284,29 +264,20 @@ async def test_dequeue_caps_at_batch_size_across_entrypoints(
         heartbeat_timeout=timedelta(seconds=30),
     )
 
-    # Exactly batch_size while work remains; never batch_size * n_entrypoints.
     assert len(picked) == min(batch_size, total)
 
 
 async def test_has_queued_work_existence_contract(apgdriver: db.Driver) -> None:
-    """has_queued_work is an existence probe (COUNT over a LIMIT 1 subquery).
-
-    It must report positive when queued work exists for the requested
-    entrypoints, zero when empty, ignore other entrypoints, and not count
-    already-picked rows (status != 'queued').
-    """
+    """queued_work reports positive when work exists, zero otherwise, ignoring picked rows."""
     q = queries.Queries(apgdriver)
 
-    # Empty queue.
     assert await q.queued_work(["foo"]) == 0
 
     await q.enqueue(["foo"] * 3, [None] * 3, [0] * 3)
 
-    # Queued work present for foo, but not for an unrelated entrypoint.
     assert await q.queued_work(["foo"]) > 0
     assert await q.queued_work(["bar"]) == 0
 
-    # Pick everything; picked rows are not 'queued', so the probe drops to 0.
     picked = await q.dequeue(
         batch_size=10,
         entrypoints={"foo": queries.EntrypointExecutionParameter(0)},

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -254,6 +254,70 @@ async def test_queue_priority_across_entrypoints(
     assert drained == sorted(drained, key=lambda j: (-j.priority, j.id))
 
 
+@pytest.mark.parametrize("batch_size", (1, 5, 7))
+async def test_dequeue_caps_at_batch_size_across_entrypoints(
+    apgdriver: db.Driver,
+    batch_size: int,
+) -> None:
+    """A single dequeue must return at most ``batch_size`` jobs total, even
+    when many entrypoints each have eligible work.
+
+    build_dequeue_query fans out one ``LIMIT $1`` lookup per entrypoint via
+    CROSS JOIN LATERAL; only the outer cap stops a single call from claiming
+    ``batch_size * n_entrypoints`` rows. Regression guard for that cap (the
+    per-entrypoint-slots churn in #668).
+    """
+    q = queries.Queries(apgdriver)
+
+    entrypoints = ["a", "b", "c", "d"]
+    per_ep = 5
+    enqueue_ep = [ep for ep in entrypoints for _ in range(per_ep)]
+    total = len(enqueue_ep)
+
+    await q.enqueue(enqueue_ep, [None] * total, [0] * total)
+
+    picked = await q.dequeue(
+        batch_size=batch_size,
+        entrypoints={ep: queries.EntrypointExecutionParameter(0) for ep in entrypoints},
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=1000,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+
+    # Exactly batch_size while work remains; never batch_size * n_entrypoints.
+    assert len(picked) == min(batch_size, total)
+
+
+async def test_has_queued_work_existence_contract(apgdriver: db.Driver) -> None:
+    """has_queued_work is an existence probe (COUNT over a LIMIT 1 subquery).
+
+    It must report positive when queued work exists for the requested
+    entrypoints, zero when empty, ignore other entrypoints, and not count
+    already-picked rows (status != 'queued').
+    """
+    q = queries.Queries(apgdriver)
+
+    # Empty queue.
+    assert await q.queued_work(["foo"]) == 0
+
+    await q.enqueue(["foo"] * 3, [None] * 3, [0] * 3)
+
+    # Queued work present for foo, but not for an unrelated entrypoint.
+    assert await q.queued_work(["foo"]) > 0
+    assert await q.queued_work(["bar"]) == 0
+
+    # Pick everything; picked rows are not 'queued', so the probe drops to 0.
+    picked = await q.dequeue(
+        batch_size=10,
+        entrypoints={"foo": queries.EntrypointExecutionParameter(0)},
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=1000,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert len(picked) == 3
+    assert await q.queued_work(["foo"]) == 0
+
+
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_retry_timer(
     apgdriver: db.Driver,

--- a/test/test_query_plan_regression.py
+++ b/test/test_query_plan_regression.py
@@ -1,17 +1,4 @@
-"""Plan-shape regression guards for the dequeue path (commit e58ff3c, #668).
-
-Functional tests prove the queries return the right rows; they are blind to
-the planner silently reverting to a Seq Scan over the whole queue (issue #667).
-These tests seed a backlog, ANALYZE, then assert via EXPLAIN that the hot
-queries still hit the entrypoint-leading indexes / keep their O(1) shape.
-
-EXPLAIN (without ANALYZE) only plans — it neither executes nor claims rows —
-so the seeded jobs stay queued and the plans are stable.
-
-Note: a Seq Scan on the queue table is NOT asserted-against globally — the
-``claimed`` UPDATE step legitimately seq-scans a tiny id-list at small N. The
-assertions target the specific hot-path nodes that carried the #668 win.
-"""
+"""EXPLAIN guards that the dequeue path still hits the entrypoint-leading indexes (#668)."""
 
 from __future__ import annotations
 
@@ -27,11 +14,11 @@ EP_PRIO_ID_IDX = f"{QUEUE_TABLE}_ep_prio_id_idx"
 EP_EA_IDX = f"{QUEUE_TABLE}_ep_ea_idx"
 
 ENTRYPOINTS = ["a", "b", "c", "d"]
-SEED = 3000  # large enough that the planner prefers the index over a Seq Scan
+# Large enough that the planner prefers the index over a Seq Scan.
+SEED = 3000
 
 
 def _flatten(node: dict) -> list[dict]:
-    """Depth-first list of every plan node."""
     out = [node]
     children = node.get("Plans")
     if isinstance(children, list):
@@ -56,8 +43,7 @@ async def _seed(driver: db.Driver) -> queries.Queries:
 
 
 async def test_dequeue_uses_entrypoint_priority_index(apgdriver: db.Driver) -> None:
-    """The per-entrypoint LATERAL must read the (entrypoint, priority, id)
-    partial index, not Seq-Scan + Sort the whole queue (issue #667)."""
+    """Dequeue's LATERAL reads the (entrypoint, priority, id) index, not a Seq Scan (#667)."""
     q = await _seed(apgdriver)
     nodes = await _plan_nodes(
         apgdriver,
@@ -69,22 +55,20 @@ async def test_dequeue_uses_entrypoint_priority_index(apgdriver: db.Driver) -> N
         1000,
         timedelta(seconds=30),
     )
-    index_scans = [
+    used = [
         n
         for n in nodes
         if "Index" in (n.get("Node Type") or "") and n.get("Index Name") == EP_PRIO_ID_IDX
     ]
-    assert index_scans, (
+    assert used, (
         f"dequeue plan no longer uses {EP_PRIO_ID_IDX}; "
         f"nodes={[(n.get('Node Type'), n.get('Index Name')) for n in nodes]}"
     )
 
 
 async def test_next_deferred_eta_uses_execute_after_index(apgdriver: db.Driver) -> None:
-    """next_deferred_eta must read the (entrypoint, execute_after) index with a
-    LIMIT, not aggregate (MIN) over a full scan."""
+    """next_deferred_eta reads the (entrypoint, execute_after) index with a LIMIT (#668)."""
     q = await _seed(apgdriver)
-    # Defer some jobs so there is an eligible deferred row to plan against.
     await q.enqueue(
         ENTRYPOINTS,
         [None] * len(ENTRYPOINTS),
@@ -97,13 +81,11 @@ async def test_next_deferred_eta_uses_execute_after_index(apgdriver: db.Driver) 
         f"eta plan no longer uses {EP_EA_IDX}; "
         f"nodes={[(n.get('Node Type'), n.get('Index Name')) for n in nodes]}"
     )
-    # The MIN->ORDER BY LIMIT 1 rewrite must keep a Limit node.
     assert any(n.get("Node Type") == "Limit" for n in nodes), "eta lost its LIMIT shape"
 
 
 async def test_has_queued_work_is_existence_probe(apgdriver: db.Driver) -> None:
-    """has_queued_work must keep the LIMIT 1 existence shape, not revert to a
-    full COUNT(*) aggregate over every queued row."""
+    """has_queued_work keeps its LIMIT 1 existence shape, not a full COUNT(*) (#668)."""
     q = await _seed(apgdriver)
     nodes = await _plan_nodes(apgdriver, q.qbq.build_has_queued_work(), ENTRYPOINTS)
     assert any(n.get("Node Type") == "Limit" for n in nodes), (

--- a/test/test_query_plan_regression.py
+++ b/test/test_query_plan_regression.py
@@ -1,0 +1,112 @@
+"""Plan-shape regression guards for the dequeue path (commit e58ff3c, #668).
+
+Functional tests prove the queries return the right rows; they are blind to
+the planner silently reverting to a Seq Scan over the whole queue (issue #667).
+These tests seed a backlog, ANALYZE, then assert via EXPLAIN that the hot
+queries still hit the entrypoint-leading indexes / keep their O(1) shape.
+
+EXPLAIN (without ANALYZE) only plans — it neither executes nor claims rows —
+so the seeded jobs stay queued and the plans are stable.
+
+Note: a Seq Scan on the queue table is NOT asserted-against globally — the
+``claimed`` UPDATE step legitimately seq-scans a tiny id-list at small N. The
+assertions target the specific hot-path nodes that carried the #668 win.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import timedelta
+
+from pgqueuer import db, queries
+from pgqueuer.adapters.persistence import qb
+
+QUEUE_TABLE = qb.DBSettings().queue_table
+EP_PRIO_ID_IDX = f"{QUEUE_TABLE}_ep_prio_id_idx"
+EP_EA_IDX = f"{QUEUE_TABLE}_ep_ea_idx"
+
+ENTRYPOINTS = ["a", "b", "c", "d"]
+SEED = 3000  # large enough that the planner prefers the index over a Seq Scan
+
+
+def _flatten(node: dict) -> list[dict]:
+    """Depth-first list of every plan node."""
+    out = [node]
+    children = node.get("Plans")
+    if isinstance(children, list):
+        for child in children:
+            out.extend(_flatten(child))
+    return out
+
+
+async def _plan_nodes(driver: db.Driver, sql: str, *args: object) -> list[dict]:
+    rows = await driver.fetch("EXPLAIN (FORMAT JSON) " + sql, *args)
+    raw = rows[0]["QUERY PLAN"]
+    plan = json.loads(raw) if isinstance(raw, str) else raw
+    return _flatten(plan[0]["Plan"])
+
+
+async def _seed(driver: db.Driver) -> queries.Queries:
+    q = queries.Queries(driver)
+    eps = [ENTRYPOINTS[i % len(ENTRYPOINTS)] for i in range(SEED)]
+    await q.enqueue(eps, [None] * SEED, [i % 7 for i in range(SEED)])
+    await driver.execute(f"ANALYZE {QUEUE_TABLE};")
+    return q
+
+
+async def test_dequeue_uses_entrypoint_priority_index(apgdriver: db.Driver) -> None:
+    """The per-entrypoint LATERAL must read the (entrypoint, priority, id)
+    partial index, not Seq-Scan + Sort the whole queue (issue #667)."""
+    q = await _seed(apgdriver)
+    nodes = await _plan_nodes(
+        apgdriver,
+        q.qbq.build_dequeue_query(),
+        10,
+        ENTRYPOINTS,
+        [0] * len(ENTRYPOINTS),
+        uuid.uuid4(),
+        1000,
+        timedelta(seconds=30),
+    )
+    index_scans = [
+        n
+        for n in nodes
+        if "Index" in (n.get("Node Type") or "") and n.get("Index Name") == EP_PRIO_ID_IDX
+    ]
+    assert index_scans, (
+        f"dequeue plan no longer uses {EP_PRIO_ID_IDX}; "
+        f"nodes={[(n.get('Node Type'), n.get('Index Name')) for n in nodes]}"
+    )
+
+
+async def test_next_deferred_eta_uses_execute_after_index(apgdriver: db.Driver) -> None:
+    """next_deferred_eta must read the (entrypoint, execute_after) index with a
+    LIMIT, not aggregate (MIN) over a full scan."""
+    q = await _seed(apgdriver)
+    # Defer some jobs so there is an eligible deferred row to plan against.
+    await q.enqueue(
+        ENTRYPOINTS,
+        [None] * len(ENTRYPOINTS),
+        [0] * len(ENTRYPOINTS),
+        [timedelta(seconds=60)] * len(ENTRYPOINTS),
+    )
+    await apgdriver.execute(f"ANALYZE {QUEUE_TABLE};")
+    nodes = await _plan_nodes(apgdriver, q.qbq.build_next_deferred_eta_query(), ENTRYPOINTS)
+    assert any(n.get("Index Name") == EP_EA_IDX for n in nodes), (
+        f"eta plan no longer uses {EP_EA_IDX}; "
+        f"nodes={[(n.get('Node Type'), n.get('Index Name')) for n in nodes]}"
+    )
+    # The MIN->ORDER BY LIMIT 1 rewrite must keep a Limit node.
+    assert any(n.get("Node Type") == "Limit" for n in nodes), "eta lost its LIMIT shape"
+
+
+async def test_has_queued_work_is_existence_probe(apgdriver: db.Driver) -> None:
+    """has_queued_work must keep the LIMIT 1 existence shape, not revert to a
+    full COUNT(*) aggregate over every queued row."""
+    q = await _seed(apgdriver)
+    nodes = await _plan_nodes(apgdriver, q.qbq.build_has_queued_work(), ENTRYPOINTS)
+    assert any(n.get("Node Type") == "Limit" for n in nodes), (
+        "has_queued_work lost its LIMIT 1 existence-probe shape; "
+        f"nodes={[n.get('Node Type') for n in nodes]}"
+    )

--- a/test/test_schema_dequeue_indexes.py
+++ b/test/test_schema_dequeue_indexes.py
@@ -1,4 +1,4 @@
-"""Schema-level checks that the dequeue indexes exist and survive upgrade (#668)."""
+"""Behavioral check that pgq upgrade delivers the dequeue indexes (#668)."""
 
 from __future__ import annotations
 
@@ -7,13 +7,6 @@ from pgqueuer.adapters.persistence import qb
 
 QUEUE_TABLE = qb.DBSettings().queue_table
 DEQUEUE_INDEXES = [f"{QUEUE_TABLE}_ep_prio_id_idx", f"{QUEUE_TABLE}_ep_ea_idx"]
-
-
-async def test_install_creates_dequeue_indexes(apgdriver: db.Driver) -> None:
-    """A freshly installed schema has the entrypoint-leading dequeue indexes (#668)."""
-    q = queries.Queries(apgdriver)
-    for index in DEQUEUE_INDEXES:
-        assert await q.table_has_index(QUEUE_TABLE, index)
 
 
 async def test_upgrade_recreates_dropped_dequeue_indexes(apgdriver: db.Driver) -> None:

--- a/test/test_schema_dequeue_indexes.py
+++ b/test/test_schema_dequeue_indexes.py
@@ -1,0 +1,29 @@
+"""Schema-level checks that the dequeue indexes exist and survive upgrade (#668)."""
+
+from __future__ import annotations
+
+from pgqueuer import db, queries
+from pgqueuer.adapters.persistence import qb
+
+QUEUE_TABLE = qb.DBSettings().queue_table
+DEQUEUE_INDEXES = [f"{QUEUE_TABLE}_ep_prio_id_idx", f"{QUEUE_TABLE}_ep_ea_idx"]
+
+
+async def test_install_creates_dequeue_indexes(apgdriver: db.Driver) -> None:
+    """A freshly installed schema has the entrypoint-leading dequeue indexes (#668)."""
+    q = queries.Queries(apgdriver)
+    for index in DEQUEUE_INDEXES:
+        assert await q.table_has_index(QUEUE_TABLE, index)
+
+
+async def test_upgrade_recreates_dropped_dequeue_indexes(apgdriver: db.Driver) -> None:
+    """pgq upgrade re-creates the dequeue indexes when they are missing (#668)."""
+    q = queries.Queries(apgdriver)
+    for index in DEQUEUE_INDEXES:
+        await apgdriver.execute(f"DROP INDEX {index};")
+        assert not await q.table_has_index(QUEUE_TABLE, index)
+
+    await q.upgrade()
+
+    for index in DEQUEUE_INDEXES:
+        assert await q.table_has_index(QUEUE_TABLE, index)


### PR DESCRIPTION
build_dequeue_query selects per-entrypoint candidates via CROSS JOIN LATERAL, then merges them. Existing test_queue_priority only covers a single entrypoint, so the cross-entrypoint merge (and the id-ASC tiebreak between different entrypoints) was unverified.

Add test_queue_priority_across_entrypoints: enqueue interleaved entrypoints with priorities tied across them, drain at batch_size 1/3/10, and assert both each batch and the full drain follow the global priority DESC, id ASC order. Guards against a future change segmenting order by entrypoint.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
