### PR TITLE
refactor(qb): extract dequeue into DequeueQueryBuilder

### DIFF
--- a/docs/reference/skip-locked.md
+++ b/docs/reference/skip-locked.md
@@ -132,7 +132,7 @@ on commit. Three documented details:[^locking]
 
 ## In PgQueuer
 
-[`build_dequeue_query`](https://github.com/janbjorge/pgqueuer/blob/main/pgqueuer/adapters/persistence/qb.py)
+[`DequeueQueryBuilder`](https://github.com/janbjorge/pgqueuer/blob/main/pgqueuer/adapters/persistence/qb.py)
 is the correct pattern, twice (simplified below; the real query adds
 concurrency-limit gating and a pick-logging CTE):
 

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -159,6 +159,7 @@ def create_default_queries_factory(
                     qbe=qb.QueryBuilderEnvironment(settings),
                     qbq=qb.QueryQueueBuilder(settings),
                     qbs=qb.QuerySchedulerBuilder(settings),
+                    dequeue_builder=qb.DequeueQueryBuilder(settings),
                 )
             return
         with contextlib.suppress(ImportError):
@@ -171,6 +172,7 @@ def create_default_queries_factory(
                     qbe=qb.QueryBuilderEnvironment(settings),
                     qbq=qb.QueryQueueBuilder(settings),
                     qbs=qb.QuerySchedulerBuilder(settings),
+                    dequeue_builder=qb.DequeueQueryBuilder(settings),
                 )
             return
         raise RuntimeError("Neither asyncpg nor psycopg could be imported.")

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -16,6 +16,7 @@ from pgqueuer.domain.types import OnConflict, SortOrder
 # Re-export for backward compatibility within the adapter layer
 __all__ = [
     "DBSettings",
+    "DequeueQueryBuilder",
     "Durability",
     "DurabilityPolicy",
     "QualifiedNames",
@@ -456,42 +457,51 @@ ALTER TABLE {self.qualified.statistics_table} RESET (
 
 
 @dataclasses.dataclass
-class QueryQueueBuilder:
+class DequeueQueryBuilder:
+    """The dequeue statement, assembled from one method per CTE.
+
+    ``render`` stitches the CTEs below into a single atomic statement -- the
+    LATERAL lookup, ``FOR UPDATE SKIP LOCKED`` claim, ``UPDATE ... RETURNING``,
+    and pick-log ``INSERT`` must stay in one statement to claim jobs without a
+    race. The pipeline is: params -> picked -> worker_load -> available ->
+    next_queued + next_stale -> eligible -> claimed -> log_pick.
+    """
+
     settings: DBSettings = dataclasses.field(default_factory=DBSettings)
 
     @property
     def qualified(self) -> QualifiedNames:
         return self.settings.qualified
 
-    def build_dequeue_query(self) -> str:
-        t = self.qualified.queue_table
-        t_log = self.qualified.queue_table_log
-        return f"""WITH
--- Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.
+    def cte_params(self) -> str:
+        return """-- Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.
 params AS (
     SELECT
         UNNEST($2::text[])   AS entrypoint,
         UNNEST($3::bigint[]) AS concurrency_limit
-),
+)"""
 
--- Per-entrypoint count of picked jobs (global, all workers).
+    def cte_picked(self) -> str:
+        return f"""-- Per-entrypoint count of picked jobs (global, all workers).
 picked AS (
     SELECT entrypoint, COUNT(*) AS total
-    FROM {t}
+    FROM {self.qualified.queue_table}
     WHERE queue_manager_id IS NOT NULL
       AND entrypoint = ANY($2)
     GROUP BY entrypoint
-),
+)"""
 
--- This worker's total picked jobs (scalar, for max_concurrent_tasks).
+    def cte_worker_load(self) -> str:
+        return f"""-- This worker's total picked jobs (scalar, for max_concurrent_tasks).
 worker_load AS (
     SELECT COUNT(*) AS total
-    FROM {t}
+    FROM {self.qualified.queue_table}
     WHERE queue_manager_id = $4
       AND entrypoint = ANY($2)
-),
+)"""
 
--- Entrypoints with free capacity (concurrency gate applied here instead of
+    def cte_available(self) -> str:
+        return """-- Entrypoints with free capacity (concurrency gate applied here instead of
 -- row-scan). remaining is NULL for unlimited entrypoints; otherwise it caps
 -- how many rows one dequeue may pick so a single statement cannot exceed
 -- the entrypoint's concurrency_limit.
@@ -506,8 +516,10 @@ available AS (
     LEFT JOIN picked pk ON pk.entrypoint = p.entrypoint
     WHERE p.concurrency_limit <= 0
        OR COALESCE(pk.total, 0) < p.concurrency_limit
-),
+)"""
 
+    def cte_next_queued(self) -> str:
+        return f"""
 -- New queued jobs: per-entrypoint LATERAL lookup hits (entrypoint, priority, id) partial index.
 -- LEAST($1, NULL) = $1, so unlimited entrypoints keep the full batch.
 next_queued AS (
@@ -515,7 +527,7 @@ next_queued AS (
     FROM available a
     CROSS JOIN LATERAL (
         SELECT q2.id, q2.priority
-        FROM {t} q2
+        FROM {self.qualified.queue_table} q2
         WHERE q2.entrypoint = a.entrypoint
           AND q2.status = 'queued'
           AND q2.execute_after < NOW()
@@ -527,15 +539,16 @@ next_queued AS (
            OR (SELECT total FROM worker_load) < $5)
     ORDER BY q.priority DESC, q.id ASC
     LIMIT $1
-),
+)"""
 
--- Stale picked jobs whose heartbeat timed out. The concurrency gate from
+    def cte_next_stale(self) -> str:
+        return f"""-- Stale picked jobs whose heartbeat timed out. The concurrency gate from
 -- next_queued is intentionally omitted: re-picking only transfers ownership
 -- of a row already counted in `picked`, so net live execution is unchanged.
 -- Applying the gate would deadlock recovery once leaked rows fill the slot.
 next_stale AS (
     SELECT q.id, q.priority
-    FROM {t} q
+    FROM {self.qualified.queue_table} q
     JOIN params p ON p.entrypoint = q.entrypoint
     WHERE q.status = 'picked'
       AND q.heartbeat < NOW() - $6::interval
@@ -545,9 +558,10 @@ next_stale AS (
     ORDER BY q.priority DESC, q.id ASC
     FOR UPDATE SKIP LOCKED
     LIMIT $1
-),
+)"""
 
--- Merge both sets into one global priority order so a recovered stale job
+    def cte_eligible(self) -> str:
+        return """-- Merge both sets into one global priority order so a recovered stale job
 -- competes on priority with fresh work instead of always losing to it.
 -- The LIMIT hard-caps this worker's total picked rows at $5: the binary
 -- worker_load gates above only stop a dequeue from starting once over
@@ -560,24 +574,53 @@ eligible AS (
     ) combined
     ORDER BY priority DESC, id ASC
     LIMIT GREATEST(LEAST($1, COALESCE($5 - (SELECT total FROM worker_load), $1)), 0)
-),
+)"""
 
--- Atomically claim the jobs and log the pick event.
+    def cte_claimed(self) -> str:
+        return f"""-- Atomically claim the jobs and log the pick event.
 claimed AS (
-    UPDATE {t}
+    UPDATE {self.qualified.queue_table}
     SET status = 'picked',
         updated   = NOW(),
         heartbeat = NOW(),
         queue_manager_id = $4
     WHERE id IN (SELECT id FROM eligible)
     RETURNING *
-),
-log_pick AS (
-    INSERT INTO {t_log} (job_id, status, entrypoint, priority)
+)"""
+
+    def cte_log_pick(self) -> str:
+        return f"""log_pick AS (
+    INSERT INTO {self.qualified.queue_table_log} (job_id, status, entrypoint, priority)
     SELECT id, status, entrypoint, priority FROM claimed
-)
+)"""
+
+    def render(self) -> str:
+        ctes = ",\n\n".join(
+            (
+                self.cte_params(),
+                self.cte_picked(),
+                self.cte_worker_load(),
+                self.cte_available(),
+                self.cte_next_queued(),
+                self.cte_next_stale(),
+                self.cte_eligible(),
+                self.cte_claimed(),
+                self.cte_log_pick(),
+            )
+        )
+        return f"""WITH
+{ctes}
 SELECT * FROM claimed ORDER BY priority DESC, id ASC;
-"""  # noqa
+"""  # noqa: E501
+
+
+@dataclasses.dataclass
+class QueryQueueBuilder:
+    settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+
+    @property
+    def qualified(self) -> QualifiedNames:
+        return self.settings.qualified
 
     def build_has_queued_work(self) -> str:
         return f"""

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -458,13 +458,15 @@ ALTER TABLE {self.qualified.statistics_table} RESET (
 
 @dataclasses.dataclass
 class DequeueQueryBuilder:
-    """The dequeue statement, assembled from one method per CTE.
+    """Build the single atomic statement that claims a batch of jobs.
 
-    ``render`` stitches the CTEs below into a single atomic statement -- the
-    LATERAL lookup, ``FOR UPDATE SKIP LOCKED`` claim, ``UPDATE ... RETURNING``,
-    and pick-log ``INSERT`` must stay in one statement to claim jobs without a
-    race. The pipeline is: params -> picked -> worker_load -> available ->
-    next_queued + next_stale -> eligible -> claimed -> log_pick.
+    The whole dequeue is one statement on purpose: the per-entrypoint LATERAL
+    lookup, the ``FOR UPDATE SKIP LOCKED`` selection, the ``UPDATE ...
+    RETURNING`` claim, and the pick-log ``INSERT`` must run together to claim
+    jobs without a race. ``render`` returns it as one linear block; read it
+    top-to-bottom, the CTEs run in the order they are written:
+    params -> picked -> worker_load -> available -> next_queued + next_stale
+    -> eligible -> claimed -> log_pick.
     """
 
     settings: DBSettings = dataclasses.field(default_factory=DBSettings)
@@ -473,35 +475,35 @@ class DequeueQueryBuilder:
     def qualified(self) -> QualifiedNames:
         return self.settings.qualified
 
-    def cte_params(self) -> str:
-        return """-- Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.
+    def render(self) -> str:
+        t = self.qualified.queue_table
+        t_log = self.qualified.queue_table_log
+        return f"""WITH
+-- Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.
 params AS (
     SELECT
         UNNEST($2::text[])   AS entrypoint,
         UNNEST($3::bigint[]) AS concurrency_limit
-)"""
+),
 
-    def cte_picked(self) -> str:
-        return f"""-- Per-entrypoint count of picked jobs (global, all workers).
+-- Per-entrypoint count of picked jobs (global, all workers).
 picked AS (
     SELECT entrypoint, COUNT(*) AS total
-    FROM {self.qualified.queue_table}
+    FROM {t}
     WHERE queue_manager_id IS NOT NULL
       AND entrypoint = ANY($2)
     GROUP BY entrypoint
-)"""
+),
 
-    def cte_worker_load(self) -> str:
-        return f"""-- This worker's total picked jobs (scalar, for max_concurrent_tasks).
+-- This worker's total picked jobs (scalar, for max_concurrent_tasks).
 worker_load AS (
     SELECT COUNT(*) AS total
-    FROM {self.qualified.queue_table}
+    FROM {t}
     WHERE queue_manager_id = $4
       AND entrypoint = ANY($2)
-)"""
+),
 
-    def cte_available(self) -> str:
-        return """-- Entrypoints with free capacity (concurrency gate applied here instead of
+-- Entrypoints with free capacity (concurrency gate applied here instead of
 -- row-scan). remaining is NULL for unlimited entrypoints; otherwise it caps
 -- how many rows one dequeue may pick so a single statement cannot exceed
 -- the entrypoint's concurrency_limit.
@@ -516,10 +518,8 @@ available AS (
     LEFT JOIN picked pk ON pk.entrypoint = p.entrypoint
     WHERE p.concurrency_limit <= 0
        OR COALESCE(pk.total, 0) < p.concurrency_limit
-)"""
+),
 
-    def cte_next_queued(self) -> str:
-        return f"""
 -- New queued jobs: per-entrypoint LATERAL lookup hits (entrypoint, priority, id) partial index.
 -- LEAST($1, NULL) = $1, so unlimited entrypoints keep the full batch.
 next_queued AS (
@@ -527,7 +527,7 @@ next_queued AS (
     FROM available a
     CROSS JOIN LATERAL (
         SELECT q2.id, q2.priority
-        FROM {self.qualified.queue_table} q2
+        FROM {t} q2
         WHERE q2.entrypoint = a.entrypoint
           AND q2.status = 'queued'
           AND q2.execute_after < NOW()
@@ -539,16 +539,15 @@ next_queued AS (
            OR (SELECT total FROM worker_load) < $5)
     ORDER BY q.priority DESC, q.id ASC
     LIMIT $1
-)"""
+),
 
-    def cte_next_stale(self) -> str:
-        return f"""-- Stale picked jobs whose heartbeat timed out. The concurrency gate from
+-- Stale picked jobs whose heartbeat timed out. The concurrency gate from
 -- next_queued is intentionally omitted: re-picking only transfers ownership
 -- of a row already counted in `picked`, so net live execution is unchanged.
 -- Applying the gate would deadlock recovery once leaked rows fill the slot.
 next_stale AS (
     SELECT q.id, q.priority
-    FROM {self.qualified.queue_table} q
+    FROM {t} q
     JOIN params p ON p.entrypoint = q.entrypoint
     WHERE q.status = 'picked'
       AND q.heartbeat < NOW() - $6::interval
@@ -558,10 +557,9 @@ next_stale AS (
     ORDER BY q.priority DESC, q.id ASC
     FOR UPDATE SKIP LOCKED
     LIMIT $1
-)"""
+),
 
-    def cte_eligible(self) -> str:
-        return """-- Merge both sets into one global priority order so a recovered stale job
+-- Merge both sets into one global priority order so a recovered stale job
 -- competes on priority with fresh work instead of always losing to it.
 -- The LIMIT hard-caps this worker's total picked rows at $5: the binary
 -- worker_load gates above only stop a dequeue from starting once over
@@ -574,44 +572,24 @@ eligible AS (
     ) combined
     ORDER BY priority DESC, id ASC
     LIMIT GREATEST(LEAST($1, COALESCE($5 - (SELECT total FROM worker_load), $1)), 0)
-)"""
+),
 
-    def cte_claimed(self) -> str:
-        return f"""-- Atomically claim the jobs and log the pick event.
+-- Atomically claim the jobs and log the pick event.
 claimed AS (
-    UPDATE {self.qualified.queue_table}
+    UPDATE {t}
     SET status = 'picked',
         updated   = NOW(),
         heartbeat = NOW(),
         queue_manager_id = $4
     WHERE id IN (SELECT id FROM eligible)
     RETURNING *
-)"""
-
-    def cte_log_pick(self) -> str:
-        return f"""log_pick AS (
-    INSERT INTO {self.qualified.queue_table_log} (job_id, status, entrypoint, priority)
+),
+log_pick AS (
+    INSERT INTO {t_log} (job_id, status, entrypoint, priority)
     SELECT id, status, entrypoint, priority FROM claimed
-)"""
-
-    def render(self) -> str:
-        ctes = ",\n\n".join(
-            (
-                self.cte_params(),
-                self.cte_picked(),
-                self.cte_worker_load(),
-                self.cte_available(),
-                self.cte_next_queued(),
-                self.cte_next_stale(),
-                self.cte_eligible(),
-                self.cte_claimed(),
-                self.cte_log_pick(),
-            )
-        )
-        return f"""WITH
-{ctes}
+)
 SELECT * FROM claimed ORDER BY priority DESC, id ASC;
-"""  # noqa: E501
+"""  # noqa
 
 
 @dataclasses.dataclass

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -56,6 +56,9 @@ class Queries:
     qbs: qb.QuerySchedulerBuilder = dataclasses.field(
         default_factory=qb.QuerySchedulerBuilder,
     )
+    dequeue_builder: qb.DequeueQueryBuilder = dataclasses.field(
+        default_factory=qb.DequeueQueryBuilder,
+    )
 
     # Optional injected tracer; falls back to the global ``tracing.TRACER.tracer``.
     tracer: TracingProtocol | None = None
@@ -182,7 +185,7 @@ class Queries:
             raise ValueError("Batch size must be greater than or equal to one (1)")
 
         rows = await self.driver.fetch(
-            self.qbq.build_dequeue_query(),
+            self.dequeue_builder.render(),
             batch_size,
             list(entrypoints.keys()),
             [x.concurrency_limit for x in entrypoints.values()],

--- a/pgqueuer/adapters/web/app.py
+++ b/pgqueuer/adapters/web/app.py
@@ -50,6 +50,7 @@ def create_web_app(
                 qbe=qb.QueryBuilderEnvironment(settings),
                 qbq=qb.QueryQueueBuilder(settings),
                 qbs=qb.QuerySchedulerBuilder(settings),
+                dequeue_builder=qb.DequeueQueryBuilder(settings),
             )
             broadcaster = Broadcaster(driver=driver, channel=settings.channel)
             await broadcaster.start()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -25,12 +25,13 @@ WIDENED_ID_TABLES = [
 
 
 def queries_for(driver: db.Driver, settings: qb.DBSettings) -> Queries:
-    """Queries wired to non-default DBSettings across all three builders."""
+    """Queries wired to non-default DBSettings across every query builder."""
     return Queries(
         driver,
         qbe=qb.QueryBuilderEnvironment(settings=settings),
         qbq=qb.QueryQueueBuilder(settings=settings),
         qbs=qb.QuerySchedulerBuilder(settings=settings),
+        dequeue_builder=qb.DequeueQueryBuilder(settings=settings),
     )
 
 

--- a/test/test_query_plan_regression.py
+++ b/test/test_query_plan_regression.py
@@ -100,7 +100,7 @@ async def test_dequeue_uses_entrypoint_priority_index(apgdriver: db.Driver) -> N
     q = await _seed(apgdriver)
     nodes = await _plan_nodes(
         apgdriver,
-        q.qbq.build_dequeue_query(),
+        q.dequeue_builder.render(),
         10,
         ENTRYPOINTS,
         [0] * len(ENTRYPOINTS),
@@ -154,7 +154,7 @@ async def test_dequeue_plan_scans_proportional_to_batch(apgdriver: db.Driver) ->
     eps = [f"ep_{i}" for i in range(BULK_EPS)]
     nodes = await _analyze_nodes(
         apgdriver,
-        q.qbq.build_dequeue_query(),
+        q.dequeue_builder.render(),
         BATCH,
         eps,
         [0] * BULK_EPS,
@@ -198,7 +198,7 @@ async def test_dequeue_gate_skips_saturated_entrypoints(apgdriver: db.Driver) ->
     eps = [f"ep_{i}" for i in range(BULK_EPS)]
     nodes = await _analyze_nodes(
         apgdriver,
-        q.qbq.build_dequeue_query(),
+        q.dequeue_builder.render(),
         BATCH,
         eps,
         [1] * BULK_EPS,


### PR DESCRIPTION
The dequeue statement was ~110 lines of inline CTEs inside QueryQueueBuilder.build_dequeue_query, the heaviest thing to read in qb.py. Move it into a dedicated DequeueQueryBuilder with one public method per CTE (params, picked, worker_load, available, next_queued, next_stale, eligible, claimed, log_pick) that render() stitches into a single atomic statement. The class docstring maps the pipeline, so the concurrency invariants are readable without scanning the whole query.

Behavior is unchanged: render() is whitespace-collapsed identical to the old build_dequeue_query() for both default and custom settings. queries.py gains a dequeue_builder field (named to avoid colliding with the dequeue method); the single call site and the explicit-settings constructors (cli, web) are updated. No facade needed.

First step of decomposing qb.py's god-classes into focused builders.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
