### PR TITLE
fix(qm): dispatch remaining batch jobs on shutdown instead of stranding picked rows

### DIFF
--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -408,9 +408,6 @@ class QueueManager:
                     with contextlib.suppress(asyncio.QueueEmpty):
                         notice_event_listener.get_nowait()
 
-                    if self.shutdown.is_set():
-                        break
-
                 await self._maybe_drain_shutdown(mode, task_manager, cached_queued_work)
                 await self._maybe_health_shutdown(
                     periodic_health_check_task, mode, shutdown_on_listener_failure

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -1,11 +1,14 @@
 import asyncio
+import itertools
 import uuid
 from datetime import timedelta
+from typing import Any
 
 import async_timeout
 import pytest
 
 from pgqueuer import db
+from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.models import Job, Log
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
@@ -218,3 +221,40 @@ async def test_max_concurrent_tasks(
         )
 
     assert len(picked_jobs) == max_concurrent_tasks
+
+
+async def test_shutdown_mid_batch_leaves_no_stranded_picked_jobs(
+    queries: InMemoryQueries,
+) -> None:
+    qm = QueueManager(queries)
+    processed = list[Job]()
+    batch_size = 5
+
+    @qm.entrypoint("fetch")
+    async def fetch(job: Job) -> None:
+        processed.append(job)
+
+    payloads: list[bytes | None] = [None] * (batch_size * 2)
+    await qm.queries.enqueue(
+        ["fetch"] * batch_size * 2,
+        payloads,
+        [0] * batch_size * 2,
+    )
+
+    original_dequeue = queries.dequeue
+    calls = itertools.count()
+
+    async def dequeue_then_shutdown(*args: Any, **kwargs: Any) -> list[Job]:
+        # Set shutdown while the second batch is being picked, mimicking a
+        # signal arriving after rows are marked picked but before dispatch.
+        if next(calls) == 1:
+            qm.shutdown.set()
+        return await original_dequeue(*args, **kwargs)
+
+    queries.dequeue = dequeue_then_shutdown  # type: ignore[method-assign]
+
+    async with async_timeout.timeout(10):
+        await qm.run(dequeue_timeout=timedelta(seconds=0.01), batch_size=batch_size)
+
+    assert len(processed) == batch_size * 2
+    assert sum(x.count for x in await queries.queue_size()) == 0


### PR DESCRIPTION
Breaking out of the dispatch loop on shutdown discarded the rest of an already-dequeued batch. Those rows were marked picked by this manager and were only recovered by a stale re-pick after heartbeat_timeout. fetch_jobs already stops new dequeues on shutdown, and the task manager awaits dispatched tasks on exit, so dispatching the remainder adds no shutdown latency.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
