### PR TITLE
docs: clean up dash-heavy phrasing across docs

### DIFF
--- a/docs/comparisons/benchmarks.md
+++ b/docs/comparisons/benchmarks.md
@@ -23,7 +23,7 @@ Continuously enqueues and dequeues jobs for a fixed duration:
 python3 tools/benchmark.py --dequeue 5 --dequeue-batch-size 10
 ```
 
-Example output — the tool prints a settings table, a live `tqdm` progress bar, then a
+Example output: the tool prints a settings table, a live `tqdm` progress bar, then a
 results table (exact numbers depend on your environment):
 
 ```
@@ -55,7 +55,7 @@ Use this when evaluating batch processing performance rather than sustained thro
 ## asyncpg vs psycopg
 
 The figures below come from a single reference run on one machine and are illustrative
-only — run the tool in your own environment for numbers that mean anything. Both tests use
+only; run the tool in your own environment for numbers that mean anything. Both tests use
 identical settings: 10-second timer, 5 dequeue workers (batch size 10), 1 enqueue worker
 (batch size 10).
 

--- a/docs/comparisons/celery-comparison.md
+++ b/docs/comparisons/celery-comparison.md
@@ -1,6 +1,6 @@
 # PgQueuer vs Celery
 
-Celery and PgQueuer solve the same core problem -- reliable background job processing --
+Celery and PgQueuer solve the same core problem (reliable background job processing)
 with different trade-offs. This page compares them side by side so you can pick the
 right tool for your situation.
 

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -2,7 +2,7 @@
 
 PgQueuer's integration tests use [Testcontainers](https://testcontainers.com/) to launch
 an ephemeral PostgreSQL instance automatically. You no longer need to run or manage a local
-database manually — just have a container runtime available (Docker Desktop, Colima,
+database manually; just have a container runtime available (Docker Desktop, Colima,
 Rancher Desktop, etc.).
 
 ## Prerequisites

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -6,23 +6,23 @@ the questions that quickly separate configuration issues from bugs.
 
 ## 1. Connection Basics
 
-- **Autocommit drift** — psycopg defaults to transactional mode while asyncpg autocommits.
+- **Autocommit drift**: psycopg defaults to transactional mode while asyncpg autocommits.
   Verify `connection.autocommit` (or pool init hooks) so enqueued jobs become visible
   immediately.
-- **Pools returning dirty state** — Reused connections may keep open transactions or altered
+- **Pools returning dirty state**: Reused connections may keep open transactions or altered
   settings. Confirm pool size fits workload and that teardown callbacks reset state.
-- **Authentication/network churn** — Sudden bursts can hit `max_connections`, stale
+- **Authentication/network churn**: Sudden bursts can hit `max_connections`, stale
   certificates, or mismatched DSNs. Cross-check the exact DSN with `psql`, check
   `pg_hba.conf`, and ensure SSL parameters match the server.
 
 ## 2. Query Flow and Transactions
 
-- **Locked rows** — Long-lived transactions block `SELECT … FOR UPDATE SKIP LOCKED`. Inspect
+- **Locked rows**: Long-lived transactions block `SELECT … FOR UPDATE SKIP LOCKED`. Inspect
   `pg_locks` + `pg_stat_activity` for blockers and keep DDL or maintenance outside hot paths.
-- **Unexpected timeouts** — Server-side `statement_timeout` or driver-level timeouts cancel
+- **Unexpected timeouts**: Server-side `statement_timeout` or driver-level timeouts cancel
   dequeues. List active timeout settings (asyncpg `timeout`, psycopg `options`) and compare
   with production defaults.
-- **Type adapters** — Binary payloads must match table encoding. Confirm `pgqueuer` table
+- **Type adapters**: Binary payloads must match table encoding. Confirm `pgqueuer` table
   column types and ensure custom adapters/serializers are registered before enqueueing.
 
 ## 3. Driver Quirks
@@ -39,7 +39,7 @@ the questions that quickly separate configuration issues from bugs.
 - Mixing `%s` and `$1` placeholders breaks prepared statement caching.
 - Async connections must be `await conn.close()`; sync connections should stay out of asyncio
   event loops.
-- **Windows event loop** — async psycopg rejects the default `ProactorEventLoop`. Use
+- **Windows event loop**: async psycopg rejects the default `ProactorEventLoop`. Use
   `SelectorEventLoop` (e.g. `asyncio.run(main, loop_factory=asyncio.SelectorEventLoop)` on
   3.12+). The `pgq` CLI does this for you; embedded use must opt in. See
   [drivers reference](../reference/drivers.md#psycopgdriver) for full snippets.
@@ -49,7 +49,7 @@ the questions that quickly separate configuration issues from bugs.
 - Health checks may raise exceptions from `pgqueuer.errors` (e.g. `FailingListenerError`);
   capture them during service startup.
 - LISTEN/NOTIFY keeps consumers awake. Firewalls that drop idle sockets or missing
-  `pg_notify` privileges starve queues — monitor `pg_notification_queue_usage()`.
+  `pg_notify` privileges starve queues; monitor `pg_notification_queue_usage()`.
 - Payloads are stored as `bytea`; producers and consumers must agree on encoding.
 
 ## 5. Rapid Triage Questions

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -56,7 +56,7 @@ The `@entrypoint()` decorator accepts several parameters that control how jobs a
 
 | Parameter | Type | Default | Effect |
 |-----------|------|---------|--------|
-| `name` | `str` | (required) | Entrypoint name -- must match what producers enqueue |
+| `name` | `str` | (required) | Entrypoint name; must match what producers enqueue |
 | `concurrency_limit` | `int` | `0` (unlimited) | Max simultaneous jobs for this entrypoint (database-enforced globally). Use `1` for serialized processing |
 | `accepts_context` | `bool \| None` | `None` (auto-detect) | Whether to pass a `Context` to the handler. When `None`, auto-detected from the signature (a parameter annotated `Context` receives it); set `True`/`False` to override |
 | `on_failure` | `"delete" \| "hold"` | `"delete"` | Hold failed jobs for manual re-queue instead of deleting |
@@ -172,11 +172,11 @@ See [Drivers](../reference/drivers.md) for detailed guidance.
 
 These are the two runtime engines inside `PgQueuer`:
 
-- **`QueueManager`** -- listens for NOTIFY events, dequeues job batches with
+- **`QueueManager`**: listens for NOTIFY events, dequeues job batches with
   `FOR UPDATE SKIP LOCKED`, dispatches them to registered entrypoints, and updates
   job status.
 
-- **`SchedulerManager`** -- polls the `pgqueuer_schedules` table, checks which cron
+- **`SchedulerManager`**: polls the `pgqueuer_schedules` table, checks which cron
   expressions are due, and executes the corresponding registered functions.
 
 When you call `pgq run myapp:main`, both managers run concurrently in the same
@@ -190,7 +190,7 @@ PgQueuer creates four tables:
 
 | Table | Purpose |
 |-------|---------|
-| `pgqueuer` | Active job queue -- rows are INSERT'd by producers and UPDATE'd/DELETE'd by workers |
+| `pgqueuer` | Active job queue; rows are INSERT'd by producers and UPDATE'd/DELETE'd by workers |
 | `pgqueuer_log` | Append-only audit trail of completed jobs (with traceback for failed jobs) |
 | `pgqueuer_statistics` | Aggregated processing statistics per entrypoint |
 | `pgqueuer_schedules` | Cron schedule definitions and last-run timestamps |
@@ -204,8 +204,8 @@ See [Database Setup](../reference/database-setup.md) for full schema details and
 
 Now that you understand the building blocks:
 
-- **[Row Locking & SKIP LOCKED](../reference/skip-locked.md)** -- how workers claim jobs without colliding
-- **[Scheduling](../guides/scheduling.md)** -- set up cron-style recurring tasks
-- **[Concurrency Control](../guides/concurrency-control.md)** -- limit parallel job execution
-- **[Reliability](../guides/reliability.md)** -- retries, idempotency, and audit trails
-- **[Deployment](../guides/deployment.md)** -- run workers in production
+- **[Row Locking & SKIP LOCKED](../reference/skip-locked.md)**: how workers claim jobs without colliding
+- **[Scheduling](../guides/scheduling.md)**: set up cron-style recurring tasks
+- **[Concurrency Control](../guides/concurrency-control.md)**: limit parallel job execution
+- **[Reliability](../guides/reliability.md)**: retries, idempotency, and audit trails
+- **[Deployment](../guides/deployment.md)**: run workers in production

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -95,7 +95,7 @@ PgQueuer reads standard PostgreSQL environment variables:
 | `PGHOST` | Database host | `localhost` |
 | `PGPORT` | Database port | `5432` |
 | `PGUSER` | Database user | current OS user |
-| `PGPASSWORD` | Database password | — |
+| `PGPASSWORD` | Database password | (none) |
 | `PGDATABASE` | Database name | same as user |
 
 You can also pass a connection string directly when constructing drivers in code.
@@ -113,5 +113,5 @@ This prefixes all table names, the enum type, the trigger, and the NOTIFY channe
 
 ## Next Steps
 
-- **[Quick Start](quickstart.md)** -- build your first consumer and producer
-- **[Core Concepts](core-concepts.md)** -- understand the mental model behind PgQueuer
+- **[Quick Start](quickstart.md)**: build your first consumer and producer
+- **[Core Concepts](core-concepts.md)**: understand the mental model behind PgQueuer

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,7 +1,7 @@
 # Quick Start
 
 This guide walks you through creating a job consumer, enqueuing work, and monitoring
-the queue -- all in under 5 minutes.
+the queue, all in under 5 minutes.
 
 **Prerequisites:** PgQueuer installed and schema created. See [Installation](installation.md)
 if you haven't done that yet.
@@ -180,7 +180,7 @@ From another process or script, push jobs into the queue:
 
 `Queries.enqueue()` accepts lists for batch enqueuing. Each list element corresponds to one
 job. The method returns the IDs of the newly created jobs. When deduplicating with
-`dedupe_key` and `on_conflict="skip"`, the result keeps one entry per input — `None` marks
+`dedupe_key` and `on_conflict="skip"`, the result keeps one entry per input; `None` marks
 positions skipped as duplicates. See
 [Reliability & Failure Handling](../guides/reliability.md#idempotency).
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -1,7 +1,7 @@
 # Upgrading from 0.x to 1.0
 
 PgQueuer 1.0 is the first stable release. From this point on, the project
-follows [semantic versioning](https://semver.org/) strictly — patch releases
+follows [semantic versioning](https://semver.org/) strictly: patch releases
 for bug fixes, minor releases for backward-compatible features, major releases
 only when a break is unavoidable.
 
@@ -23,7 +23,7 @@ The full list of 23 numbered breaking changes lives in
    `DatabaseRetryEntrypointExecutor`.
 7. Construct `QueueManager` / `SchedulerManager` /  `CompletionWatcher` with a
    `Queries` instance rather than a raw driver.
-8. Run your test suite — most breakages surface at decoration or startup time.
+8. Run your test suite; most breakages surface at decoration or startup time.
 
 ## 1. Database schema
 
@@ -78,7 +78,7 @@ async def resize_image(job: Job) -> None:
 ```
 
 Wrap blocking calls with `asyncio.to_thread`. Drop imports of `SyncEntrypoint`
-and `SyncContextEntrypoint` — both are removed.
+and `SyncContextEntrypoint`: both are removed.
 
 ## 3. Factory functions are async context managers
 
@@ -86,7 +86,7 @@ and `SyncContextEntrypoint` — both are removed.
 functions that return a value, and `@contextmanager` factories, are rejected.
 
 ```python
-# Before — any of these worked
+# Before: any of these worked
 async def factory() -> PgQueuer:
     return PgQueuer(...)
 
@@ -110,7 +110,7 @@ async def factory():
 ```
 
 Replace any `from pgqueuer.factories import run_factory` with
-`validate_factory_result` — the new name validates the type but does not
+`validate_factory_result`: the new name validates the type but does not
 convert it.
 
 ## 4. CLI connection options
@@ -127,7 +127,7 @@ pgq --pg-host db.internal --pg-user app --pg-database queue install
 # After
 PGHOST=db.internal PGUSER=app PGDATABASE=queue pgq install
 
-# Custom schema — use PGOPTIONS
+# Custom schema: use PGOPTIONS
 PGOPTIONS="-csearch_path=myschema" pgq install
 ```
 
@@ -235,7 +235,7 @@ sm = SchedulerManager(queries)
 watcher = CompletionWatcher(driver, queries=queries)
 ```
 
-`PgQueuer(driver)` is **unchanged** — it still accepts a driver and constructs
+`PgQueuer(driver)` is **unchanged**: it still accepts a driver and constructs
 `Queries` internally. Most user code only touches `PgQueuer`.
 
 Replace `qm.connection` / `sm.connection` accesses with `qm.queries.driver`.
@@ -290,7 +290,7 @@ async def notify(self, channel: str, payload: str) -> None:
 ```
 
 Remove any imports of `build_notify_query` from
-`pgqueuer.adapters.persistence.qb` — the helper is gone.
+`pgqueuer.adapters.persistence.qb`: the helper is gone.
 
 ## 11. Other API renames and removals
 
@@ -309,11 +309,11 @@ Remove any imports of `build_notify_query` from
 
 ## New features worth adopting
 
-- `RetryRequested` for transient errors — see [Database-Level Retry](../guides/retry.md).
-- `on_failure="hold"` to park failed jobs instead of deleting them — see
+- `RetryRequested` for transient errors; see [Database-Level Retry](../guides/retry.md).
+- `on_failure="hold"` to park failed jobs instead of deleting them; see
   [Holding Failed Jobs](../guides/hold-failed-jobs.md). Pairs with `pgq failed`
   and `pgq requeue`.
-- MCP server for read-only queue introspection — see
+- MCP server for read-only queue introspection; see
   [MCP Server](../integrations/mcp-server.md).
 - `ScheduleContext` gives scheduled tasks access to the same shared `resources`
   mapping as queue handlers.

--- a/docs/guides/completion-tracking.md
+++ b/docs/guides/completion-tracking.md
@@ -143,11 +143,11 @@ async def wait_for_first(
 
 To improve reliability without heavy polling:
 
-1. **Listener health check** — Run with the `pgq run --shutdown-on-listener-failure` flag
+1. **Listener health check**: Run with the `pgq run --shutdown-on-listener-failure` flag
    (or pass `shutdown_on_listener_failure=True` to `QueueManager.run()`) so the manager stops
    (and can be restarted by a supervisor) if the LISTEN channel becomes unhealthy.
 
-2. **Minimize the refresh poll** — Set a long `refresh_interval` to rely primarily on
+2. **Minimize the refresh poll**: Set a long `refresh_interval` to rely primarily on
    notifications when your channel is stable:
 
     ```python

--- a/docs/guides/custom-executors.md
+++ b/docs/guides/custom-executors.md
@@ -51,7 +51,7 @@ async def notification_task(job: Job) -> None:
 
 `DatabaseRetryEntrypointExecutor` converts unhandled exceptions into database-level retries
 via `RetryRequested`. The job is re-queued in the database so any worker can pick it up after
-the delay — retries survive worker restarts.
+the delay; retries survive worker restarts.
 
 ### When to Use It
 
@@ -91,7 +91,7 @@ async def sync_inventory(job: Job) -> None:
 | `max_delay` | `5m` | Cap on exponential backoff |
 | `backoff_multiplier` | `2.0` | Multiplier applied to delay after each attempt |
 
-If the handler raises `RetryRequested` directly, it passes through unchanged — the executor
+If the handler raises `RetryRequested` directly, it passes through unchanged; the executor
 only converts non-retry exceptions. See [Database-Level Retry](retry.md) for the full guide.
 
 !!! tip "Combine with `on_failure=\"hold\"`"

--- a/docs/guides/deferred-execution.md
+++ b/docs/guides/deferred-execution.md
@@ -1,7 +1,6 @@
 # Deferred Execution
 
-The `execute_after` attribute enables deferred job execution, allowing you to control when
-a job becomes eligible for processing.
+The `execute_after` attribute controls when a job becomes eligible for processing.
 
 ## How It Works
 
@@ -43,6 +42,6 @@ deferred jobs are never picked early.
 Deferred jobs participate in the normal priority queue once their `execute_after` time passes:
 
 ```python
-# High priority but deferred — will jump the queue once eligible
+# High priority but deferred: will jump the queue once eligible
 await queries.enqueue("urgent_task", b"data", priority=10, execute_after=timedelta(hours=1))
 ```

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Patterns
 
-PgQueuer requires no message broker, Redis instance, or additional infrastructure — just
+PgQueuer requires no message broker, Redis instance, or additional infrastructure, just
 PostgreSQL. This page covers how to run workers in production.
 
 ## Single Worker Process
@@ -55,7 +55,7 @@ Run multiple worker processes against the same PostgreSQL database. PgQueuer use
 
 Each worker:
 - Listens on the same `ch_pgqueuer` channel independently
-- Claims jobs atomically — no coordinator or leader election needed
+- Claims jobs atomically; no coordinator or leader election needed
 - Can run on separate VMs, containers, or processes on the same host
 
 **Starting multiple workers:**
@@ -151,7 +151,7 @@ LISTEN connection causes a clean restart rather than silent degradation:
 `pgq run` handles `SIGTERM` and `SIGINT`. On receiving a signal:
 
 1. Stop accepting new jobs from the queue.
-2. Wait for in-flight jobs to finish. PgQueuer has no built-in drain timeout — it awaits
+2. Wait for in-flight jobs to finish. PgQueuer has no built-in drain timeout; it awaits
    running jobs to completion, so bound the wait via your orchestrator (see below).
 3. Exit cleanly.
 
@@ -165,7 +165,7 @@ in-flight jobs finish provided the `terminationGracePeriodSeconds` is long enoug
 ## Schema Migrations on Deploy
 
 Run `pgq upgrade` before deploying new application code. It is safe to run against a live
-database — migrations are additive and non-destructive:
+database. Migrations are additive and non-destructive:
 
 ```bash
 # Deploy workflow
@@ -186,7 +186,7 @@ PgQueuer reads standard PostgreSQL environment variables:
 | `PGUSER` | Database user |
 | `PGPASSWORD` | Database password |
 | `PGDATABASE` | Database name |
-| `PGQUEUER_PREFIX` | Prefix prepended to table/channel names (default: empty — names default to `pgqueuer`, `ch_pgqueuer`, etc.) |
+| `PGQUEUER_PREFIX` | Prefix prepended to table/channel names (default: empty; names default to `pgqueuer`, `ch_pgqueuer`, etc.) |
 
 Use `PGQUEUER_PREFIX` to run multiple isolated PgQueuer instances in the same database:
 

--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -1,7 +1,7 @@
 # Heartbeat Monitoring
 
-PgQueuer's automatic heartbeat mechanism ensures active jobs are continuously monitored
-for liveness.
+PgQueuer updates a heartbeat timestamp on every active job so that stalled or
+crashed workers can be detected.
 
 ## How It Works
 
@@ -11,8 +11,8 @@ timestamp on the job record. This signals that the job is still actively being p
 - **Periodic updates**: The heartbeat timestamp is refreshed at a configurable interval.
 - **Stall detection**: External monitoring can compare `heartbeat` against `NOW()` to
   identify stalled or hung jobs.
-- **Resource management**: Prevents unresponsive jobs from holding locks indefinitely,
-  enabling external supervisors to detect and handle stuck workers.
+- **Resource management**: Unresponsive jobs do not hold locks indefinitely, and
+  external supervisors can detect and handle stuck workers.
 
 ## Stall Detection Pattern
 

--- a/docs/guides/hold-failed-jobs.md
+++ b/docs/guides/hold-failed-jobs.md
@@ -18,7 +18,7 @@ workers until explicitly re-queued.
 4. If `"delete"` (default): the job is deleted and logged with `exception` (existing behavior).
 5. Failed jobs sit in the queue table until someone re-queues or deletes them.
 
-The hold operation flows through the same batched buffer as normal job completions — there is
+The hold operation flows through the same batched buffer as normal job completions; there is
 no performance penalty in the common (non-failure) path.
 
 ## Use Cases
@@ -132,8 +132,8 @@ await queries.requeue_jobs([JobId(42), JobId(43)])
 ### What happens on re-queue
 
 - Status changes from `failed` to `queued`.
-- `execute_after` is set to `NOW()` — the job is immediately eligible.
-- `attempts` is reset to `0` — a fresh start.
+- `execute_after` is set to `NOW()`: the job is immediately eligible.
+- `attempts` is reset to `0`: a fresh start.
 - A log entry with `status='queued'` is written for auditability.
 - Any worker can pick up the re-queued job.
 - If `DatabaseRetryEntrypointExecutor` is configured, the job gets a full new set of retry

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -4,7 +4,7 @@ This page covers the knobs available for tuning PgQueuer throughput and latency 
 
 ## Batch Size
 
-`batch_size` controls how many jobs are fetched from the database in a single `FOR UPDATE SKIP LOCKED` query. Per the PostgreSQL manual, the `LIMIT` this maps to also bounds how many rows the statement locks per round-trip — see [Row Locking & SKIP LOCKED](../reference/skip-locked.md) for the mechanics.
+`batch_size` controls how many jobs are fetched from the database in a single `FOR UPDATE SKIP LOCKED` query. Per the PostgreSQL manual, the `LIMIT` this maps to also bounds how many rows the statement locks per round-trip; see [Row Locking & SKIP LOCKED](../reference/skip-locked.md) for the mechanics.
 
 ```python
 await pgq.run(batch_size=25, dequeue_timeout=timedelta(seconds=10))
@@ -35,7 +35,7 @@ async def resize_image(job: Job) -> None:
     ...
 ```
 
-`concurrency_limit` is enforced **globally at the database level** across every worker — set
+`concurrency_limit` is enforced **globally at the database level** across every worker; set
 `concurrency_limit=4` and at most 4 such jobs run across your entire fleet. Use it when tasks
 share a scarce external resource (e.g., an API with rate limits). `max_concurrent_tasks`, by
 contrast, is a per-process safety ceiling on total asyncio tasks.
@@ -117,9 +117,9 @@ into `pgqueuer` and sends a notification on the `ch_pgqueuer` channel.
 **What can go wrong:** pgBouncer in transaction-pooling mode drops `LISTEN` subscriptions
 between transactions. PgQueuer handles this in two ways:
 
-1. **Polling fallback** — `QueueManager` re-polls after `dequeue_timeout` even without a
+1. **Polling fallback**: `QueueManager` re-polls after `dequeue_timeout` even without a
    NOTIFY, so jobs are never permanently stuck.
-2. **Listener health check** — start with `--shutdown-on-listener-failure` so a supervisor
+2. **Listener health check**: start with `--shutdown-on-listener-failure` so a supervisor
    can restart a manager whose LISTEN channel has become unhealthy:
 
 ```bash

--- a/docs/guides/reliability.md
+++ b/docs/guides/reliability.md
@@ -11,7 +11,7 @@ When a job raises an unhandled exception, PgQueuer:
 2. Captures the full traceback, exception type, and message into a **TracebackRecord**.
 3. Moves the record from the active queue (`pgqueuer`) to the log table (`pgqueuer_log`).
 
-The job is **not** automatically retried at this point — it is considered definitively failed
+The job is **not** automatically retried at this point; it is considered definitively failed
 for this execution attempt. The traceback is persisted in `pgqueuer_log` for inspection
 via a direct query:
 
@@ -33,7 +33,7 @@ PgQueuer provides three complementary retry mechanisms.
 ### Database-level retry: durable re-queuing
 
 Raise `RetryRequested` from your handler to re-queue the job in the database. The job row is
-updated in-place — the `id`, `payload`, and all metadata are preserved. Any worker can pick
+updated in-place: the `id`, `payload`, and all metadata are preserved. Any worker can pick
 up the retried job.
 
 ```python
@@ -119,17 +119,17 @@ WHERE status IN ('queued', 'picked') AND dedupe_key IS NOT NULL
 ```
 
 If a job with the same `dedupe_key` already exists in `queued` or `picked` state, a
-`DuplicateJobError` is raised. The constraint only covers `queued` and `picked`, so once the
-job leaves those states — `successful`, `exception`, `canceled`, `deleted`, or `failed`
-(held) — the key is released and the same key can be used again.
+`DuplicateJobError` is raised. The constraint only covers `queued` and `picked`. Once the
+job moves to `successful`, `exception`, `canceled`, `deleted`, or `failed`
+(held), the key is released and the same key can be used again.
 
-**Choosing a dedupe key:** Use a stable, business-meaningful identifier — for example,
+**Choosing a dedupe key:** Use a stable, business-meaningful identifier, for example
 `f"invoice-{order_id}"` or `f"report-{date}-{user_id}"`. This turns enqueue into an
 idempotent operation: calling it twice with the same key and payload is safe.
 
 ### Skipping duplicates instead of raising
 
-By default a duplicate fails the whole enqueue call — in a batch, nothing is inserted.
+By default a duplicate fails the whole enqueue call: in a batch, nothing is inserted.
 Pass `on_conflict="skip"` to insert the non-duplicate jobs and skip the rest:
 
 ```python
@@ -150,7 +150,7 @@ job id and no `queued` entry in the log table. The same flag is available on the
 `pgq queue --dedupe-key ... --on-conflict skip`.
 
 **Duplicates within a single batch:** if the same `dedupe_key` appears more than once in one
-`enqueue` call — even with different payloads — the **first occurrence by input order** is
+`enqueue` call, even with different payloads, the **first occurrence by input order** is
 enqueued and every later occurrence is treated as a conflict. Under `on_conflict="skip"` the
 later positions come back as `None`; under the default they fail the call. Order your inputs
 so the payload you want kept comes first.

--- a/docs/guides/retry.md
+++ b/docs/guides/retry.md
@@ -1,6 +1,6 @@
 # Database-Level Retry
 
-PgQueuer supports **database-level retry** — when a job handler raises `RetryRequested`, the
+PgQueuer supports **database-level retry**: when a job handler raises `RetryRequested`, the
 job stays in the queue table and is re-queued for another attempt. The job row is updated
 in-place (not deleted and re-inserted), so the `id`, `payload`, `headers`, and all metadata
 are preserved across retries.
@@ -58,7 +58,7 @@ execution it is `0`, after one retry it is `1`, and so on:
 @pgq.entrypoint("resilient_task")
 async def resilient_task(job: Job) -> None:
     if job.attempts > 5:
-        # Give up after 5 retries — let it fail terminally
+        # Give up after 5 retries and let it fail terminally
         raise RuntimeError("Too many retries, giving up")
 
     try:
@@ -100,7 +100,7 @@ async def flaky_api(job: Job) -> None:
 After `max_attempts` consecutive failures, the original exception propagates as a terminal
 failure (the job is deleted and logged with status `exception`).
 
-If your handler raises `RetryRequested` directly, it passes through the executor unchanged —
+If your handler raises `RetryRequested` directly, it passes through the executor unchanged;
 the executor only converts non-retry exceptions.
 
 ### Parameters
@@ -127,7 +127,7 @@ With `initial_delay=1s`, `backoff_multiplier=2.0`, `max_delay=60s`:
 | 6+ | 60s (capped) |
 
 The table shows the delay *formula* independent of `max_attempts`. With the default
-`max_attempts=5`, only attempts 0–4 are retried (delays 1s–16s); the 5th failure is terminal,
+`max_attempts=5`, only attempts 0-4 are retried (delays 1s-16s); the 5th failure is terminal,
 so the 32s/60s rows never apply unless you raise `max_attempts`.
 
 ## Retry vs. Heartbeat Recovery
@@ -177,7 +177,7 @@ ORDER BY created;
 | Scenario | What happens |
 |----------|-------------|
 | Handler raises `RetryRequested` | Job updated to `queued`, attempts incremented, log entry written |
-| Handler raises any other exception | Job deleted, logged as `exception` (or held if `on_failure="hold"` — see [Holding Failed Jobs](hold-failed-jobs.md)) |
+| Handler raises any other exception | Job deleted, logged as `exception` (or held if `on_failure="hold"`: see [Holding Failed Jobs](hold-failed-jobs.md)) |
 | Handler completes normally | Job deleted, logged as `successful` (existing behavior) |
 | `DatabaseRetryEntrypointExecutor` + exception + attempts < max | Converted to `RetryRequested` with backoff |
 | `DatabaseRetryEntrypointExecutor` + exception + attempts >= max | Exception propagates as terminal failure (or held if `on_failure="hold"`) |

--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -25,8 +25,8 @@ async def heartbeat(schedule: Schedule) -> None:
 
 - **Registration**: Define tasks using the `@schedule` decorator with a name and a cron expression.
 - **Execution**: The scheduler runs tasks at defined intervals and tracks execution state.
-- **Database Integration**: Schedules are stored in PostgreSQL, ensuring durability and recovery
-  across process restarts.
+- **Database Integration**: Schedules are stored in PostgreSQL and survive process
+  restarts.
 
 ### Scheduler Flow Diagram
 
@@ -44,11 +44,11 @@ in the final position.
 ### 5-field format
 
 ```
-┌───────────── minute (0–59)
-│ ┌───────────── hour (0–23)
-│ │ ┌───────────── day of month (1–31)
-│ │ │ ┌───────────── month (1–12)
-│ │ │ │ ┌───────────── day of week (0–6, Sunday=0)
+┌───────────── minute (0-59)
+│ ┌───────────── hour (0-23)
+│ │ ┌───────────── day of month (1-31)
+│ │ │ ┌───────────── month (1-12)
+│ │ │ │ ┌───────────── day of week (0-6, Sunday=0)
 │ │ │ │ │
 * * * * *
 ```
@@ -73,12 +73,12 @@ Second-level schedules follow croniter's
 behavior.
 
 ```
-┌───────────── minute (0–59)
-│ ┌───────────── hour (0–23)
-│ │ ┌───────────── day of month (1–31)
-│ │ │ ┌───────────── month (1–12)
-│ │ │ │ ┌───────────── day of week (0–6, Sunday=0)
-│ │ │ │ │ ┌───────────── second (0–59)
+┌───────────── minute (0-59)
+│ ┌───────────── hour (0-23)
+│ │ ┌───────────── day of month (1-31)
+│ │ │ ┌───────────── month (1-12)
+│ │ │ │ ┌───────────── day of week (0-6, Sunday=0)
+│ │ │ │ │ ┌───────────── second (0-59)
 │ │ │ │ │ │
 * * * * * *
 ```
@@ -123,7 +123,7 @@ async def fetch_db(schedule: Schedule) -> None:
     await perform_task()
 ```
 
-By default, `clean_old=False` — old schedules are retained.
+By default, `clean_old=False`: old schedules are retained.
 
 ## Managing Schedules via CLI
 

--- a/docs/guides/shared-resources.md
+++ b/docs/guides/shared-resources.md
@@ -36,7 +36,7 @@ async def build_pgqueuer():
 
     pgq = PgQueuer(driver, resources=resources)
 
-    # Annotating a parameter as Context is enough — PgQueuer injects it.
+    # Annotating a parameter as Context is enough; PgQueuer injects it.
     @pgq.entrypoint("process_user")
     async def process_user(job: Job, ctx: Context) -> None:
         http = ctx.resources["http_client"]
@@ -92,7 +92,7 @@ async def process_with_context(job: Job, ctx: Context) -> None:
 ```
 
 Detection is annotation-driven, so a handler with an unrelated extra parameter
-(`async def f(job: Job, config: dict | None = None)`) is left untouched—no `Context` is injected
+(`async def f(job: Job, config: dict | None = None)`) is left untouched and no `Context` is injected
 into it. Entry points that declare only the job are invoked with the job alone:
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 **Your PostgreSQL database is already a job queue.**
 
 PgQueuer turns PostgreSQL into a fast, reliable background job processor.
-Jobs live in the same database as your application data -- one stack,
+Jobs live in the same database as your application data: one stack,
 full ACID guarantees, zero additional infrastructure.
 
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
@@ -21,18 +21,18 @@ If you're already running PostgreSQL, it can do double duty as your job queue.
 That gives you:
 
 - **One fewer service** to provision, monitor, and keep available
-- **Transactional enqueuing** -- commit a job in the same transaction as your application data
-- **Consistent state** -- your queue and your data always agree because they share the same database
-- **Lower latency** -- jobs stay local, no round-trip to an external broker
+- **Transactional enqueuing**: commit a job in the same transaction as your application data
+- **Consistent state**: your queue and your data always agree because they share the same database
+- **Lower latency**: jobs stay local, no round-trip to an external broker
 
 ## How PgQueuer Works
 
-PgQueuer uses battle-tested PostgreSQL primitives to deliver jobs safely and fast:
+PgQueuer builds on standard PostgreSQL primitives to deliver jobs safely and fast:
 
-- **`FOR UPDATE SKIP LOCKED`** -- workers claim jobs atomically; a job is never handed to two workers
-- **`LISTEN/NOTIFY`** -- a trigger on the queue table fires `pg_notify()` on every insert, waking workers instantly
-- **ACID transactions** -- jobs are enqueued and processed with the same guarantees as your application data
-- **Row-level locking** -- multiple workers scale horizontally against a single database
+- **`FOR UPDATE SKIP LOCKED`**: workers claim jobs atomically; a job is never handed to two workers
+- **`LISTEN/NOTIFY`**: a trigger on the queue table fires `pg_notify()` on every insert, waking workers instantly
+- **ACID transactions**: jobs are enqueued and processed with the same guarantees as your application data
+- **Row-level locking**: multiple workers scale horizontally against a single database
 
 ```
 ┌──────────┐  enqueue   ┌────────────┐  NOTIFY   ┌──────────┐
@@ -106,8 +106,8 @@ That's it. Just PostgreSQL and your application code.
     ---
 
     Cron-style recurring tasks via the `@schedule` decorator with 5-field
-    (minute-level) or 6-field (second-level) expressions. No separate
-    beat process required.
+    (minute-level) or 6-field (second-level) expressions, without a
+    separate beat process.
 
 -   **Automatic Retries & Heartbeat**
 
@@ -130,14 +130,14 @@ That's it. Just PostgreSQL and your application code.
     ---
 
     `PgQueuer.in_memory()` provides a drop-in replacement for tests
-    and CI. No Docker, no PostgreSQL instance needed.
+    and CI that needs neither Docker nor a PostgreSQL instance.
 
 -   **Completion Tracking**
 
     ---
 
     `CompletionWatcher` lets callers await job results via
-    `LISTEN/NOTIFY` -- no polling required. Wait for one job, many jobs,
+    `LISTEN/NOTIFY` instead of polling. Wait for one job, many jobs,
     or race them with `asyncio.wait`.
 
 -   **Deferred Execution**
@@ -189,8 +189,8 @@ are backed by PostgreSQL and you want a simpler operational footprint.
 
 ## Next Steps
 
-- **[Installation](getting-started/installation.md)** -- install PgQueuer and set up the database schema
-- **[Quick Start](getting-started/quickstart.md)** -- build your first consumer and producer in 5 minutes
-- **[Core Concepts](getting-started/core-concepts.md)** -- understand jobs, entrypoints, and the status lifecycle
-- **[Architecture](reference/architecture.md)** -- how data flows from producer to consumer
-- **[Upgrading from 0.x](getting-started/upgrading.md)** -- migration guide for users coming from pre-1.0 releases
+- **[Installation](getting-started/installation.md)**: install PgQueuer and set up the database schema
+- **[Quick Start](getting-started/quickstart.md)**: build your first consumer and producer in 5 minutes
+- **[Core Concepts](getting-started/core-concepts.md)**: understand jobs, entrypoints, and the status lifecycle
+- **[Architecture](reference/architecture.md)**: how data flows from producer to consumer
+- **[Upgrading from 0.x](getting-started/upgrading.md)**: migration guide for users coming from pre-1.0 releases

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -2,7 +2,7 @@
 
 PgQueuer ships an optional [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server
 that gives AI agents read-only access to your queue state, statistics, and schedules.
-All queries are predefined — no arbitrary SQL is accepted.
+All queries are predefined; the server does not accept arbitrary SQL.
 
 ## Installation
 
@@ -163,7 +163,7 @@ globals, so you can create multiple servers or embed one in a larger application
 ```python
 from pgqueuer.adapters.mcp.server import create_mcp_server
 
-# All parameters are optional — asyncpg reads libpq env vars by default
+# All parameters are optional; asyncpg reads libpq env vars by default
 server = create_mcp_server()
 
 # Or pass an explicit DSN and/or custom settings
@@ -177,9 +177,9 @@ server.run(transport="stdio")
 The MCP server lives in the adapter layer (`pgqueuer/adapters/mcp/`) and follows
 the same hexagonal architecture as the rest of PgQueuer:
 
-- **`server.py`** — `create_mcp_server()` factory, `PgQueuerDatabase` wrapper,
+- **`server.py`**: `create_mcp_server()` factory, `PgQueuerDatabase` wrapper,
   all tool registrations.
-- **`__main__.py`** — `python -m pgqueuer.adapters.mcp` entry point.
+- **`__main__.py`**: `python -m pgqueuer.adapters.mcp` entry point.
 - All SQL queries are defined as `build_*` methods in
-  `pgqueuer/adapters/persistence/qb.py` — no SQL is constructed at runtime.
+  `pgqueuer/adapters/persistence/qb.py`: no SQL is constructed at runtime.
 - The server uses an asyncpg connection pool managed by FastMCP's lifespan.

--- a/docs/integrations/postgrest.md
+++ b/docs/integrations/postgrest.md
@@ -16,7 +16,7 @@ PostgreSQL function.
     - Applying appropriate network and authentication controls.
 
     These examples are minimal and need hardening. Table names (`pgqueuer`,
-    `pgqueuer_log`) may differ if you installed PgQueuer with custom settings — adjust
+    `pgqueuer_log`) may differ if you installed PgQueuer with custom settings; adjust
     everywhere accordingly.
 
 ## Overview

--- a/docs/integrations/prometheus.md
+++ b/docs/integrations/prometheus.md
@@ -43,8 +43,8 @@ return Response(content=content, media_type="text/plain; version=0.0.4")
 
 ## Standalone Metrics Service
 
-A Docker-based standalone metrics service is available in `tools/prometheus`. Note that
-this service uses its own implementation separate from the `pgqueuer.metrics` library module.
+A Docker-based standalone metrics service is available in `tools/prometheus`. This
+service uses its own implementation, separate from the `pgqueuer.metrics` library module.
 
 ### Building the Image
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -72,17 +72,17 @@ CREATE TYPE pgqueuer_status AS ENUM (
 
 The lifecycle of a job flows through these statuses:
 
-- **`queued`** — Newly enqueued jobs start here and wait for a worker to pick them up.
-- **`picked`** — Set by `QueueManager` when a worker begins processing. A heartbeat
+- **`queued`**: Newly enqueued jobs start here and wait for a worker to pick them up.
+- **`picked`**: Set by `QueueManager` when a worker begins processing. A heartbeat
   timestamp tracks active work.
-- **`successful`** — Assigned after a job completes without errors. Details are copied to
+- **`successful`**: Assigned after a job completes without errors. Details are copied to
   the statistics log and removed from the queue.
-- **`exception`** — Indicates the job failed with an uncaught error. The traceback is
+- **`exception`**: Indicates the job failed with an uncaught error. The traceback is
   stored for later inspection.
-- **`failed`** — Job held in the queue for manual review when `on_failure="hold"` is set.
+- **`failed`**: Job held in the queue for manual review when `on_failure="hold"` is set.
   Can be re-queued or deleted manually.
-- **`canceled`** — Jobs canceled before completion receive this status and are logged.
-- **`deleted`** — Used when jobs are removed from the queue without running, such as during
+- **`canceled`**: Jobs canceled before completion receive this status and are logged.
+- **`deleted`**: Used when jobs are removed from the queue without running, such as during
   manual cleanup operations.
 
 ### Status Transition Diagram

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,10 +12,10 @@ Set up the necessary database schema for PgQueuer.
 **Options:**
 
 - `--durability`: Define the durability level for tables.
-  - `volatile`: All tables are unlogged — maximum performance, no crash recovery.
+  - `volatile`: All tables are unlogged: maximum performance, no crash recovery.
   - `balanced`: Critical tables (`pgqueuer`, `pgqueuer_schedules`) are logged; auxiliary
     tables are unlogged.
-  - `durable` *(default)*: All tables are logged — full crash recovery.
+  - `durable` *(default)*: All tables are logged: full crash recovery.
 - `--dry-run`: Print SQL commands without executing them.
 
 ```bash
@@ -115,7 +115,7 @@ Manually enqueue a job.
 
 - `--dedupe-key`: Deduplication key; an active (`queued`/`picked`) job with the same key
   blocks the enqueue.
-- `--on-conflict`: What to do on a dedupe-key conflict — `raise` (default) exits with an
+- `--on-conflict`: What to do on a dedupe-key conflict: `raise` (default) exits with an
   error, `skip` exits 0 without enqueuing.
 
 ```bash
@@ -172,7 +172,7 @@ pgq schedules --remove fetch_db
 ### `failed`
 
 List jobs held with `status='failed'` for manual intervention. Held jobs come from
-entrypoints registered with `on_failure="hold"` — see [Holding Failed Jobs](../guides/hold-failed-jobs.md).
+entrypoints registered with `on_failure="hold"`: see [Holding Failed Jobs](../guides/hold-failed-jobs.md).
 
 **Options:**
 
@@ -225,7 +225,7 @@ Start a `QueueManager` to process jobs.
 # Run with a limit of 5 concurrent tasks
 pgq run my_module:my_factory --max-concurrent-tasks 5
 
-# Drain mode — process all queued jobs then exit
+# Drain mode: process all queued jobs then exit
 pgq run my_module:my_factory --mode drain
 ```
 
@@ -245,20 +245,20 @@ crash recovery.
 
 ### Volatile
 
-- All tables are **unlogged** — no Write-Ahead Log (WAL) writes.
+- All tables are **unlogged**: no Write-Ahead Log (WAL) writes.
 - Data is **lost** if PostgreSQL crashes.
 - Best for: temporary workloads where data loss is acceptable, or maximum throughput testing.
 
 ### Balanced
 
-- Critical tables (`pgqueuer`, `pgqueuer_schedules`) are **logged** — survive crashes.
-- Auxiliary tables (`pgqueuer_log`, `pgqueuer_statistics`) are **unlogged** — faster writes.
+- Critical tables (`pgqueuer`, `pgqueuer_schedules`) are **logged**: survive crashes.
+- Auxiliary tables (`pgqueuer_log`, `pgqueuer_statistics`) are **unlogged**: faster writes.
 - Best for: production systems where job data must survive crashes but log/statistics can be
   sacrificed for speed.
 
 ### Durable *(default)*
 
-- All tables are **logged** — full WAL writes.
+- All tables are **logged**: full WAL writes.
 - Data survives crashes and restarts.
 - Best for: production environments where data integrity is critical.
 
@@ -275,19 +275,19 @@ manager instance; the CLI loads it, calls it, and runs the returned manager unti
 pgq run my_module:factory
           │
           ▼
-  1. LOAD FACTORY — import module, retrieve function
+  1. LOAD FACTORY: import module, retrieve function
           │
           ▼
-  2. SETUP SIGNAL HANDLERS — SIGINT, SIGTERM
+  2. SETUP SIGNAL HANDLERS: SIGINT, SIGTERM
           │
           ▼
-  3. SUPERVISOR LOOP — continues until shutdown
+  3. SUPERVISOR LOOP: continues until shutdown
           │
           ▼
-  4. INVOKE YOUR FACTORY — create connection, register entrypoints
+  4. INVOKE YOUR FACTORY: create connection, register entrypoints
           │
           ▼
-  5. LINK SHUTDOWN EVENT — connect signal to manager
+  5. LINK SHUTDOWN EVENT: connect signal to manager
           │
           ▼
   6. RUN THE MANAGER
@@ -301,7 +301,7 @@ pgq run my_module:factory
 ### Factory Contract
 
 The factory **must** return an `AsyncContextManager` (typically via `@asynccontextmanager`).
-Bare awaitables and sync context managers are **not** accepted — passing one raises
+Bare awaitables and sync context managers are **not** accepted; passing one raises
 `TypeError` with migration instructions.
 
 ```python

--- a/docs/reference/database-permissions.md
+++ b/docs/reference/database-permissions.md
@@ -90,7 +90,7 @@ PGOPTIONS="-csearch_path=pgq" pgq install
 ```
 
 This separates PgQueuer objects from application tables and makes privilege management
-cleaner — you can grant or revoke schema-level access as a single operation.
+cleaner: you can grant or revoke schema-level access as a single operation.
 
 ## Verifying Permissions
 

--- a/docs/reference/database-setup.md
+++ b/docs/reference/database-setup.md
@@ -7,10 +7,10 @@ for job queuing and processing.
 
 PgQueuer uses four primary tables:
 
-- **`pgqueuer`** — the active job queue
-- **`pgqueuer_log`** — job execution history and audit trail
-- **`pgqueuer_statistics`** — aggregated statistics
-- **`pgqueuer_schedules`** — recurring schedule definitions
+- **`pgqueuer`**: the active job queue
+- **`pgqueuer_log`**: job execution history and audit trail
+- **`pgqueuer_statistics`**: aggregated statistics
+- **`pgqueuer_schedules`**: recurring schedule definitions
 
 ## Installation
 

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -8,21 +8,21 @@ abstracting database communication.
 Drivers:
 
 - Manage database connections and enforce required configuration (e.g., autocommit).
-- Abstract PostgreSQL-specific features to streamline queue operations.
+- Abstract the PostgreSQL-specific features that queue operations rely on.
 - Provide a consistent interface for executing queries.
 
 ## Requirements
 
 For any driver:
 
-1. **Autocommit mode** — The connection must operate in autocommit mode.
+1. **Autocommit mode**: The connection must operate in autocommit mode.
    - For `psycopg`, explicitly set `connection.autocommit = True`.
    - For `asyncpg`, autocommit is the default unless a transaction is explicitly started.
 
-2. **PostgreSQL compatibility** — The driver must support PostgreSQL-specific features
+2. **PostgreSQL compatibility**: The driver must support PostgreSQL-specific features
    used by PgQueuer.
 
-3. **Default isolation level** — Connections should maintain the default PostgreSQL
+3. **Default isolation level**: Connections should maintain the default PostgreSQL
    isolation level unless explicitly modified.
 
 ## Driver Protocol
@@ -100,7 +100,7 @@ driver = PsycopgDriver(conn)
 
 ### `SyncPsycopgDriver`
 
-Designed for blocking code or frameworks such as Flask. **Can only enqueue jobs** — PgQueuer's
+Designed for blocking code or frameworks such as Flask. **Can only enqueue jobs**: PgQueuer's
 consumers and internals require an async driver.
 
 ```python

--- a/docs/reference/in-memory.md
+++ b/docs/reference/in-memory.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-The in-memory adapter is a drop-in replacement for the PostgreSQL backend, allowing PgQueuer
-to run entirely without a database connection. Located in `pgqueuer.adapters.inmemory`, it
+The in-memory adapter is a drop-in replacement for the PostgreSQL backend, so PgQueuer
+can run entirely without a database connection. Located in `pgqueuer.adapters.inmemory`, it
 provides `InMemoryDriver` and `InMemoryQueries` classes that satisfy the same
 `RepositoryPort` protocol as the production PostgreSQL-backed implementation.
 
-`QueueManager` and `SchedulerManager` work unchanged against the in-memory adapter — you
+`QueueManager` and `SchedulerManager` work unchanged against the in-memory adapter. You
 don't need to rewrite your job handlers or business logic.
 
 The simplest way to use it is via the factory method:
@@ -60,20 +60,20 @@ asyncio.run(main())
 
 **Recommended for:**
 
-- **Unit and integration tests** — no PostgreSQL instance or Docker container required
-- **CI/CD pipelines** — resource-constrained environments (GitHub Actions, lightweight containers)
-- **Local development** — prototype queue logic without infrastructure setup
-- **Short-lived batch containers** — process a fixed job set and discard (ETL, one-time cleanup)
-- **Proof-of-concept** — quickly demonstrate queue logic
+- **Unit and integration tests**: no PostgreSQL instance or Docker container required
+- **CI/CD pipelines**: resource-constrained environments (GitHub Actions, lightweight containers)
+- **Local development**: prototype queue logic without infrastructure setup
+- **Short-lived batch containers**: process a fixed job set and discard (ETL, one-time cleanup)
+- **Proof-of-concept**: quickly demonstrate queue logic
 
 **Not suitable for:**
 
-- **Production workloads requiring durability** — any restart loses all queued and in-flight jobs
-- **Multi-process workers** — no visibility across processes
-- **Multi-node / distributed deployments** — no shared state between machines
-- **Long-running services** — process restarts lose data
-- **ACID transaction guarantees** — no rollback or atomic retry semantics
-- **Monitoring and observability** — no external store for post-exit inspection
+- **Production workloads requiring durability**: any restart loses all queued and in-flight jobs
+- **Multi-process workers**: no visibility across processes
+- **Multi-node / distributed deployments**: no shared state between machines
+- **Long-running services**: process restarts lose data
+- **ACID transaction guarantees**: no rollback or atomic retry semantics
+- **Monitoring and observability**: no external store for post-exit inspection
 
 ## Limitations Reference
 
@@ -97,15 +97,15 @@ in-memory dictionaries and never executes SQL.
 ### Event Loop Yielding
 
 The `dequeue()` method includes an explicit `await asyncio.sleep(0)` to yield control to
-the event loop. This is critical — without it, `QueueManager.fetch_jobs` would starve signal
+the event loop. This is critical: without it, `QueueManager.fetch_jobs` would starve signal
 handlers, timers, and concurrent jobs. The PostgreSQL adapter naturally yields during real
 I/O; the in-memory adapter must do so explicitly.
 
 ### Schema Management
 
-- `install()`, `upgrade()` — no-ops
-- `uninstall()` — clears all internal dictionaries, resetting queue state
-- Schema inspection methods — always return `True`
+- `install()`, `upgrade()`: no-ops
+- `uninstall()`: clears all internal dictionaries, resetting queue state
+- Schema inspection methods always return `True`
 
 ### Job State
 

--- a/docs/reference/ports-and-adapters.md
+++ b/docs/reference/ports-and-adapters.md
@@ -52,7 +52,7 @@ to new paths, thin re-export shims preserve the old import locations.
 Ports are `Protocol` classes living in `pgqueuer/ports/`. They capture what the core needs
 without specifying how.
 
-**QueueRepositoryPort** — persistence for the job queue:
+**QueueRepositoryPort**: persistence for the job queue:
 
 ```python
 class QueueRepositoryPort(Protocol):
@@ -66,7 +66,7 @@ class QueueRepositoryPort(Protocol):
     async def queued_work(self, entrypoints) -> int: ...
 ```
 
-**ScheduleRepositoryPort** — persistence for cron schedules:
+**ScheduleRepositoryPort**: persistence for cron schedules:
 
 ```python
 class ScheduleRepositoryPort(Protocol):
@@ -77,7 +77,7 @@ class ScheduleRepositoryPort(Protocol):
     async def delete_schedule(self, ids, entrypoints) -> None: ...
 ```
 
-**NotificationPort** — PostgreSQL NOTIFY abstraction:
+**NotificationPort**: PostgreSQL NOTIFY abstraction:
 
 ```python
 class NotificationPort(Protocol):
@@ -85,7 +85,7 @@ class NotificationPort(Protocol):
     async def notify_health_check(self, health_check_event_id) -> None: ...
 ```
 
-**SchemaManagementPort** — DDL operations:
+**SchemaManagementPort**: DDL operations:
 
 ```python
 class SchemaManagementPort(Protocol):
@@ -103,11 +103,11 @@ inheritance or registration required.
 
 ### Existing Ports (Already In Place)
 
-- **`Driver`** (`pgqueuer.ports.driver`) — database execution abstraction.
+- **`Driver`** (`pgqueuer.ports.driver`): database execution abstraction.
   Methods: `fetch`, `execute`, `add_listener`, `notify`. Adapters:
   `AsyncpgDriver`, `AsyncpgPoolDriver`, `PsycopgDriver`, `SyncPsycopgDriver`,
   and the in-memory driver.
-- **`TracingProtocol`** (`pgqueuer.ports.tracing`) — distributed tracing.
+- **`TracingProtocol`** (`pgqueuer.ports.tracing`): distributed tracing.
   Adapters: `LogfireTracing`, `SentryTracing`, `OpenTelemetryTracing`.
 
 ### Dependency Injection Pattern
@@ -189,24 +189,24 @@ root: `pgqueuer.db`, `pgqueuer.queries`, `pgqueuer.qm`, `pgqueuer.sm`,
 Internal-only modules (`buffers`, `cache`, `cli`, `completion`, `heartbeat`,
 `listeners`, `logconfig`, `qb`, `query_helpers`, `supervisor`, `tm`, `tracing`)
 were exposed at the package root in pre-v1 releases. In v1.0.0 those shims were
-removed — import from the canonical location under `pgqueuer.core.*`,
+removed; import from the canonical location under `pgqueuer.core.*`,
 `pgqueuer.adapters.*`, or `pgqueuer.ports.*` instead. See breaking change #11
 in the v1.0.0 release notes for the full mapping.
 
 ### Migration Phases
 
-**Phase 0** — ~~Deprecate unused infrastructure fields in executor parameters.~~ Done — deprecated fields removed.
+**Phase 0**: ~~Deprecate unused infrastructure fields in executor parameters.~~ Done; deprecated fields removed.
 
-**Phase 1** — Extract port protocols. Purely additive.
+**Phase 1**: Extract port protocols. Purely additive.
 
-**Phase 2** — Dependency injection for `QueueManager` and `SchedulerManager`.
+**Phase 2**: Dependency injection for `QueueManager` and `SchedulerManager`.
 
-**Phase 3** — Inject tracing instead of global singleton.
+**Phase 3**: Inject tracing instead of global singleton.
 
-**Phase 4** — Directory restructure. Move modules into `domain/`, `ports/`, `core/`,
+**Phase 4**: Directory restructure. Move modules into `domain/`, `ports/`, `core/`,
 `adapters/`. Old paths become re-export shims.
 
-**Phase 5** — Enforce boundaries via `import-linter` CI rules.
+**Phase 5**: Enforce boundaries via `import-linter` CI rules.
 
 Phase dependency graph:
 

--- a/docs/reference/skip-locked.md
+++ b/docs/reference/skip-locked.md
@@ -13,7 +13,7 @@ same job twice and without blocking each other.
 
 ## Why plain reads don't work
 
-PostgreSQL's MVCC means a plain `SELECT` never blocks and never locks a row —
+PostgreSQL's MVCC means a plain `SELECT` never blocks and never locks a row:
 "reading never blocks writing and writing never blocks reading."[^mvcc] So two
 workers running the same `SELECT ... LIMIT 1` both read `id=1`. MVCC gives each a
 consistent snapshot; it does **not** hand them *different* rows. Coordinating
@@ -40,11 +40,11 @@ different transactions):[^explicit]
  FOR UPDATE           X        X          X          X
 ```
 
-PgQueuer uses `FOR UPDATE` (strongest) because a claim is a write intent — the
+PgQueuer uses `FOR UPDATE` (strongest) because a claim is a write intent: the
 next step is `UPDATE ... status='picked'`. Two facts about these locks:[^explicit]
 
 - Held until the transaction ends; a claim is durable only after commit.
-- They block writers/lockers, never plain readers — a dashboard `SELECT count(*)`
+- They block writers/lockers, never plain readers: a dashboard `SELECT count(*)`
   is never blocked by a dequeue.
 
 ---
@@ -60,9 +60,9 @@ next step is `UPDATE ... status='picked'`. Two facts about these locks:[^explici
    forever       immediately   keep scanning
 ```
 
-- **default** — waits indefinitely.[^explicit] Fatal for a queue: workers convoy.
-- **`NOWAIT`** — errors instead of waiting; forces app-side retry.
-- **`SKIP LOCKED`** — locked rows are treated as nonexistent. No wait, no error.
+- **default**: waits indefinitely.[^explicit] Fatal for a queue: workers convoy.
+- **`NOWAIT`**: errors instead of waiting; forces app-side retry.
+- **`SKIP LOCKED`**: locked rows are treated as nonexistent. No wait, no error.
 
 ---
 
@@ -85,7 +85,7 @@ No worker blocks another; no job is handed out twice.
 
 !!! note "Inconsistent by design"
     `SKIP LOCKED` "provides an inconsistent view of the data."[^locking] Worker B
-    genuinely can't see jobs 1 and 2 — exactly what a queue wants, and why the
+    genuinely can't see jobs 1 and 2: exactly what a queue wants, and why the
     manual warns against it for general-purpose queries.
 
 ---
@@ -98,7 +98,7 @@ SELECT id FROM pgqueuer WHERE status='queued' ORDER BY id LIMIT 1 FOR UPDATE;
 ```
 
 All workers target the same top row; `N-1` block on the winner and process
-single-file no matter how many you add — the failure mode behind Craig Ringer's
+single-file no matter how many you add: the failure mode behind Craig Ringer's
 "most work-queue implementations are wrong."[^ringer] `SKIP LOCKED` fixes it.
 
 ---
@@ -126,14 +126,14 @@ on commit. Three documented details:[^locking]
   return rows out of order under `READ COMMITTED`. The subquery form contains it.
 - `LIMIT` stops locking once satisfied, so `LIMIT $batch_size` also bounds rows
   locked.
-- `OFFSET` still locks skipped rows — avoid it in a dequeue path.
+- `OFFSET` still locks skipped rows; avoid it in a dequeue path.
 
 ---
 
 ## In PgQueuer
 
 [`build_dequeue_query`](https://github.com/janbjorge/pgqueuer/blob/main/pgqueuer/adapters/persistence/qb.py)
-is the correct pattern, twice (simplified below — the real query adds
+is the correct pattern, twice (simplified below; the real query adds
 concurrency-limit gating and a pick-logging CTE):
 
 ```sql
@@ -164,15 +164,15 @@ claimed AS (            -- atomic claim
 SELECT * FROM claimed ORDER BY priority DESC, id ASC;
 ```
 
-- **Two scans, both `SKIP LOCKED`** — fresh `queued` work plus `picked` jobs with
+- **Two scans, both `SKIP LOCKED`**: fresh `queued` work plus `picked` jobs with
   a stale `heartbeat`. Recovery never blocks on jobs a live worker still holds.
 - **The `UPDATE ... RETURNING` is the claim.** After commit, `status='picked'` +
   `queue_manager_id` keep other workers off the rows; the locks themselves are
   already released.
 - **Stale recovery, not stuck jobs.** A crashed worker drops its locks but leaves
-  a `picked` row; the `heartbeat` timeout — not the lock — lets `next_stale`
+  a `picked` row; the `heartbeat` timeout, not the lock, lets `next_stale`
   reclaim it. See [Heartbeat Monitoring](../guides/heartbeat.md).
-- **`LIMIT $1` is `batch_size`** — also the bound on rows locked. See
+- **`LIMIT $1` is `batch_size`**: also the bound on rows locked. See
   [Performance Tuning](../guides/performance-tuning.md).
 
 ---


### PR DESCRIPTION
Replace em/en dashes with colons, semicolons, or commas throughout docs/ (bullet definition lists, mid-sentence asides, code comments, diagram labels). Keep the two verbatim external titles in the skip-locked sources, SQL comment syntax, and CLI arg separators.

Also rewrite a handful of participle-tail sentences (heartbeat, deferred-execution, scheduling, in-memory, drivers intros), rework negation-stack feature cards on the landing page, normalize numeric ranges to hyphens, and mark the PGPASSWORD default as (none).

mkdocs build --strict passes.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
