### PR TITLE
fix(schema): rebuild aggregation index on upgrade

### DIFF
--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -85,7 +85,7 @@ class QueryBuilderEnvironment:
         traceback JSONB DEFAULT NULL,
         aggregated BOOLEAN DEFAULT FALSE
     );
-    CREATE INDEX {s.queue_table_log}_not_aggregated ON {qn.queue_table_log} (entrypoint, priority, status, created) WHERE not aggregated;
+    CREATE INDEX {s.queue_table_log}_not_aggregated ON {qn.queue_table_log} ((1)) WHERE not aggregated;
     CREATE INDEX {s.queue_table_log}_created ON {qn.queue_table_log} (created);
     CREATE INDEX {s.queue_table_log}_status ON {qn.queue_table_log} (status);
     CREATE INDEX {s.queue_table_log}_job_id_status ON {qn.queue_table_log} (job_id, created DESC);
@@ -253,7 +253,7 @@ class QueryBuilderEnvironment:
         entrypoint TEXT NOT NULL,
         aggregated BOOLEAN DEFAULT FALSE
     );"""
-        yield f"CREATE INDEX IF NOT EXISTS {s.queue_table_log}_not_aggregated ON {qn.queue_table_log} (entrypoint, priority, status, created) WHERE not aggregated;"  # noqa
+        yield f"CREATE INDEX IF NOT EXISTS {s.queue_table_log}_not_aggregated ON {qn.queue_table_log} ((1)) WHERE not aggregated;"  # noqa
         yield f"CREATE INDEX IF NOT EXISTS {s.queue_table_log}_created ON {qn.queue_table_log} (created);"  # noqa
         yield f"CREATE INDEX IF NOT EXISTS {s.queue_table_log}_status ON {qn.queue_table_log} (status);"  # noqa
         yield f"ALTER TABLE {qn.queue_table_log} ADD COLUMN IF NOT EXISTS traceback JSONB DEFAULT NULL;"  # noqa: E501
@@ -265,6 +265,14 @@ class QueryBuilderEnvironment:
         yield f"ALTER TYPE {qn.queue_status_type} ADD VALUE IF NOT EXISTS 'failed';"
         yield f"CREATE INDEX IF NOT EXISTS {s.queue_table}_ep_prio_id_idx ON {qn.queue_table} (entrypoint, priority DESC, id ASC) WHERE status = 'queued';"  # noqa
         yield f"CREATE INDEX IF NOT EXISTS {s.queue_table}_ep_ea_idx ON {qn.queue_table} (entrypoint, execute_after) WHERE status = 'queued';"  # noqa
+        # #668 fattened this partial index to a 4-column composite, but the
+        # aggregation GROUP BY is on date_trunc('sec', created) (an expression),
+        # so the index ordering is never used -- the planner HashAggregates
+        # regardless, while every log insert pays to maintain the wider key.
+        # Revert to the constant-key worklist index. DROP first: CREATE INDEX
+        # IF NOT EXISTS cannot redefine an index that already exists by name.
+        yield f"DROP INDEX IF EXISTS {s.qualify(f'{s.queue_table_log}_not_aggregated')};"  # noqa
+        yield f"CREATE INDEX IF NOT EXISTS {s.queue_table_log}_not_aggregated ON {qn.queue_table_log} ((1)) WHERE not aggregated;"  # noqa
         # Widen int4 id columns to BIGINT on pre-existing installs (issue #671).
         # int4 SERIAL caps lifetime ids at ~2.1B; once exceeded inserts fail.
         # ALTER TYPE takes an ACCESS EXCLUSIVE lock and rewrites the table, so it

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -922,6 +922,44 @@ async def test_aggregate_logs_advisory_lock_skips_when_held(
     assert await _unaggregated_count(q) == 0
 
 
+async def test_upgrade_from_legacy_composite_index_still_aggregates(
+    apgdriver: db.Driver,
+) -> None:
+    """An install carrying #668's composite aggregation index upgrades and aggregates.
+
+    Reverting the index only matters if the migration SQL is sound: the
+    schema-qualified DROP must find the index, the CREATE must not collide, and
+    re-running upgrade must stay a no-op. Drive the real upgrade + aggregation
+    path against a seeded legacy composite so a broken migration fails here --
+    the index shape alone has no behavioral effect worth asserting.
+    """
+    log_table = DBSettings().queue_table_log
+    index = f"{log_table}_not_aggregated"
+    q = queries.Queries(apgdriver)
+
+    # Recreate the fattened index #668 shipped to fresh installs of its era.
+    await apgdriver.execute(f"DROP INDEX {index};")
+    await apgdriver.execute(
+        f"CREATE INDEX {index} ON {log_table} "
+        "(entrypoint, priority, status, created) WHERE not aggregated;"
+    )
+
+    # Upgrade rebuilds the index and stays idempotent across repeated runs.
+    await q.upgrade()
+    assert await q.table_has_index(log_table, index)
+    await q.upgrade()
+    assert await q.table_has_index(log_table, index)
+
+    # The aggregation path that relies on this index still folds log -> stats.
+    N = 5
+    await _log_n_successful(q, N)
+    assert await _unaggregated_count(q) > 0
+    await q.aggregate_logs()
+    assert await _unaggregated_count(q) == 0
+    stats = await q.driver.fetch(q.qbq.build_log_statistics_query(), None, None)
+    assert sum(int(r["count"]) for r in stats) == 3 * N  # queued + picked + successful
+
+
 async def test_enqueue_with_headers(apgdriver: db.Driver) -> None:
     q = queries.Queries(apgdriver)
     headers = {"trace": "abc"}


### PR DESCRIPTION
The aggregation index change in #668 edited an existing upgrade yield in place, flipping ((1)) to the composite while keeping CREATE INDEX IF NOT EXISTS. On existing deployments the index name already exists, so the statement is a no-op and the composite is never built -- the WHERE NOT aggregated speedup reaches only fresh installs.

Restore the historical yield to ((1)) and append a DROP INDEX IF EXISTS plus CREATE composite step, following the append-only idempotent migration pattern. Install DDL is unchanged (already composite).

Add a regression test that seeds the legacy ((1)) index, runs upgrade, and asserts the index is rebuilt as the composite.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
