### PR TITLE
build: check formatting in make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo "Available commands:"
 	@echo "  pytest       Run pytest"
 	@echo "  benchmark    Run benchmark"
-	@echo "  lint         Run ruff linter"
+	@echo "  lint         Run ruff linter and formatting check"
 	@echo "  import-lint  Run import linter (hex architecture validation)"
 	@echo "  typecheck    Run mypy type checks"
 	@echo "  sync         Install dependencies via uv"
@@ -20,6 +20,7 @@ benchmark:
 
 lint:
 	 uv run ruff check .
+	 uv run ruff format . --check
 
 import-lint:
 	 uv run lint-imports


### PR DESCRIPTION
CI runs ruff format --check as a separate step, but make check only ran ruff check, so format drift passed locally and failed in CI.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
