### PR TITLE
fix: preserve priority when merging queued and stale jobs in dequeue

### DIFF
--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -273,19 +273,19 @@ class InMemoryQueries:
             if now - j["heartbeat"] < heartbeat_timeout:
                 continue
             candidates.append(j)
-        candidates.sort(key=lambda j: (j["heartbeat"], j["id"]))
+        candidates.sort(key=lambda j: (-j["priority"], j["id"]))
         return candidates
 
     def _select_jobs(
         self,
         batch_size: int,
-        candidates: list[dict[str, Any]],
+        candidates: list[tuple[dict[str, Any], bool]],
         entrypoints: dict[str, EntrypointExecutionParameter],
         picked_per_ep: dict[str, int],
     ) -> list[dict[str, Any]]:
         selected: list[dict[str, Any]] = []
         seen: set[int] = set()
-        for j in candidates:
+        for j, stale in candidates:
             if len(selected) >= batch_size:
                 break
             if j["id"] in seen:
@@ -295,14 +295,19 @@ class InMemoryQueries:
             ep = j["entrypoint"]
             params = entrypoints[ep]
 
+            # Stale recovery transfers ownership of a row already counted in
+            # picked_per_ep, so the concurrency gate does not apply
+            # (mirrors next_stale in qb.py).
             if (
-                params.concurrency_limit > 0
+                not stale
+                and params.concurrency_limit > 0
                 and picked_per_ep.get(ep, 0) >= params.concurrency_limit
             ):
                 continue
 
             selected.append(j)
-            picked_per_ep[ep] = picked_per_ep.get(ep, 0) + 1
+            if not stale:
+                picked_per_ep[ep] = picked_per_ep.get(ep, 0) + 1
 
         return selected
 
@@ -354,15 +359,18 @@ class InMemoryQueries:
         queued_candidates = self._collect_queued_candidates(now, entrypoints)
         retry_candidates = self._collect_retry_candidates(now, entrypoints, heartbeat_timeout)
 
+        # One global priority order so recovered stale jobs compete on priority
+        # with fresh work instead of always losing to it (mirrors eligible in qb.py).
+        candidates = sorted(
+            [(j, False) for j in queued_candidates] + [(j, True) for j in retry_candidates],
+            key=lambda c: (-c[0]["priority"], c[0]["id"]),
+        )
         selected = self._select_jobs(
             remaining,
-            queued_candidates,
+            candidates,
             entrypoints,
             picked_per_ep,
         )
-        # Stale recovery transfers ownership of a row already in picked_per_ep,
-        # so the concurrency gate does not apply (mirrors next_stale in qb.py).
-        selected.extend(retry_candidates[: remaining - len(selected)])
 
         for j in selected:
             j["status"] = "picked"

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -464,7 +464,7 @@ available AS (
 ),
 
 -- New queued jobs: per-entrypoint LATERAL lookup hits (entrypoint, priority, id) partial index.
-next_queued_src AS (
+next_queued AS (
     SELECT q.id, q.priority
     FROM available a
     CROSS JOIN LATERAL (
@@ -483,16 +483,12 @@ next_queued_src AS (
     LIMIT $1
 ),
 
-next_queued AS (
-    SELECT id FROM next_queued_src
-),
-
 -- Stale picked jobs whose heartbeat timed out. The concurrency gate from
 -- next_queued is intentionally omitted: re-picking only transfers ownership
 -- of a row already counted in `picked`, so net live execution is unchanged.
 -- Applying the gate would deadlock recovery once leaked rows fill the slot.
 next_stale AS (
-    SELECT q.id
+    SELECT q.id, q.priority
     FROM {t} q
     JOIN params p ON p.entrypoint = q.entrypoint
     WHERE q.status = 'picked'
@@ -505,14 +501,15 @@ next_stale AS (
     LIMIT $1
 ),
 
--- Merge both sets, keeping priority order, capped to batch size.
+-- Merge both sets into one global priority order so a recovered stale job
+-- competes on priority with fresh work instead of always losing to it.
 eligible AS (
     SELECT id FROM (
-        SELECT id, 0 AS src FROM next_queued
+        SELECT id, priority FROM next_queued
         UNION ALL
-        SELECT id, 1 AS src FROM next_stale
+        SELECT id, priority FROM next_stale
     ) combined
-    ORDER BY src, id
+    ORDER BY priority DESC, id ASC
     LIMIT $1
 ),
 

--- a/test/test_inmemory.py
+++ b/test/test_inmemory.py
@@ -281,6 +281,28 @@ async def test_dequeue_retry_stale_picked(queries: InMemoryQueries) -> None:
     assert jobs2[0].id == jobs[0].id
 
 
+async def test_dequeue_stale_priority_beats_fresh_work(queries: InMemoryQueries) -> None:
+    """A stale high-priority job outranks fresh lower-priority work (#684)."""
+    await queries.enqueue("ep", b"stale-hi", priority=10)
+    qm_id = uuid.uuid4()
+    params = {"ep": EntrypointExecutionParameter(0)}
+
+    picked = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
+    assert len(picked) == 1
+    stale_id = picked[0].id
+
+    from datetime import datetime, timezone
+
+    queries._jobs[int(stale_id)]["heartbeat"] = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
+    await queries.enqueue(["ep"] * 3, [b"fresh-lo"] * 3, [0] * 3)
+
+    recovered = await queries.dequeue(
+        1, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+    )
+    assert [j.id for j in recovered] == [stale_id]
+
+
 async def test_dequeue_empty_entrypoints(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     jobs = await queries.dequeue(

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -242,6 +242,36 @@ async def test_queue_priority_across_entrypoints(
     assert drained == sorted(drained, key=lambda j: (-j.priority, j.id))
 
 
+async def test_stale_job_priority_beats_fresh_work(apgdriver: db.Driver) -> None:
+    """A stale high-priority job outranks fresh lower-priority work (#684)."""
+    q = queries.Queries(apgdriver)
+    entrypoints = {"placeholder": queries.EntrypointExecutionParameter(0)}
+    heartbeat_timeout = timedelta(seconds=0.01)
+
+    await q.enqueue("placeholder", b"stale-hi", priority=10)
+    picked = await q.dequeue(
+        batch_size=10,
+        entrypoints=entrypoints,
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=1000,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert len(picked) == 1
+    stale_id = picked[0].id
+
+    await q.enqueue(["placeholder"] * 3, [b"fresh-lo"] * 3, [0] * 3)
+    await asyncio.sleep(heartbeat_timeout.total_seconds())
+
+    recovered = await q.dequeue(
+        batch_size=1,
+        entrypoints=entrypoints,
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=1000,
+        heartbeat_timeout=heartbeat_timeout,
+    )
+    assert [j.id for j in recovered] == [stale_id]
+
+
 @pytest.mark.parametrize("batch_size", (1, 5, 7))
 async def test_dequeue_caps_at_batch_size_across_entrypoints(
     apgdriver: db.Driver,


### PR DESCRIPTION
The eligible CTE ordered the merged set by (src, id), so fresh queued jobs always filled the batch ahead of recovered stale jobs and priority was dropped at the merge — a stale high-priority job could be starved indefinitely behind a stream of lower-priority fresh work. Regression from the CTE split in #607; the pre-split query ordered priority DESC, id ASC across both statuses.

Carry priority through next_queued and next_stale and order eligible by priority DESC, id ASC. Fold away the next_queued_src shim left over from #668. Apply the same merge ordering in the in-memory adapter, which shared the flaw.

Fixes #684

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
