### PR TITLE
fix(queries): cap dequeue picks to remaining per-entrypoint and worker slots

### DIFF
--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -454,9 +454,17 @@ worker_load AS (
       AND entrypoint = ANY($2)
 ),
 
--- Entrypoints with free capacity (concurrency gate applied here instead of row-scan).
+-- Entrypoints with free capacity (concurrency gate applied here instead of
+-- row-scan). remaining is NULL for unlimited entrypoints; otherwise it caps
+-- how many rows one dequeue may pick so a single statement cannot exceed
+-- the entrypoint's concurrency_limit.
 available AS (
-    SELECT p.entrypoint
+    SELECT
+        p.entrypoint,
+        CASE
+            WHEN p.concurrency_limit <= 0 THEN NULL
+            ELSE p.concurrency_limit - COALESCE(pk.total, 0)
+        END AS remaining
     FROM params p
     LEFT JOIN picked pk ON pk.entrypoint = p.entrypoint
     WHERE p.concurrency_limit <= 0
@@ -464,6 +472,7 @@ available AS (
 ),
 
 -- New queued jobs: per-entrypoint LATERAL lookup hits (entrypoint, priority, id) partial index.
+-- LEAST($1, NULL) = $1, so unlimited entrypoints keep the full batch.
 next_queued AS (
     SELECT q.id, q.priority
     FROM available a
@@ -474,7 +483,7 @@ next_queued AS (
           AND q2.status = 'queued'
           AND q2.execute_after < NOW()
         ORDER BY q2.priority DESC, q2.id ASC
-        LIMIT $1
+        LIMIT LEAST($1, a.remaining)
         FOR UPDATE SKIP LOCKED
     ) q
     WHERE ($5::BIGINT IS NULL
@@ -503,6 +512,9 @@ next_stale AS (
 
 -- Merge both sets into one global priority order so a recovered stale job
 -- competes on priority with fresh work instead of always losing to it.
+-- The LIMIT hard-caps this worker's total picked rows at $5: the binary
+-- worker_load gates above only stop a dequeue from starting once over
+-- budget, they do not stop one batch from overshooting it.
 eligible AS (
     SELECT id FROM (
         SELECT id, priority FROM next_queued
@@ -510,7 +522,7 @@ eligible AS (
         SELECT id, priority FROM next_stale
     ) combined
     ORDER BY priority DESC, id ASC
-    LIMIT $1
+    LIMIT GREATEST(LEAST($1, COALESCE($5 - (SELECT total FROM worker_load), $1)), 0)
 ),
 
 -- Atomically claim the jobs and log the pick event.

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -320,6 +320,50 @@ async def test_has_queued_work_existence_contract(apgdriver: db.Driver) -> None:
     assert await q.queued_work(["foo"]) == 0
 
 
+async def test_dequeue_caps_picks_to_entrypoint_remaining_slots(apgdriver: db.Driver) -> None:
+    """One dequeue never picks more jobs for an entrypoint than its free slots."""
+    q = queries.Queries(apgdriver)
+
+    await q.enqueue(["tight"] * 10, [None] * 10, [0] * 10)
+    await q.enqueue(["loose"] * 10, [None] * 10, [0] * 10)
+
+    picked = await q.dequeue(
+        batch_size=10,
+        entrypoints={
+            "tight": queries.EntrypointExecutionParameter(2),
+            "loose": queries.EntrypointExecutionParameter(0),
+        },
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+
+    tight = [job for job in picked if job.entrypoint == "tight"]
+    assert len(tight) <= 2
+    assert len(picked) == 10
+
+
+async def test_dequeue_hard_caps_worker_budget(apgdriver: db.Driver) -> None:
+    """A worker's picked total never exceeds global_concurrency_limit, even mid-batch."""
+    q = queries.Queries(apgdriver)
+    queue_manager_id = uuid.uuid4()
+
+    await q.enqueue(["fetch"] * 10, [None] * 10, [0] * 10)
+
+    async def dequeue() -> list[models.Job]:
+        return await q.dequeue(
+            batch_size=4,
+            entrypoints={"fetch": queries.EntrypointExecutionParameter(0)},
+            queue_manager_id=queue_manager_id,
+            global_concurrency_limit=5,
+            heartbeat_timeout=timedelta(seconds=30),
+        )
+
+    assert len(await dequeue()) == 4
+    assert len(await dequeue()) == 1
+    assert len(await dequeue()) == 0
+
+
 @pytest.mark.parametrize("N", (1, 2, 64))
 async def test_queue_retry_timer(
     apgdriver: db.Driver,


### PR DESCRIPTION
## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
