### PR TITLE
test: bump testcontainers to >=4.14.2 to drop deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ dev = [
     "types-tabulate",
     "uvicorn",
     "time-machine>=2.16.0",
-    "testcontainers>=4.12.0",
+    "testcontainers>=4.14.2",
     "import-linter>=2.0",
     "mcp>=1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1478,7 +1478,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.0.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
-    { name = "testcontainers", marker = "extra == 'dev'", specifier = ">=4.12.0" },
+    { name = "testcontainers", marker = "extra == 'dev'", specifier = ">=4.14.2" },
     { name = "time-machine", marker = "extra == 'dev'", specifier = ">=2.16.0" },
     { name = "tqdm", marker = "extra == 'dev'" },
     { name = "typer", specifier = ">=0.15.1" },
@@ -2228,7 +2228,7 @@ wheels = [
 
 [[package]]
 name = "testcontainers"
-version = "4.13.2"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docker" },
@@ -2237,9 +2237,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/51/edac83edab339d8b4dce9a7b659163afb1ea7e011bfed1d5573d495a4485/testcontainers-4.13.2.tar.gz", hash = "sha256:2315f1e21b059427a9d11e8921f85fef322fbe0d50749bcca4eaa11271708ba4", size = 78692, upload-time = "2025-10-07T21:53:07.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/5e/73aa94770f1df0595364aed526f31d54440db5492911e2857318ed326e51/testcontainers-4.13.2-py3-none-any.whl", hash = "sha256:0209baf8f4274b568cde95bef2cadf7b1d33b375321f793790462e235cd684ee", size = 124771, upload-time = "2025-10-07T21:53:05.937Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
testcontainers 4.13.x decorates its own deprecated wait_for helper with @wait_container_is_ready() at module import, emitting a DeprecationWarning on every 'from testcontainers.core.container import DockerContainer'. The suite already uses the modern HealthcheckWaitStrategy, so the warning is pure noise from the dependency.

4.14.2 removed that import-time self-decoration, so bumping the floor clears the warning at its source. DB-backed tests still pass.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
