### PR TITLE
test: drop redundant @pytest.mark.asyncio markers

### DIFF
--- a/test/test_inmemory.py
+++ b/test/test_inmemory.py
@@ -17,7 +17,6 @@ from pgqueuer.ports.repository import EntrypointExecutionParameter
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_enqueue_single(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("my_ep", b"payload", priority=5)
     assert len(ids) == 1
@@ -30,7 +29,6 @@ async def test_enqueue_single(queries: InMemoryQueries) -> None:
     assert stats[0].status == "queued"
 
 
-@pytest.mark.asyncio
 async def test_enqueue_batch(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue(
         ["a", "b", "c"],
@@ -41,7 +39,6 @@ async def test_enqueue_batch(queries: InMemoryQueries) -> None:
     assert ids[0] < ids[1] < ids[2]
 
 
-@pytest.mark.asyncio
 async def test_enqueue_returns_ids_with_priority(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", None, priority=10)
     assert len(ids) == 1
@@ -52,14 +49,12 @@ async def test_enqueue_returns_ids_with_priority(queries: InMemoryQueries) -> No
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_dedupe_key_rejects_duplicate(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, dedupe_key="unique1")
     with pytest.raises(DuplicateJobError):
         await queries.enqueue("ep", None, dedupe_key="unique1")
 
 
-@pytest.mark.asyncio
 async def test_dedupe_key_freed_after_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, dedupe_key="dk1")
     qm_id = uuid.uuid4()
@@ -162,7 +157,6 @@ async def test_dedupe_key_on_conflict_skip_freed_after_log(queries: InMemoryQuer
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_dequeue_basic(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", b"data")
     qm_id = uuid.uuid4()
@@ -179,7 +173,6 @@ async def test_dequeue_basic(queries: InMemoryQueries) -> None:
     assert jobs[0].payload == b"data"
 
 
-@pytest.mark.asyncio
 async def test_dequeue_priority_ordering(queries: InMemoryQueries) -> None:
     await queries.enqueue(
         ["ep", "ep", "ep"],
@@ -199,7 +192,6 @@ async def test_dequeue_priority_ordering(queries: InMemoryQueries) -> None:
     assert priorities == sorted(priorities, reverse=True)
 
 
-@pytest.mark.asyncio
 async def test_dequeue_execute_after(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, execute_after=timedelta(hours=1))
     qm_id = uuid.uuid4()
@@ -214,7 +206,6 @@ async def test_dequeue_execute_after(queries: InMemoryQueries) -> None:
     assert len(jobs) == 0
 
 
-@pytest.mark.asyncio
 async def test_dequeue_serialized_dispatch(queries: InMemoryQueries) -> None:
     await queries.enqueue(
         ["ep", "ep"],
@@ -233,7 +224,6 @@ async def test_dequeue_serialized_dispatch(queries: InMemoryQueries) -> None:
     assert len(jobs2) == 0
 
 
-@pytest.mark.asyncio
 async def test_dequeue_concurrency_limit(queries: InMemoryQueries) -> None:
     await queries.enqueue(
         ["ep", "ep", "ep"],
@@ -250,7 +240,6 @@ async def test_dequeue_concurrency_limit(queries: InMemoryQueries) -> None:
     assert len(jobs2) == 0
 
 
-@pytest.mark.asyncio
 async def test_dequeue_global_concurrency_limit(queries: InMemoryQueries) -> None:
     await queries.enqueue(
         ["ep", "ep", "ep"],
@@ -271,7 +260,6 @@ async def test_dequeue_global_concurrency_limit(queries: InMemoryQueries) -> Non
     assert len(jobs2) == 0
 
 
-@pytest.mark.asyncio
 async def test_dequeue_retry_stale_picked(queries: InMemoryQueries) -> None:
     """Picked jobs with expired heartbeat should be retried."""
     await queries.enqueue("ep", None)
@@ -293,7 +281,6 @@ async def test_dequeue_retry_stale_picked(queries: InMemoryQueries) -> None:
     assert jobs2[0].id == jobs[0].id
 
 
-@pytest.mark.asyncio
 async def test_dequeue_empty_entrypoints(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     jobs = await queries.dequeue(
@@ -302,7 +289,6 @@ async def test_dequeue_empty_entrypoints(queries: InMemoryQueries) -> None:
     assert len(jobs) == 0
 
 
-@pytest.mark.asyncio
 async def test_dequeue_batch_size_validation(queries: InMemoryQueries) -> None:
     with pytest.raises(ValueError):
         await queries.dequeue(0, {}, uuid.uuid4(), None, heartbeat_timeout=timedelta(seconds=30))
@@ -313,7 +299,6 @@ async def test_dequeue_batch_size_validation(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_log_jobs_removes_from_queue(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     qm_id = uuid.uuid4()
@@ -330,7 +315,6 @@ async def test_log_jobs_removes_from_queue(queries: InMemoryQueries) -> None:
     assert len(stats) == 0
 
 
-@pytest.mark.asyncio
 async def test_log_jobs_adds_to_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     qm_id = uuid.uuid4()
@@ -353,7 +337,6 @@ async def test_log_jobs_adds_to_log(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_mark_job_as_cancelled(queries: InMemoryQueries, driver: InMemoryDriver) -> None:
     notifications: list[str] = []
     await driver.add_listener(queries.qbq.settings.channel, notifications.append)
@@ -373,7 +356,6 @@ async def test_mark_job_as_cancelled(queries: InMemoryQueries, driver: InMemoryD
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_clear_queue_truncate(queries: InMemoryQueries) -> None:
     await queries.enqueue(["a", "b"], [None, None], [0, 0])
     await queries.clear_queue()
@@ -387,7 +369,6 @@ async def test_clear_queue_truncate(queries: InMemoryQueries) -> None:
     assert len(deleted_entries) == 0
 
 
-@pytest.mark.asyncio
 async def test_clear_queue_filtered(queries: InMemoryQueries) -> None:
     await queries.enqueue(["a", "b"], [None, None], [0, 0])
     await queries.clear_queue("a")
@@ -407,7 +388,6 @@ async def test_clear_queue_filtered(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_update_heartbeat(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     qm_id = uuid.uuid4()
@@ -430,7 +410,6 @@ async def test_update_heartbeat(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_queue_log_lifecycle(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     qm_id = uuid.uuid4()
@@ -455,7 +434,6 @@ async def test_queue_log_lifecycle(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_log_statistics(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     qm_id = uuid.uuid4()
@@ -478,7 +456,6 @@ async def test_log_statistics(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_job_status(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", None)
     qm_id = uuid.uuid4()
@@ -501,7 +478,6 @@ async def test_job_status(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_queued_work(queries: InMemoryQueries) -> None:
     await queries.enqueue(["ep", "ep", "other"], [None, None, None], [0, 0, 0])
     count = await queries.queued_work(["ep"])
@@ -513,7 +489,6 @@ async def test_queued_work(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_schedule_lifecycle(queries: InMemoryQueries) -> None:
     from pgqueuer.domain.models import CronExpressionEntrypoint
     from pgqueuer.domain.types import CronEntrypoint, CronExpression
@@ -549,7 +524,6 @@ async def test_schedule_lifecycle(queries: InMemoryQueries) -> None:
     assert len(schedules) == 0
 
 
-@pytest.mark.asyncio
 async def test_clear_schedule(queries: InMemoryQueries) -> None:
     from pgqueuer.domain.models import CronExpressionEntrypoint
     from pgqueuer.domain.types import CronEntrypoint, CronExpression
@@ -569,7 +543,6 @@ async def test_clear_schedule(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_table_changed_notification(queries: InMemoryQueries, driver: InMemoryDriver) -> None:
     notifications: list[str] = []
     await driver.add_listener(queries.qbq.settings.channel, notifications.append)
@@ -578,7 +551,6 @@ async def test_table_changed_notification(queries: InMemoryQueries, driver: InMe
     assert any("table_changed_event" in n for n in notifications)
 
 
-@pytest.mark.asyncio
 async def test_health_check_notification(queries: InMemoryQueries, driver: InMemoryDriver) -> None:
     notifications: list[str] = []
     await driver.add_listener(queries.qbq.settings.channel, notifications.append)
@@ -592,7 +564,6 @@ async def test_health_check_notification(queries: InMemoryQueries, driver: InMem
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_schema_methods_return_true(queries: InMemoryQueries) -> None:
     assert await queries.has_table("any_table") is True
     assert await queries.table_has_column("t", "c") is True
@@ -600,13 +571,11 @@ async def test_schema_methods_return_true(queries: InMemoryQueries) -> None:
     assert await queries.has_user_defined_enum("k", "e") is True
 
 
-@pytest.mark.asyncio
 async def test_install_upgrade_noop(queries: InMemoryQueries) -> None:
     await queries.install()
     await queries.upgrade()
 
 
-@pytest.mark.asyncio
 async def test_uninstall_clears_state(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     await queries.uninstall()
@@ -619,19 +588,16 @@ async def test_uninstall_clears_state(queries: InMemoryQueries) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_driver_context_manager(driver: InMemoryDriver) -> None:
     async with driver as d:
         assert d is driver
 
 
-@pytest.mark.asyncio
 async def test_driver_fetch_raises(driver: InMemoryDriver) -> None:
     with pytest.raises(NotImplementedError):
         await driver.fetch("SELECT 1")
 
 
-@pytest.mark.asyncio
 async def test_driver_execute_raises(driver: InMemoryDriver) -> None:
     with pytest.raises(NotImplementedError):
         await driver.execute("SELECT 1")

--- a/test/test_inmemory_integration.py
+++ b/test/test_inmemory_integration.py
@@ -6,8 +6,6 @@ import time
 import uuid
 from datetime import timedelta
 
-import pytest
-
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.core.applications import PgQueuer
 from pgqueuer.domain.models import Job
@@ -31,7 +29,6 @@ def test_in_memory_factory_creates_instance() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_qm_drain_processes_all_jobs() -> None:
     pq = PgQueuer.in_memory()
     processed: list[int] = []
@@ -61,7 +58,6 @@ async def test_qm_drain_processes_all_jobs() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_performance_enqueue_dequeue() -> None:
     """10k enqueue + dequeue cycle should complete quickly."""
     driver = InMemoryDriver()


### PR DESCRIPTION
asyncio_mode = "auto" in pyproject.toml makes the decorator a no-op; AGENTS.md already forbids it. Also removes the now-unused pytest import in test_inmemory_integration.py.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
