### PR TITLE
fix(cli): expose --heartbeat-timeout on pgq run

### DIFF
--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -44,6 +44,13 @@ await pgq.run(
 With `heartbeat_timeout` set, a job that stops updating its heartbeat for the
 specified duration will be retried by the next available worker.
 
+Workers started from the command line configure the same setting with
+`--heartbeat-timeout` (in seconds):
+
+```bash
+pgq run my_module:my_factory --heartbeat-timeout 300
+```
+
 !!! note
     The default `heartbeat_timeout` is 30 seconds. Set it to match your expected
     maximum job runtime plus a safety margin to avoid prematurely re-queuing

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -205,6 +205,7 @@ Start a `QueueManager` to process jobs.
 |------|------|---------|-------------|
 | `--dequeue-timeout` | float | 30.0 | Max seconds to wait for new jobs per batch |
 | `--batch-size` | int | 10 | Jobs to dequeue per batch |
+| `--heartbeat-timeout` | float | 30.0 | Seconds without a heartbeat before a job is re-picked by another worker |
 | `--restart-delay` | float | 5.0 | Seconds between restarts when `--restart-on-failure` is set |
 | `--restart-on-failure` | bool | False | Restart the manager automatically after failures |
 | `--log-level` | str | INFO | Logging level (DEBUG, INFO, WARNING, ERROR) |

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -424,6 +424,11 @@ def run(
         "--batch-size",
         help="Number of jobs to pull from the queue at once.",
     ),
+    heartbeat_timeout: float = typer.Option(
+        30.0,
+        "--heartbeat-timeout",
+        help="Seconds without a heartbeat before a job is re-picked by another worker.",
+    ),
     restart_delay: float = typer.Option(
         5.0,
         "--restart-delay",
@@ -478,6 +483,7 @@ def run(
             mode=mode,
             max_concurrent_tasks=max_concurrent_tasks,
             shutdown_on_listener_failure=shutdown_on_listener_failure,
+            heartbeat_timeout=timedelta(seconds=heartbeat_timeout),
         )
     )
 

--- a/pgqueuer/adapters/cli/supervisor.py
+++ b/pgqueuer/adapters/cli/supervisor.py
@@ -59,6 +59,7 @@ async def runit(
     mode: types.QueueExecutionMode,
     max_concurrent_tasks: int | None,
     shutdown_on_listener_failure: bool,
+    heartbeat_timeout: timedelta = timedelta(seconds=30),
 ) -> None:
     """Supervise a manager lifecycle; optionally restart after *restart_delay* on failure.
 
@@ -80,6 +81,7 @@ async def runit(
                     mode,
                     max_concurrent_tasks,
                     shutdown_on_listener_failure,
+                    heartbeat_timeout,
                 )
         except Exception as exc:
             if not restart_on_failure:
@@ -100,6 +102,7 @@ async def run_manager(
     mode: types.QueueExecutionMode,
     max_concurrent_tasks: int | None,
     shutdown_on_listener_failure: bool,
+    heartbeat_timeout: timedelta = timedelta(seconds=30),
 ) -> None:
     """Dispatch ``run()`` on the concrete manager type.
 
@@ -113,6 +116,7 @@ async def run_manager(
             mode=mode,
             max_concurrent_tasks=max_concurrent_tasks,
             shutdown_on_listener_failure=shutdown_on_listener_failure,
+            heartbeat_timeout=heartbeat_timeout,
         )
     elif isinstance(manager, sm.SchedulerManager):
         await manager.run()
@@ -123,6 +127,7 @@ async def run_manager(
             mode=mode,
             max_concurrent_tasks=max_concurrent_tasks,
             shutdown_on_listener_failure=shutdown_on_listener_failure,
+            heartbeat_timeout=heartbeat_timeout,
         )
     else:
         raise NotImplementedError(f"Unsupported instance type: {type(manager)}")

--- a/test/test_cli_run_and_install.py
+++ b/test/test_cli_run_and_install.py
@@ -5,11 +5,13 @@ import signal
 import subprocess
 import sys
 import time
+from datetime import timedelta
 from urllib.parse import urlparse
 
 import pytest
 from typer.testing import CliRunner
 
+from pgqueuer.adapters.cli import supervisor
 from pgqueuer.adapters.cli.cli import app
 
 
@@ -167,3 +169,27 @@ def test_cli_install_upgrade_uninstall_cycle(dsn: str) -> None:
 
     # 7. verify absent again
     invoke_ok(["verify", "--expect", "absent"], base_env)
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        ([], timedelta(seconds=30)),
+        (["--heartbeat-timeout", "7"], timedelta(seconds=7)),
+    ],
+)
+def test_cli_run_forwards_heartbeat_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected: timedelta,
+) -> None:
+    """`pgq run` forwards --heartbeat-timeout (default 30s) to supervisor.runit (#674)."""
+    captured: dict[str, object] = {}
+
+    async def fake_runit(factory: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(supervisor, "runit", fake_runit)
+    result = CliRunner().invoke(app, ["run", "examples.consumer:main", *extra_args])
+    assert result.exit_code == 0, result.output
+    assert captured["heartbeat_timeout"] == expected

--- a/test/test_superviser.py
+++ b/test/test_superviser.py
@@ -287,6 +287,50 @@ async def test_run_max_concurrent_tasks_twice_batch_size(
         )
 
 
+async def test_run_manager_forwards_heartbeat_timeout_queue_manager(
+    queue_manager: QueueManager,
+) -> None:
+    """run_manager passes heartbeat_timeout through to QueueManager.run (#674)."""
+    captured: dict[str, object] = {}
+
+    async def capture_run(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    queue_manager.run = capture_run  # type: ignore[assignment]
+    await supervisor.run_manager(
+        queue_manager,
+        dequeue_timeout=timedelta(seconds=1),
+        batch_size=10,
+        mode=QueueExecutionMode.continuous,
+        max_concurrent_tasks=None,
+        shutdown_on_listener_failure=False,
+        heartbeat_timeout=timedelta(seconds=7),
+    )
+    assert captured["heartbeat_timeout"] == timedelta(seconds=7)
+
+
+async def test_run_manager_forwards_heartbeat_timeout_pg_queuer(
+    pg_queuer: PgQueuer,
+) -> None:
+    """run_manager passes heartbeat_timeout through to PgQueuer.run (#674)."""
+    captured: dict[str, object] = {}
+
+    async def capture_run(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    pg_queuer.run = capture_run  # type: ignore[assignment]
+    await supervisor.run_manager(
+        pg_queuer,
+        dequeue_timeout=timedelta(seconds=1),
+        batch_size=10,
+        mode=QueueExecutionMode.continuous,
+        max_concurrent_tasks=None,
+        shutdown_on_listener_failure=False,
+        heartbeat_timeout=timedelta(seconds=7),
+    )
+    assert captured["heartbeat_timeout"] == timedelta(seconds=7)
+
+
 async def test_shutdown_on_listener_failure(queue_manager: QueueManager) -> None:
     with pytest.raises(FailingListenerError):
         await queue_manager.listener_healthy(timedelta(seconds=0))


### PR DESCRIPTION
CLI workers were pinned to the 30s default; jobs stalling past it were re-picked and double-executed with no CLI workaround. Forward the flag through runit/run_manager to manager.run().

Closes #674

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
