### PR TITLE
refactor(settings): make prefix a DBSettings field, deprecate add_prefix

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -134,8 +134,8 @@ Display a live dashboard showing job statistics.
 - `-i`, `--interval <seconds>`: Refresh interval. If not set, updates once and exits.
 - `-n`, `--limit <number>`: Number of most recent log entries to display (default: `25`).
 
-The table format can be controlled via the `TABLEFMT` environment variable
-(prefixed by `PGQUEUER_PREFIX` if set; default: `pretty`).
+The table format can be controlled via the `PGQUEUER_TABLEFMT` environment
+variable (legacy spelling `TABLEFMT` still works; default: `pretty`).
 
 ```bash
 pgq dashboard --interval 10 --limit 25

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -173,6 +173,11 @@ async def yield_queries(
         yield q
 
 
+def tablefmt() -> str:
+    """Tabulate table format; PGQUEUER_TABLEFMT preferred, legacy TABLEFMT honored."""
+    return os.environ.get("PGQUEUER_TABLEFMT", os.environ.get("TABLEFMT", "pretty"))
+
+
 async def display_stats(log_stats: list[models.LogStatistics]) -> None:
     print(
         tabulate(
@@ -187,7 +192,7 @@ async def display_stats(log_stats: list[models.LogStatistics]) -> None:
                 for stat in log_stats
             ],
             headers=["Created", "Count", "Entrypoint", "Status", "Priority"],
-            tablefmt=os.environ.get(qb.add_prefix("TABLEFMT"), "pretty"),
+            tablefmt=tablefmt(),
         )
     )
 
@@ -235,7 +240,7 @@ async def display_schedule(schedules: list[models.Schedule]) -> None:
                 "status",
                 "entrypoint",
             ],
-            tablefmt=os.environ.get(qb.add_prefix("TABLEFMT"), "pretty"),
+            tablefmt=tablefmt(),
         )
     )
 
@@ -626,7 +631,7 @@ def failed(
                 tabulate(
                     rows,
                     headers=["ID", "Entrypoint", "Attempts", "Created", "Payload bytes"],
-                    tablefmt=os.environ.get(qb.add_prefix("TABLEFMT"), "pretty"),
+                    tablefmt=tablefmt(),
                 )
             )
 

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -161,7 +161,7 @@ class QueryBuilderEnvironment:
     DROP TABLE      IF EXISTS   {self.settings.schedules_table};
     DROP TABLE      IF EXISTS   {self.settings.queue_table_log};
     DROP TYPE       IF EXISTS   {self.settings.queue_status_type};
-    DROP TYPE       IF EXISTS   {add_prefix("pgqueuer_statistics_status")};
+    DROP TYPE       IF EXISTS   {self.settings.legacy_statistics_status_type};
     """  # noqa
 
     def build_upgrade_queries(self) -> Generator[str, None, None]:

--- a/pgqueuer/domain/settings.py
+++ b/pgqueuer/domain/settings.py
@@ -5,27 +5,32 @@ from __future__ import annotations
 import dataclasses
 import os
 import re
+import warnings
 from enum import Enum
 from typing import Literal
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pgqueuer.domain.models import Channel
 
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 def add_prefix(string: str) -> str:
-    """Prepend ``PGQUEUER_PREFIX`` (if set) to *string* for namespacing DB objects."""
-    env = os.environ.get("PGQUEUER_PREFIX", "")
-    if env and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", env):
-        raise ValueError(
-            "Invalid prefix: The 'PGQUEUER_PREFIX' environment variable must "
-            "start with a letter or underscore and contain only letters, "
-            "numbers, and underscores. It cannot contain '.', spaces, or "
-            "other special characters."
-        )
+    """Deprecated: ``DBSettings`` applies ``PGQUEUER_PREFIX`` itself via its ``prefix`` field."""
+    warnings.warn(
+        "add_prefix is deprecated; DBSettings reads PGQUEUER_PREFIX itself "
+        "(DBSettings(prefix=...) or the PGQUEUER_PREFIX environment variable).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return f"{os.environ.get('PGQUEUER_PREFIX', '')}{string}"
 
-    return f"{env}{string}"
+
+def name_env_alias(field_name: str) -> AliasChoices:
+    """Env spellings for an object-name field: ``PGQUEUER_X`` plus the legacy bare ``X``."""
+    return AliasChoices(f"pgqueuer_{field_name}", field_name)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -117,24 +122,86 @@ class ConnectionSettings(BaseSettings):
 
 
 class DBSettings(BaseSettings):
-    """Names of PgQueuer DB objects, each prefixed via ``PGQUEUER_PREFIX``."""
+    """Names of PgQueuer DB objects, namespaced by ``prefix``.
+
+    Each name field accepts two env spellings: the ``PGQUEUER_``-prefixed one
+    (preferred) and the legacy bare one that predates it (e.g.
+    ``PGQUEUER_QUEUE_TABLE`` and ``QUEUE_TABLE``).
+    """
 
     model_config = SettingsConfigDict(
-        env_prefix=add_prefix(""),
+        env_prefix="PGQUEUER_",
         extra="ignore",
     )
 
-    channel: Channel = Field(default=Channel(add_prefix("ch_pgqueuer")))
-    function: str = Field(default=add_prefix("fn_pgqueuer_changed"))
-    statistics_table: str = Field(default=add_prefix("pgqueuer_statistics"))
-    queue_status_type: str = Field(default=add_prefix("pgqueuer_status"))
-    queue_table: str = Field(default=add_prefix("pgqueuer"))
-    queue_table_log: str = Field(default=add_prefix("pgqueuer_log"))
-    trigger: str = Field(default=add_prefix("tg_pgqueuer_changed"))
-    schedules_table: str = Field(default=add_prefix("pgqueuer_schedules"))
-    durability: Durability = Field(default=Durability.durable)
+    # Prepended to every object name not explicitly overridden; lets multiple
+    # PgQueuer instances share one database.
+    prefix: str = Field(default="")
+
+    channel: Channel = Field(
+        default=Channel("ch_pgqueuer"), validation_alias=name_env_alias("channel")
+    )
+    function: str = Field(
+        default="fn_pgqueuer_changed", validation_alias=name_env_alias("function")
+    )
+    statistics_table: str = Field(
+        default="pgqueuer_statistics", validation_alias=name_env_alias("statistics_table")
+    )
+    queue_status_type: str = Field(
+        default="pgqueuer_status", validation_alias=name_env_alias("queue_status_type")
+    )
+    queue_table: str = Field(default="pgqueuer", validation_alias=name_env_alias("queue_table"))
+    queue_table_log: str = Field(
+        default="pgqueuer_log", validation_alias=name_env_alias("queue_table_log")
+    )
+    trigger: str = Field(default="tg_pgqueuer_changed", validation_alias=name_env_alias("trigger"))
+    schedules_table: str = Field(
+        default="pgqueuer_schedules", validation_alias=name_env_alias("schedules_table")
+    )
+    durability: Durability = Field(
+        default=Durability.durable, validation_alias=name_env_alias("durability")
+    )
 
     # When True, `pgq upgrade` widens legacy int4 id columns/sequences to BIGINT
     # (issue #671). The widen takes an ACCESS EXCLUSIVE lock and rewrites each
     # table; set False to skip it and apply the widening out-of-band.
-    widen_id: bool = Field(default=True)
+    widen_id: bool = Field(default=True, validation_alias=name_env_alias("widen_id"))
+
+    @field_validator("prefix")
+    @classmethod
+    def validate_prefix(cls, value: str) -> str:
+        if value and not IDENTIFIER_PATTERN.match(value):
+            raise ValueError(
+                "prefix must start with a letter or underscore and contain only "
+                "letters, digits, and underscores"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def apply_prefix(self) -> DBSettings:
+        """Prepend ``prefix`` to every object name not explicitly overridden."""
+        if not self.prefix:
+            return self
+        fields_set = self.model_fields_set
+        if "channel" not in fields_set:
+            self.channel = Channel(f"{self.prefix}{self.channel}")
+        if "function" not in fields_set:
+            self.function = f"{self.prefix}{self.function}"
+        if "statistics_table" not in fields_set:
+            self.statistics_table = f"{self.prefix}{self.statistics_table}"
+        if "queue_status_type" not in fields_set:
+            self.queue_status_type = f"{self.prefix}{self.queue_status_type}"
+        if "queue_table" not in fields_set:
+            self.queue_table = f"{self.prefix}{self.queue_table}"
+        if "queue_table_log" not in fields_set:
+            self.queue_table_log = f"{self.prefix}{self.queue_table_log}"
+        if "trigger" not in fields_set:
+            self.trigger = f"{self.prefix}{self.trigger}"
+        if "schedules_table" not in fields_set:
+            self.schedules_table = f"{self.prefix}{self.schedules_table}"
+        return self
+
+    @property
+    def legacy_statistics_status_type(self) -> str:
+        """Pre-v0.27 enum type name, kept only so uninstall can drop it."""
+        return f"{self.prefix}pgqueuer_statistics_status"

--- a/pgqueuer/domain/settings.py
+++ b/pgqueuer/domain/settings.py
@@ -7,9 +7,9 @@ import os
 import re
 import warnings
 from enum import Enum
-from typing import Literal
+from typing import Callable, Literal
 
-from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pgqueuer.domain.models import Channel
@@ -31,6 +31,16 @@ def add_prefix(string: str) -> str:
 def name_env_alias(field_name: str) -> AliasChoices:
     """Env spellings for an object-name field: ``PGQUEUER_X`` plus the legacy bare ``X``."""
     return AliasChoices(f"pgqueuer_{field_name}", field_name)
+
+
+def prefixed_default(base: str) -> Callable[[dict[str, str]], str]:
+    """Default for an object-name field: *base* behind the already-validated ``prefix``.
+
+    Runs only when the field is not explicitly provided, so overrides are
+    never double-prefixed. Requires ``prefix`` to be declared before the name
+    fields (pydantic passes previously validated fields as ``data``).
+    """
+    return lambda data: f"{data['prefix']}{base}"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -135,28 +145,41 @@ class DBSettings(BaseSettings):
     )
 
     # Prepended to every object name not explicitly overridden; lets multiple
-    # PgQueuer instances share one database.
+    # PgQueuer instances share one database. Declared first: the name-field
+    # default factories read it from the validated data.
     prefix: str = Field(default="")
 
     channel: Channel = Field(
-        default=Channel("ch_pgqueuer"), validation_alias=name_env_alias("channel")
+        default_factory=lambda data: Channel(f"{data['prefix']}ch_pgqueuer"),
+        validation_alias=name_env_alias("channel"),
     )
     function: str = Field(
-        default="fn_pgqueuer_changed", validation_alias=name_env_alias("function")
+        default_factory=prefixed_default("fn_pgqueuer_changed"),
+        validation_alias=name_env_alias("function"),
     )
     statistics_table: str = Field(
-        default="pgqueuer_statistics", validation_alias=name_env_alias("statistics_table")
+        default_factory=prefixed_default("pgqueuer_statistics"),
+        validation_alias=name_env_alias("statistics_table"),
     )
     queue_status_type: str = Field(
-        default="pgqueuer_status", validation_alias=name_env_alias("queue_status_type")
+        default_factory=prefixed_default("pgqueuer_status"),
+        validation_alias=name_env_alias("queue_status_type"),
     )
-    queue_table: str = Field(default="pgqueuer", validation_alias=name_env_alias("queue_table"))
+    queue_table: str = Field(
+        default_factory=prefixed_default("pgqueuer"),
+        validation_alias=name_env_alias("queue_table"),
+    )
     queue_table_log: str = Field(
-        default="pgqueuer_log", validation_alias=name_env_alias("queue_table_log")
+        default_factory=prefixed_default("pgqueuer_log"),
+        validation_alias=name_env_alias("queue_table_log"),
     )
-    trigger: str = Field(default="tg_pgqueuer_changed", validation_alias=name_env_alias("trigger"))
+    trigger: str = Field(
+        default_factory=prefixed_default("tg_pgqueuer_changed"),
+        validation_alias=name_env_alias("trigger"),
+    )
     schedules_table: str = Field(
-        default="pgqueuer_schedules", validation_alias=name_env_alias("schedules_table")
+        default_factory=prefixed_default("pgqueuer_schedules"),
+        validation_alias=name_env_alias("schedules_table"),
     )
     durability: Durability = Field(
         default=Durability.durable, validation_alias=name_env_alias("durability")
@@ -176,30 +199,6 @@ class DBSettings(BaseSettings):
                 "letters, digits, and underscores"
             )
         return value
-
-    @model_validator(mode="after")
-    def apply_prefix(self) -> DBSettings:
-        """Prepend ``prefix`` to every object name not explicitly overridden."""
-        if not self.prefix:
-            return self
-        fields_set = self.model_fields_set
-        if "channel" not in fields_set:
-            self.channel = Channel(f"{self.prefix}{self.channel}")
-        if "function" not in fields_set:
-            self.function = f"{self.prefix}{self.function}"
-        if "statistics_table" not in fields_set:
-            self.statistics_table = f"{self.prefix}{self.statistics_table}"
-        if "queue_status_type" not in fields_set:
-            self.queue_status_type = f"{self.prefix}{self.queue_status_type}"
-        if "queue_table" not in fields_set:
-            self.queue_table = f"{self.prefix}{self.queue_table}"
-        if "queue_table_log" not in fields_set:
-            self.queue_table_log = f"{self.prefix}{self.queue_table_log}"
-        if "trigger" not in fields_set:
-            self.trigger = f"{self.prefix}{self.trigger}"
-        if "schedules_table" not in fields_set:
-            self.schedules_table = f"{self.prefix}{self.schedules_table}"
-        return self
 
     @property
     def legacy_statistics_status_type(self) -> str:

--- a/test/test_listeners.py
+++ b/test/test_listeners.py
@@ -14,7 +14,7 @@ from pgqueuer.core.listeners import (
     default_event_router,
     initialize_notice_event_listener,
 )
-from pgqueuer.domain.settings import DBSettings, add_prefix
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.models import (
     AnyEvent,
     CancellationEvent,
@@ -125,7 +125,7 @@ async def test_emit_stable_changed_insert(apgdriver: db.Driver) -> None:
     (event,) = evnets
 
     assert event.root.type == "table_changed_event"
-    assert event.root.table == add_prefix("pgqueuer")
+    assert event.root.table == DBSettings().queue_table
     assert event.root.operation == "insert"
 
 
@@ -149,7 +149,7 @@ async def test_emit_stable_changed_update(apgdriver: db.Driver) -> None:
     (event,) = evnets
 
     assert event.root.type == "table_changed_event"
-    assert event.root.table == add_prefix("pgqueuer")
+    assert event.root.table == DBSettings().queue_table
     assert event.root.operation == "insert"
     evnets.clear()
 
@@ -190,7 +190,7 @@ async def test_emits_truncate_table_truncate(apgdriver: db.Driver) -> None:
     (event,) = evnets
 
     assert event.root.type == "table_changed_event"
-    assert event.root.table == add_prefix("pgqueuer")
+    assert event.root.table == DBSettings().queue_table
     assert event.root.operation == "truncate"
     evnets.clear()
 
@@ -214,7 +214,7 @@ async def test_pgqueuer_heartbeat_event_trigger(apgdriver: db.Driver) -> None:
 
     (event,) = evnets
     assert event.root.type == "table_changed_event"
-    assert event.root.table == add_prefix("pgqueuer")
+    assert event.root.table == DBSettings().queue_table
     evnets.clear()
 
     await asyncio.gather(

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,17 +1,70 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
-from pgqueuer.domain.settings import ConnectionSettings
+from pgqueuer.domain.settings import ConnectionSettings, DBSettings, add_prefix
 
 pytestmark = pytest.mark.usefixtures("clean_connection_env")
 
 
 def test_statistics_table_status_type_removed() -> None:
     """statistics_table_status_type was removed in v0.27.0."""
-    from pgqueuer.domain.settings import DBSettings
-
     assert "statistics_table_status_type" not in DBSettings.model_fields
+
+
+def test_prefix_applies_to_all_object_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PGQUEUER_PREFIX is read at instantiation, not import time."""
+    monkeypatch.setenv("PGQUEUER_PREFIX", "acme_")
+    settings = DBSettings()
+    assert settings.queue_table == "acme_pgqueuer"
+    assert settings.channel == "acme_ch_pgqueuer"
+    assert settings.function == "acme_fn_pgqueuer_changed"
+    assert settings.statistics_table == "acme_pgqueuer_statistics"
+    assert settings.queue_status_type == "acme_pgqueuer_status"
+    assert settings.queue_table_log == "acme_pgqueuer_log"
+    assert settings.trigger == "acme_tg_pgqueuer_changed"
+    assert settings.schedules_table == "acme_pgqueuer_schedules"
+
+
+def test_prefix_skips_explicit_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicitly set names (constructor or env) are used verbatim, never double-prefixed."""
+    assert DBSettings(prefix="acme_", queue_table="jobs").queue_table == "jobs"
+
+    monkeypatch.setenv("PGQUEUER_PREFIX", "acme_")
+    monkeypatch.setenv("PGQUEUER_QUEUE_TABLE", "jobs")
+    settings = DBSettings()
+    assert settings.queue_table == "jobs"
+    assert settings.statistics_table == "acme_pgqueuer_statistics"
+
+
+def test_legacy_bare_env_spelling_still_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pre-refactor env overrides used the bare field name (env_prefix was the prefix value)."""
+    monkeypatch.setenv("QUEUE_TABLE", "legacy_jobs")
+    assert DBSettings().queue_table == "legacy_jobs"
+
+    monkeypatch.setenv("PGQUEUER_QUEUE_TABLE", "new_jobs")
+    assert DBSettings().queue_table == "new_jobs"  # new spelling wins when both are set
+
+
+def test_invalid_prefix_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PGQUEUER_PREFIX", "bad.dot")
+    with pytest.raises(ValidationError, match="prefix"):
+        DBSettings()
+
+
+def test_legacy_statistics_status_type_carries_prefix() -> None:
+    assert DBSettings().legacy_statistics_status_type == "pgqueuer_statistics_status"
+    assert (
+        DBSettings(prefix="acme_").legacy_statistics_status_type
+        == "acme_pgqueuer_statistics_status"
+    )
+
+
+def test_add_prefix_shim_warns_and_concats(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PGQUEUER_PREFIX", "acme_")
+    with pytest.deprecated_call():
+        assert add_prefix("pgqueuer") == "acme_pgqueuer"
 
 
 def test_connection_settings_defaults() -> None:

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -22,10 +22,14 @@ from tqdm.asyncio import tqdm
 from pgqueuer import PgQueuer, types
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, PsycopgDriver
-from pgqueuer.domain.settings import add_prefix
 from pgqueuer.models import Job
 from pgqueuer.ports import RepositoryPort
 from pgqueuer.queries import Queries
+
+
+def tablefmt() -> str:
+    """Tabulate table format; PGQUEUER_TABLEFMT preferred, legacy TABLEFMT honored."""
+    return os.environ.get("PGQUEUER_TABLEFMT", os.environ.get("TABLEFMT", "pretty"))
 
 
 def job_progress_bar(total: int | None = None) -> tqdm:
@@ -73,7 +77,7 @@ class BenchmarkResult(BaseModel):
                     ["Queued", self.queued],
                 ],
                 headers=["Field", "Value"],
-                tablefmt=os.environ.get(add_prefix("TABLEFMT"), "pretty"),
+                tablefmt=tablefmt(),
                 colalign=("left", "left"),
             )
         )
@@ -127,7 +131,7 @@ class ThroughputSettings(BaseModel):
                     ["Output JSON", self.output_json or "None"],
                 ],
                 headers=["Field", "Value"],
-                tablefmt=os.environ.get(add_prefix("TABLEFMT"), "pretty"),
+                tablefmt=tablefmt(),
                 colalign=("left", "left"),
             )
         )
@@ -171,7 +175,7 @@ class DrainSettings(BaseModel):
                     ["Output JSON", self.output_json or "None"],
                 ],
                 headers=["Field", "Value"],
-                tablefmt=os.environ.get(add_prefix("TABLEFMT"), "pretty"),
+                tablefmt=tablefmt(),
                 colalign=("left", "left"),
             )
         )

--- a/tools/prometheus/prometheus.py
+++ b/tools/prometheus/prometheus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from itertools import groupby
@@ -10,7 +11,6 @@ from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.responses import Response
 
 from pgqueuer.db import AsyncpgDriver
-from pgqueuer.domain.settings import add_prefix
 from pgqueuer.models import LogStatistics, QueueStatistics
 from pgqueuer.queries import Queries
 
@@ -40,7 +40,8 @@ def prometheus_format(
 ) -> str:
     """Format metric data into a Prometheus-compatible string."""
     label_parts = ",".join(f'{k}="{v}"' for k, v in labels.items())
-    return f"{add_prefix(metric_name)}{{{label_parts}}} {value}"
+    prefix = os.environ.get("PGQUEUER_PREFIX", "")
+    return f"{prefix}{metric_name}{{{label_parts}}} {value}"
 
 
 def aggregated_queue_statistics(


### PR DESCRIPTION
add_prefix read PGQUEUER_PREFIX at import time while the CLI set it at runtime, and env_prefix=add_prefix("") conflated the object-name prefix with the pydantic env-var namespace. prefix is now a validated field applied by a model validator to names not explicitly overridden.

Backward compatible: add_prefix remains as a deprecated shim, legacy bare env spellings (QUEUE_TABLE, DURABILITY, ...) still bind alongside the new PGQUEUER_* ones, and TABLEFMT still works as a fallback for PGQUEUER_TABLEFMT. Generated SQL is byte-identical to before.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
