### PR TITLE
fix(qm): confirm empty queue with uncached count before drain shutdown

### DIFF
--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -304,7 +304,11 @@ class QueueManager:
             return
         if task_manager.tasks:
             await asyncio.sleep(0)
-        if (await cached_queued_work()) == 0 and not task_manager.tasks:
+        if task_manager.tasks or (await cached_queued_work()) != 0:
+            return
+        # The cached count may predate a RetryRequested re-queue that landed
+        # within the TTL window; confirm with an uncached read before exiting.
+        if await self.queries.queued_work(list(self.entrypoint_registry.keys())) == 0:
             self.shutdown.set()
 
     async def _maybe_health_shutdown(

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -6,6 +6,9 @@ import async_timeout
 import pytest
 
 from pgqueuer import db
+from pgqueuer.adapters.inmemory import InMemoryQueries
+from pgqueuer.core.cache import TTLCache
+from pgqueuer.core.tm import TaskManager
 from pgqueuer.models import Job, Log
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
@@ -218,3 +221,44 @@ async def test_max_concurrent_tasks(
         )
 
     assert len(picked_jobs) == max_concurrent_tasks
+
+
+async def test_drain_shutdown_ignores_stale_cached_queued_work(
+    queries: InMemoryQueries,
+) -> None:
+    qm = QueueManager(queries)
+
+    @qm.entrypoint("fetch")
+    async def fetch(job: Job) -> None:
+        pass
+
+    cached = TTLCache.create(
+        ttl=timedelta(hours=1),
+        on_expired=lambda: qm.queries.queued_work(["fetch"]),
+    )
+    assert await cached() == 0
+
+    # A job enqueued after the cache refresh (e.g. a RetryRequested re-queue)
+    # must block drain shutdown even though the cached count still reads 0.
+    await qm.queries.enqueue(["fetch"], [None], [0])
+
+    await qm._maybe_drain_shutdown(QueueExecutionMode.drain, TaskManager(), cached)
+    assert not qm.shutdown.is_set()
+
+
+async def test_drain_shutdown_sets_shutdown_when_queue_confirmed_empty(
+    queries: InMemoryQueries,
+) -> None:
+    qm = QueueManager(queries)
+
+    @qm.entrypoint("fetch")
+    async def fetch(job: Job) -> None:
+        pass
+
+    cached = TTLCache.create(
+        ttl=timedelta(hours=1),
+        on_expired=lambda: qm.queries.queued_work(["fetch"]),
+    )
+
+    await qm._maybe_drain_shutdown(QueueExecutionMode.drain, TaskManager(), cached)
+    assert qm.shutdown.is_set()


### PR DESCRIPTION
The drain check trusted a 250ms TTL cache of queued_work. A RetryRequested re-queue landing inside the TTL window while the last in-flight task finished read a stale zero and shut down, stranding the retried job in the queue. Re-check with an uncached count before setting shutdown; the cache still short-circuits busy iterations.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
