### PR TITLE
feat(stats): periodic log->statistics aggregation without cron

### DIFF
--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -14,6 +14,7 @@ await pgq.run(batch_size=25, dequeue_timeout=timedelta(seconds=10))
 |-----------|---------|--------|
 | `batch_size` | `10` | Jobs fetched per dequeue round-trip |
 | `dequeue_timeout` | `30 s` | How long to wait for new NOTIFY before polling |
+| `log_aggregation_interval` | `30 s` | How often to roll `pgqueuer_log` into `pgqueuer_statistics`; `0` disables (aggregate on read) |
 
 **Tuning guidance:**
 - Increase `batch_size` when jobs are short-lived (< 1 s) and you see many dequeue round-trips

--- a/docs/guides/reliability.md
+++ b/docs/guides/reliability.md
@@ -193,6 +193,24 @@ or use `pgq dashboard` from the CLI.
     PgQueuer does not automatically prune `pgqueuer_log`. Add a periodic `DELETE` job or
     PostgreSQL table partition policy to manage log growth in high-throughput systems.
 
+## Statistics Aggregation
+
+Rows in `pgqueuer_log` are rolled up into per-second counts in `pgqueuer_statistics`
+(grouped by entrypoint, priority, and status). `QueueManager` runs this aggregation on a
+timer while it processes jobs, so statistics stay current without anyone reading them:
+
+```python
+await pgq.run(log_aggregation_interval=timedelta(seconds=30))
+```
+
+- Default interval is 30 seconds. The task runs on every worker, but a Postgres advisory
+  lock lets only one worker aggregate at a time, so counts are never doubled.
+- Pass `timedelta(0)` to disable the background task. Aggregation then happens only
+  on-demand, the first time statistics are read (CLI `pgq dashboard`, Prometheus metrics,
+  or the MCP server).
+- Aggregation never deletes log rows; it flags them `aggregated = TRUE`. Log retention is
+  still your responsibility (see the note above).
+
 ## Summary
 
 | Concern | Mechanism |
@@ -204,3 +222,4 @@ or use `pgq dashboard` from the CLI.
 | Graceful duplicate handling in batches | `enqueue(..., on_conflict="skip")` |
 | Failure inspection | `pgqueuer_log` with traceback |
 | Audit trail | `pgqueuer_log` for all terminal states |
+| Up-to-date statistics | periodic `log_aggregation_interval` |

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -675,6 +675,10 @@ class InMemoryQueries:
             )
             self._next_stats_id += 1
 
+    async def aggregate_logs(self) -> None:
+        """Fold unaggregated log rows into per-second statistics buckets."""
+        self.aggregate_log_to_statistics()
+
     async def log_statistics(
         self,
         limit: int | None,

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -746,31 +746,42 @@ SELECT * FROM claimed ORDER BY priority DESC, id ASC;
     def build_fetch_log_query(self) -> str:
         return f"SELECT * FROM {self.qualified.queue_table_log}"
 
-    def build_aggregate_log_data_to_statistics_query(self) -> str:
-        return f"""WITH log_aggregation AS (
+    def build_aggregate_log_data_to_statistics_query(self, advisory_lock: bool = False) -> str:
+        """Fold unaggregated log rows into per-second statistics buckets.
+
+        A single-row ``guard`` CTE gates the whole statement. With
+        ``advisory_lock=True`` its ``proceed`` column is a
+        ``pg_try_advisory_xact_lock``, so concurrent workers serialize on
+        aggregation (losers see ``proceed = FALSE`` and no-op) -- used by the
+        periodic background task. Without it ``proceed`` is an unconditional
+        ``TRUE`` (the on-demand ``log_statistics`` read path).
+        """
+        log = self.qualified.queue_table_log
+        stats = self.qualified.statistics_table
+        proceed = f"pg_try_advisory_xact_lock(hashtext('{stats}'))" if advisory_lock else "TRUE"
+        return f"""WITH guard AS (
+            SELECT {proceed} AS proceed
+        ),
+        log_aggregation AS (
             SELECT
                 entrypoint,
                 priority,
                 status,
                 COUNT(*) AS count,
                 date_trunc('sec', created) AS created
-            FROM {self.qualified.queue_table_log}
-            WHERE NOT aggregated
+            FROM {log}, guard
+            WHERE NOT aggregated AND guard.proceed
             GROUP BY entrypoint, priority, status, date_trunc('sec', created)
         ),
         updated_logs AS (
-            UPDATE {self.qualified.queue_table_log}
+            UPDATE {log}
             SET aggregated = TRUE
-            WHERE NOT aggregated
+            FROM guard
+            WHERE NOT aggregated AND guard.proceed
             RETURNING id
         )
-        INSERT INTO {self.qualified.statistics_table} (count, created, entrypoint, priority, status)
-        SELECT
-            count,
-            created,
-            entrypoint,
-            priority,
-            status
+        INSERT INTO {stats} (count, created, entrypoint, priority, status)
+        SELECT count, created, entrypoint, priority, status
         FROM log_aggregation
         ON CONFLICT (
             priority,
@@ -778,7 +789,7 @@ SELECT * FROM claimed ORDER BY priority DESC, id ASC;
             status,
             entrypoint
         ) DO UPDATE SET
-            count = {self.qualified.statistics_table}.count + EXCLUDED.count
+            count = {stats}.count + EXCLUDED.count
         """  # noqa
 
     def build_retry_job_query(self) -> str:

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -417,13 +417,25 @@ class Queries:
         else:
             await self.driver.execute(self.qbq.build_truncate_log_query())
 
+    async def aggregate_logs(self) -> None:
+        """Fold unaggregated pgqueuer_log rows into pgqueuer_statistics.
+
+        Advisory-locked so concurrent workers running the periodic task serialize
+        on aggregation instead of double-counting.
+        """
+        await self.driver.execute(
+            self.qbq.build_aggregate_log_data_to_statistics_query(advisory_lock=True)
+        )
+
     async def log_statistics(
         self,
         limit: int | None,
         last: timedelta | None = None,
     ) -> list[models.LogStatistics]:
         """Aggregate pending log rows, then return up to *limit* recent stats within *last*."""
-        await self.driver.execute(self.qbq.build_aggregate_log_data_to_statistics_query())
+        await self.driver.execute(
+            self.qbq.build_aggregate_log_data_to_statistics_query(advisory_lock=False)
+        )
         return [
             models.LogStatistics.model_validate(x)
             for x in await self.driver.fetch(

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -161,6 +161,7 @@ class PgQueuer:
         max_concurrent_tasks: int | None = None,
         shutdown_on_listener_failure: bool = False,
         heartbeat_timeout: timedelta = timedelta(seconds=30),
+        log_aggregation_interval: timedelta = timedelta(seconds=30),
     ) -> None:
         """Run QueueManager and SchedulerManager concurrently."""
         tasks = [
@@ -172,6 +173,7 @@ class PgQueuer:
                     max_concurrent_tasks=max_concurrent_tasks,
                     shutdown_on_listener_failure=shutdown_on_listener_failure,
                     heartbeat_timeout=heartbeat_timeout,
+                    log_aggregation_interval=log_aggregation_interval,
                 )
             ),
             asyncio.create_task(self.sm.run()),

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
+import random
 import sys
 import uuid
 from collections.abc import MutableMapping
@@ -111,6 +112,23 @@ class QueueManager:
                 await asyncio.wait_for(
                     self.shutdown.wait(),
                     timeout=interval.total_seconds(),
+                )
+
+    async def _run_periodic_log_aggregation(self, interval: timedelta) -> None:
+        """Aggregate log->statistics every *interval* (jittered) until shutdown.
+
+        Non-cron: mirrors ``_run_periodic_health_check``. Aggregation failures are
+        swallowed so a transient DB hiccup never tears down the worker; the next
+        tick retries. The advisory lock in ``aggregate_logs`` serializes across
+        workers, and the jitter desyncs their ticks.
+        """
+        while not self.shutdown.is_set():
+            with suppress(Exception):
+                await self.queries.aggregate_logs()
+            with suppress(TimeoutError, asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    self.shutdown.wait(),
+                    timeout=interval.total_seconds() * random.uniform(0.8, 1.2),
                 )
 
     def get_context(self, job_id: models.JobId) -> models.Context:
@@ -346,6 +364,7 @@ class QueueManager:
         max_concurrent_tasks: int | None = None,
         shutdown_on_listener_failure: bool = False,
         heartbeat_timeout: timedelta = timedelta(seconds=30),
+        log_aggregation_interval: timedelta = timedelta(seconds=30),
     ) -> None:
         """Process jobs until shutdown.
 
@@ -356,6 +375,9 @@ class QueueManager:
         of the tightest registered limit.
         ``heartbeat_timeout`` is the staleness threshold for re-picking a job;
         heartbeats are emitted at half this interval.
+        ``log_aggregation_interval`` drives a background task that folds
+        ``pgqueuer_log`` into ``pgqueuer_statistics`` on a timer instead of only
+        on stats reads; pass ``timedelta(0)`` to disable (pure on-demand).
         """
         await self.verify_structure()
 
@@ -383,6 +405,15 @@ class QueueManager:
             tm.cancel_on_exit(
                 asyncio.create_task(self._run_periodic_health_check())
             ) as periodic_health_check_task,
+            (
+                tm.cancel_on_exit(
+                    asyncio.create_task(
+                        self._run_periodic_log_aggregation(log_aggregation_interval)
+                    )
+                )
+                if log_aggregation_interval.total_seconds() > 0
+                else nullcontext()
+            ),
             tm.cancel_on_exit(asyncio.create_task(self.shutdown.wait())) as shutdown_task,
         ):
             notice_event_listener = listeners.PGNoticeEventListener()

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -142,6 +142,10 @@ class QueueRepositoryPort(Protocol):
 
     async def queue_log(self) -> list[models.Log]: ...
 
+    async def aggregate_logs(self) -> None:
+        """Fold unaggregated log rows into statistics without reading them back."""
+        ...
+
     async def log_statistics(
         self,
         limit: int | None,

--- a/test/test_port_conformance.py
+++ b/test/test_port_conformance.py
@@ -21,6 +21,7 @@ def test_queries_has_queue_repository_methods() -> None:
         "eligible_queued_work",
         "queue_log",
         "job_status",
+        "aggregate_logs",
     }
     assert required <= set(dir(Queries))
 
@@ -69,6 +70,7 @@ def test_inmemory_has_queue_repository_methods() -> None:
         "eligible_queued_work",
         "queue_log",
         "job_status",
+        "aggregate_logs",
     }
     assert required <= set(dir(InMemoryQueries))
 

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -163,6 +163,43 @@ async def test_drain_mode(
     assert len(jobs) == N
 
 
+async def test_periodic_log_aggregation_loops_until_shutdown() -> None:
+    """The periodic task calls aggregate_logs repeatedly and stops on shutdown."""
+    calls = 0
+    qm: QueueManager
+
+    class Stub:
+        async def aggregate_logs(self) -> None:
+            nonlocal calls
+            calls += 1
+            if calls >= 3:
+                qm.shutdown.set()
+
+    qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
+    async with async_timeout.timeout(5):
+        await qm._run_periodic_log_aggregation(timedelta(seconds=0))
+    assert calls == 3
+
+
+async def test_periodic_log_aggregation_survives_aggregate_errors() -> None:
+    """A failing aggregate_logs never tears down the loop; the next tick retries."""
+    calls = 0
+    qm: QueueManager
+
+    class Stub:
+        async def aggregate_logs(self) -> None:
+            nonlocal calls
+            calls += 1
+            if calls >= 3:
+                qm.shutdown.set()
+            raise RuntimeError("boom")
+
+    qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
+    async with async_timeout.timeout(5):
+        await qm._run_periodic_log_aggregation(timedelta(seconds=0))
+    assert calls == 3
+
+
 @pytest.mark.parametrize("N", (1, 10, 100))
 async def test_traceback_log(
     apgdriver: db.Driver,

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -857,6 +857,71 @@ async def test_log_statistics(
     assert sum(x.count for x in stats) == 3 * N
 
 
+async def _unaggregated_count(q: queries.Queries) -> int:
+    rows = await q.driver.fetch(q.qbq.build_unaggregated_log_count_query())
+    return int(rows[0]["unaggregated"])
+
+
+async def _log_n_successful(q: queries.Queries, N: int) -> None:
+    await q.enqueue(["placeholder"] * N, [None] * N, [0] * N)
+    jobs = await q.dequeue(
+        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
+        batch_size=N,
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=1000,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+    assert len(jobs) == N
+    for job in jobs:
+        await q.log_jobs([(job, "successful", None)])
+
+
+async def test_aggregate_logs_populates_statistics_without_read(apgdriver: db.Driver) -> None:
+    """aggregate_logs folds log rows into statistics with no log_statistics read."""
+    q = queries.Queries(apgdriver)
+    N = 5
+    await _log_n_successful(q, N)
+
+    assert await _unaggregated_count(q) > 0
+
+    await q.aggregate_logs()
+
+    assert await _unaggregated_count(q) == 0
+    stats = await q.driver.fetch(q.qbq.build_log_statistics_query(), None, None)
+    assert sum(int(r["count"]) for r in stats) == 3 * N  # queued + picked + successful
+
+
+async def test_aggregate_logs_advisory_lock_skips_when_held(
+    apgdriver: db.Driver,
+    dsn: str,
+) -> None:
+    """aggregate_logs no-ops while another session holds the aggregation advisory lock."""
+    q = queries.Queries(apgdriver)
+    N = 4
+    await _log_n_successful(q, N)
+
+    lock_key = f"hashtext('{q.qbq.qualified.statistics_table}')"
+
+    # Hold the advisory xact lock in a separate session for the duration.
+    holder = await asyncpg.connect(dsn=dsn)
+    try:
+        tx = holder.transaction()
+        await tx.start()
+        await holder.execute(f"SELECT pg_advisory_xact_lock({lock_key})")
+
+        # Lock held -> aggregation must be a no-op.
+        await q.aggregate_logs()
+        assert await _unaggregated_count(q) == 3 * N
+
+        await tx.rollback()  # release the lock
+    finally:
+        await holder.close()
+
+    # Lock free -> aggregation proceeds.
+    await q.aggregate_logs()
+    assert await _unaggregated_count(q) == 0
+
+
 async def test_enqueue_with_headers(apgdriver: db.Driver) -> None:
     q = queries.Queries(apgdriver)
     headers = {"trace": "abc"}


### PR DESCRIPTION
  Aggregation of pgqueuer_log into pgqueuer_statistics was pull-based: it ran
  only as a side effect of a stats read (CLI, Prometheus, MCP). When nothing
  queried stats, unaggregated log rows piled up, and long gaps forced large
  backlog aggregations (#623).

  Run aggregation on a timer inside QueueManager.run() instead, following the
  existing _run_periodic_health_check background task. No cron, no
  schedules_table, no croniter.

  - Add RepositoryPort.aggregate_logs(): folds log rows into statistics
    without reading them back (postgres and in-memory adapters).
  - Give build_aggregate_log_data_to_statistics_query an advisory_lock kwarg.
    When True it wraps the statement in pg_try_advisory_xact_lock, so
    concurrent workers take turns instead of double-counting; when False the
    SQL is byte-identical to before. aggregate_logs uses the locked variant;
    log_statistics keeps the unlocked on-demand behavior.
  - Add QueueManager._run_periodic_log_aggregation(interval): runs
    aggregate_logs on a jittered, shutdown-aware timer and swallows errors, so
    a transient DB failure does not tear down the worker. run() gains
    log_aggregation_interval (default 30s); timedelta(0) disables it (pure
    on-demand). Threaded through PgQueuer.run()

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
