### PR TITLE
fix(qm): probe eligible queued work before deferred eta in dequeue timeoutmeout

### DIFF
--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -560,6 +560,16 @@ class InMemoryQueries:
             1 for j in self._jobs.values() if j["status"] == "queued" and j["entrypoint"] in ep_set
         )
 
+    async def eligible_queued_work(self, entrypoints: list[str]) -> int:
+        """Like ``queued_work`` but counting only jobs whose ``execute_after`` has passed."""
+        now = utc_now()
+        ep_set = set(entrypoints)
+        return sum(
+            1
+            for j in self._jobs.values()
+            if j["status"] == "queued" and j["entrypoint"] in ep_set and j["execute_after"] <= now
+        )
+
     async def queue_log(self) -> list[models.Log]:
         return [models.Log.model_validate(entry) for entry in self._log]
 

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -542,6 +542,19 @@ SELECT * FROM claimed ORDER BY priority DESC, id ASC;
         ) sub
         """
 
+    def build_has_eligible_queued_work(self) -> str:
+        return f"""
+        SELECT COUNT(*) AS queued_work
+        FROM (
+            SELECT 1
+            FROM {self.settings.queue_table}
+            WHERE entrypoint = ANY($1)
+              AND status = 'queued'
+              AND execute_after <= NOW()
+            LIMIT 1
+        ) sub
+        """
+
     def build_enqueue_query(self, on_conflict: OnConflict = "raise") -> str:
         if on_conflict == "skip":
             # The arbiter predicate must textually match the partial unique index

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -297,6 +297,11 @@ class Queries:
         rows = await self.driver.fetch(self.qbq.build_has_queued_work(), entrypoints)
         return rows[0]["queued_work"] if rows else 0
 
+    async def eligible_queued_work(self, entrypoints: list[str]) -> int:
+        """Like ``queued_work`` but counting only jobs whose ``execute_after`` has passed."""
+        rows = await self.driver.fetch(self.qbq.build_has_eligible_queued_work(), entrypoints)
+        return rows[0]["queued_work"] if rows else 0
+
     async def clear_queue(self, entrypoint: str | list[str] | None = None) -> None:
         """Delete jobs; restrict to *entrypoint* when given, else truncate."""
         if entrypoint:

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -339,6 +339,11 @@ class QueueManager:
         eta = await self.queries.next_deferred_eta(entrypoints)
         if eta is not None and eta < dequeue_timeout:
             return max(eta, self.min_dequeue_poll_interval)
+        # A deferred job can cross its execute_after between the two probes
+        # above: the eligibility probe still saw it as deferred, the eta probe
+        # no longer sees it as future. queued_work counts both, closing the gap.
+        if eta is None and await self.queries.queued_work(entrypoints) > 0:
+            return self.min_dequeue_poll_interval
         return dequeue_timeout
 
     async def run(

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -328,16 +328,17 @@ class QueueManager:
             await periodic_health_check_task
 
     async def _effective_dequeue_timeout(self, dequeue_timeout: timedelta) -> timedelta:
-        """Return a potentially shortened timeout if a deferred job is about to become eligible."""
+        """Return a potentially shortened timeout if work is ready or a deferred job is due soon."""
         entrypoints = list(self.entrypoint_registry.keys())
+        # A job may have become eligible between the preceding dequeue and this
+        # check (TOCTOU), and its notification may already have been consumed by
+        # the per-dispatch drain. Eligible work always warrants a fast re-poll,
+        # even when deferred jobs exist.
+        if await self.queries.eligible_queued_work(entrypoints) > 0:
+            return self.min_dequeue_poll_interval
         eta = await self.queries.next_deferred_eta(entrypoints)
         if eta is not None and eta < dequeue_timeout:
             return max(eta, self.min_dequeue_poll_interval)
-        # When eta is None there are no future-deferred jobs, but a job may have
-        # become eligible between the preceding dequeue and this check (TOCTOU).
-        # If queued work exists, wake up quickly so the next iteration picks it up.
-        if eta is None and await self.queries.queued_work(entrypoints) > 0:
-            return self.min_dequeue_poll_interval
         return dequeue_timeout
 
     async def run(

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -136,6 +136,10 @@ class QueueRepositoryPort(Protocol):
 
     async def queued_work(self, entrypoints: list[str]) -> int: ...
 
+    async def eligible_queued_work(self, entrypoints: list[str]) -> int:
+        """Like ``queued_work`` but counting only jobs whose ``execute_after`` has passed."""
+        ...
+
     async def queue_log(self) -> list[models.Log]: ...
 
     async def log_statistics(

--- a/test/test_execute_after.py
+++ b/test/test_execute_after.py
@@ -228,6 +228,32 @@ async def test_effective_dequeue_timeout_toctou_fallback() -> None:
     )
 
 
+async def test_effective_dequeue_timeout_deferred_job_crossing_eligibility() -> None:
+    """A deferred job whose execute_after passes between the eligibility probe
+    and the eta probe must still trigger a fast re-poll, not a full timeout."""
+    from unittest.mock import AsyncMock, patch
+
+    pq = PgQueuer.in_memory()
+
+    @pq.entrypoint("ep")
+    async def handler(job: Job) -> None:
+        pass
+
+    # The job is queued throughout, but both probes miss it: the eligibility
+    # probe ran before execute_after passed, the eta probe after.
+    await pq.qm.queries.enqueue("ep", None, 0, timedelta(seconds=5))
+
+    with (
+        patch.object(pq.qm.queries, "eligible_queued_work", new_callable=AsyncMock, return_value=0),
+        patch.object(pq.qm.queries, "next_deferred_eta", new_callable=AsyncMock, return_value=None),
+    ):
+        timeout = await pq.qm._effective_dequeue_timeout(timedelta(seconds=30))
+
+    assert timeout == pq.qm.min_dequeue_poll_interval, (
+        f"Expected fast re-poll for job crossing eligibility, got {timeout}"
+    )
+
+
 async def test_effective_dequeue_timeout_eligible_work_beats_deferred_eta() -> None:
     """Eligible work must trigger a fast re-poll even when a deferred job exists
     (the eligible job's notification may have been coalesced away)."""

--- a/test/test_execute_after.py
+++ b/test/test_execute_after.py
@@ -226,3 +226,24 @@ async def test_effective_dequeue_timeout_toctou_fallback() -> None:
     assert timeout < timedelta(seconds=1), (
         f"Expected short timeout due to queued work, got {timeout}"
     )
+
+
+async def test_effective_dequeue_timeout_eligible_work_beats_deferred_eta() -> None:
+    """Eligible work must trigger a fast re-poll even when a deferred job exists
+    (the eligible job's notification may have been coalesced away)."""
+    pq = PgQueuer.in_memory()
+
+    @pq.entrypoint("ep")
+    async def handler(job: Job) -> None:
+        pass
+
+    # One job eligible now, one deferred far into the future.
+    await pq.qm.queries.enqueue("ep", None, 0, timedelta(seconds=-1))
+    await pq.qm.queries.enqueue("ep", None, 0, timedelta(seconds=20))
+
+    timeout = await pq.qm._effective_dequeue_timeout(timedelta(seconds=30))
+
+    # Without the eligibility check, the deferred job's ~20s eta would win.
+    assert timeout == pq.qm.min_dequeue_poll_interval, (
+        f"Expected fast re-poll for eligible work despite deferred eta, got {timeout}"
+    )

--- a/test/test_inmemory.py
+++ b/test/test_inmemory.py
@@ -506,6 +506,13 @@ async def test_queued_work(queries: InMemoryQueries) -> None:
     assert count == 2
 
 
+async def test_eligible_queued_work_excludes_deferred(queries: InMemoryQueries) -> None:
+    await queries.enqueue("ep", None, 0)
+    await queries.enqueue("ep", None, 0, execute_after=timedelta(seconds=30))
+    assert await queries.queued_work(["ep"]) == 2
+    assert await queries.eligible_queued_work(["ep"]) == 1
+
+
 # ---------------------------------------------------------------------------
 # Schedule CRUD
 # ---------------------------------------------------------------------------

--- a/test/test_port_conformance.py
+++ b/test/test_port_conformance.py
@@ -18,6 +18,7 @@ def test_queries_has_queue_repository_methods() -> None:
         "mark_job_as_cancelled",
         "update_heartbeat",
         "queued_work",
+        "eligible_queued_work",
         "queue_log",
         "job_status",
     }
@@ -65,6 +66,7 @@ def test_inmemory_has_queue_repository_methods() -> None:
         "mark_job_as_cancelled",
         "update_heartbeat",
         "queued_work",
+        "eligible_queued_work",
         "queue_log",
         "job_status",
     }

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -320,6 +320,30 @@ async def test_has_queued_work_existence_contract(apgdriver: db.Driver) -> None:
     assert await q.queued_work(["foo"]) == 0
 
 
+async def test_eligible_queued_work_excludes_deferred(apgdriver: db.Driver) -> None:
+    """eligible_queued_work ignores jobs whose execute_after is in the future."""
+    q = queries.Queries(apgdriver)
+
+    await q.enqueue("foo", None, 0)
+    await q.enqueue("foo", None, 0, execute_after=timedelta(seconds=30))
+
+    assert await q.queued_work(["foo"]) > 0
+    assert await q.eligible_queued_work(["foo"]) > 0
+
+    picked = await q.dequeue(
+        batch_size=10,
+        entrypoints={"foo": queries.EntrypointExecutionParameter(0)},
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=1000,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert len(picked) == 1
+
+    # Only the deferred job remains: still queued work, but none eligible.
+    assert await q.queued_work(["foo"]) > 0
+    assert await q.eligible_queued_work(["foo"]) == 0
+
+
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_retry_timer(
     apgdriver: db.Driver,


### PR DESCRIPTION
The TOCTOU fallback only ran when no deferred jobs existed, and queued_work counts deferred rows, so it could not signal eligible-now work. With any deferred job present, a job that became eligible right after an empty dequeue slept until the deferred eta or the full dequeue_timeout. Probe a new deferred-aware eligible_queued_work first, unconditionally.

Scoped subset of the thundering-herd-mitigation branch; the coalescing and jitter work rebases cleanly on top.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
