### PR TITLE
refactor!: make one DBSettings the single source of truth

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -186,6 +186,22 @@ This prefixes all table names, the enum type, the trigger, and the NOTIFY channe
 The two settings are independent: a prefix separates instances that share a
 schema, and `PGQUEUER_SCHEMA` moves the whole installation into another schema.
 
+To configure names in code instead of env vars, build a `DBSettings` and pass
+it to the composition root — `Queries` and `PgQueuer` both accept `settings=`:
+
+```python
+from pgqueuer import DBSettings, PgQueuer, Queries
+
+settings = DBSettings(prefix="billing_")
+pgq = PgQueuer(driver, settings=settings)
+# or, when wiring Queries yourself:
+queries = Queries(driver, settings=settings)
+```
+
+One `DBSettings` instance flows to every query builder and the NOTIFY/LISTEN
+channel, so table names and notifications can never disagree. `DBSettings` is
+immutable; build a new instance to change a value.
+
 ## Next Steps
 
 - **[Quick Start](quickstart.md)**: build your first consumer and producer

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -1,4 +1,23 @@
-# Upgrading from 0.x to 1.0
+# Upgrading
+
+## Upgrading to 2.0: settings plumbing
+
+PgQueuer 2.0 makes one `DBSettings` instance the single source of truth for
+table names and the NOTIFY/LISTEN channel. No database changes are required.
+
+| Change | Migration |
+|---|---|
+| `qbe=`/`qbq=`/`qbs=` removed from `Queries`, `SyncQueries`, `InMemoryQueries` | Pass `Queries(driver, settings=DBSettings(...))`; the builders are built from it and remain readable as attributes |
+| `Queries` second positional argument is now `settings` | Use keywords when constructing with more than a driver |
+| `channel=` on `PgQueuer` / `QueueManager` deprecated | Drop it; the channel derives from the queries' settings. To customize, use `DBSettings(channel=...)` or `PGQUEUER_CHANNEL`. A `channel=` that conflicts with the settings is now an immediate error — that combination silently broke LISTEN/NOTIFY before |
+| `DBSettings` is frozen | Build a new instance instead of mutating; mutation was already unsafe (`qualified` is cached) |
+| Custom `RepositoryPort` implementations need a `settings: DBSettings` attribute | Add the attribute; core components read table names and the channel through it |
+
+Behavior fixes included: `CompletionWatcher` and `pgq --prefix ... listen` now
+listen on the configured channel instead of the default one, and env vars are
+read when objects are constructed rather than at import time.
+
+## Upgrading from 0.x to 1.0
 
 PgQueuer 1.0 is the first stable release. From this point on, the project
 follows [semantic versioning](https://semver.org/) strictly: patch releases

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -103,15 +103,14 @@ server.run(transport="stdio")
 
 ### Custom Table Prefix or Schema
 
-If you use `PGQUEUER_PREFIX` or `PGQUEUER_SCHEMA` to namespace your tables, pass
-custom settings:
+`PGQUEUER_PREFIX` and `PGQUEUER_SCHEMA` are read automatically when the server
+starts. To configure names in code instead, pass a `DBSettings` instance:
 
 ```python
+from pgqueuer import DBSettings
 from pgqueuer.adapters.mcp.server import create_mcp_server
-from pgqueuer.adapters.persistence.qb import DBSettings
 
-# reads PGQUEUER_PREFIX / PGQUEUER_SCHEMA
-server = create_mcp_server(settings=DBSettings())
+server = create_mcp_server(settings=DBSettings(prefix="myapp_"))
 server.run(transport="stdio")
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -195,10 +195,12 @@ Listen to PostgreSQL NOTIFY channels for debugging.
 
 **Options:**
 
-- `--channel`: Channel name to listen on (default: `ch_pgqueuer`).
+- `--channel`: Channel name to listen on. Defaults to the channel from the
+  settings, so `--prefix` and `PGQUEUER_CHANNEL` are honored.
 
 ```bash
 pgq listen
+pgq --prefix billing listen   # listens on billing's channel
 pgq listen --channel my_custom_channel
 ```
 

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -167,7 +167,8 @@ All classmethods accept:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `connection` / `pool` | Yes | The database connection or pool |
-| `channel` | No | Custom `Channel` configuration. Defaults to `Channel(DBSettings().channel)` |
+| `settings` | No | `DBSettings` instance shared by all queries and the listener. Defaults to reading `PGQUEUER_*` env vars |
+| `channel` | No | Deprecated. The channel derives from `settings`; use `DBSettings(channel=...)` or `PGQUEUER_CHANNEL` |
 | `resources` | No | Mutable mapping for shared resources. Defaults to `{}` |
 
 ## Best Practices

--- a/docs/reference/ports-and-adapters.md
+++ b/docs/reference/ports-and-adapters.md
@@ -120,10 +120,14 @@ as the first positional parameter. The underlying driver is accessed via
 @dataclasses.dataclass
 class QueueManager:
     queries: RepositoryPort
-    channel: models.Channel = dataclasses.field(
-        default=models.Channel(DBSettings().channel),
-    )
+    # Deprecated; the LISTEN channel derives from queries.settings.channel.
+    channel: models.Channel | None = None
 ```
+
+`QueueRepositoryPort` carries a `settings: DBSettings` attribute, so every
+consumer (QueueManager, SchedulerManager, CompletionWatcher) derives table
+names and the NOTIFY/LISTEN channel from the queries object it was given —
+one `DBSettings` instance per composition root, no independent defaults.
 
 Callers construct concrete adapters at the composition root:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
       - Core Concepts: getting-started/core-concepts.md
-      - Upgrading from 0.x: getting-started/upgrading.md
+      - Upgrading: getting-started/upgrading.md
   - Guides:
       - Job Processing:
           - Concurrency Control: guides/concurrency-control.md

--- a/pgqueuer/__init__.py
+++ b/pgqueuer/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.applications import PgQueuer
 from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, PsycopgDriver
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.errors import RetryRequested
 from pgqueuer.executors import DatabaseRetryEntrypointExecutor
 from pgqueuer.models import Job, JobId
@@ -18,6 +19,7 @@ except ImportError:
 __all__ = [
     "AsyncpgDriver",
     "AsyncpgPoolDriver",
+    "DBSettings",
     "DatabaseRetryEntrypointExecutor",
     "InMemoryDriver",
     "InMemoryQueries",

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -154,24 +154,14 @@ def create_default_queries_factory(
             from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
             async with connect_asyncpg(dsn=config.pg_dsn or None) as connection:
-                yield queries.Queries(
-                    AsyncpgDriver(connection),
-                    qbe=qb.QueryBuilderEnvironment(settings),
-                    qbq=qb.QueryQueueBuilder(settings),
-                    qbs=qb.QuerySchedulerBuilder(settings),
-                )
+                yield queries.Queries(AsyncpgDriver(connection), settings=settings)
             return
         with contextlib.suppress(ImportError):
             from pgqueuer.adapters.connections import connect_psycopg
             from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
             async with connect_psycopg(dsn=config.pg_dsn or None) as connection:
-                yield queries.Queries(
-                    PsycopgDriver(connection),
-                    qbe=qb.QueryBuilderEnvironment(settings),
-                    qbq=qb.QueryQueueBuilder(settings),
-                    qbs=qb.QuerySchedulerBuilder(settings),
-                )
+                yield queries.Queries(PsycopgDriver(connection), settings=settings)
             return
         raise RuntimeError("Neither asyncpg nor psycopg could be imported.")
 
@@ -318,10 +308,10 @@ def verify(
             divergence = list[str]()
 
             required_tables = [
-                q.qbe.settings.queue_table,
-                q.qbe.settings.statistics_table,
-                q.qbe.settings.schedules_table,
-                q.qbe.settings.queue_table_log,
+                q.settings.queue_table,
+                q.settings.statistics_table,
+                q.settings.schedules_table,
+                q.settings.queue_table_log,
             ]
 
             for table in required_tables:
@@ -330,15 +320,15 @@ def verify(
                     state = "missing" if expect_present else "unexpected"
                     divergence.append(f"{state} table '{table}'")
 
-            func_exists = await q.has_function(q.qbe.settings.function)
+            func_exists = await q.has_function(q.settings.function)
             if expect_present != func_exists:
                 state = "missing" if expect_present else "unexpected"
-                divergence.append(f"{state} function '{q.qbe.settings.function}'")
+                divergence.append(f"{state} function '{q.settings.function}'")
 
-            trig_exists = await q.has_trigger(q.qbe.settings.trigger)
+            trig_exists = await q.has_trigger(q.settings.trigger)
             if expect_present != trig_exists:
                 state = "missing" if expect_present else "unexpected"
-                divergence.append(f"{state} trigger '{q.qbe.settings.trigger}'")
+                divergence.append(f"{state} trigger '{q.settings.trigger}'")
 
             if divergence:
                 print("\n".join(divergence))
@@ -456,14 +446,18 @@ def web(
 @app.command(help="Listen to a PostgreSQL NOTIFY channel for debug purposes.")
 def listen(
     ctx: Context,
-    channel: str = typer.Option(
-        qb.DBSettings().channel,
+    channel: str | None = typer.Option(
+        None,
         "--channel",
+        show_default="channel from settings",
     ),
 ) -> None:
     async def run() -> None:
         async with yield_queries(ctx, qb.DBSettings()) as q:
-            await display_pg_channel(q.driver, models.Channel(channel))
+            await display_pg_channel(
+                q.driver,
+                models.Channel(channel) if channel else q.settings.channel,
+            )
 
     asyncio_run(run())
 

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -43,17 +43,15 @@ class InMemoryQueries:
 
     driver: InMemoryDriver
 
-    qbe: qb.QueryBuilderEnvironment = dataclasses.field(
-        default_factory=qb.QueryBuilderEnvironment,
-    )
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-    qbs: qb.QuerySchedulerBuilder = dataclasses.field(
-        default_factory=qb.QuerySchedulerBuilder,
+    settings: qb.DBSettings = dataclasses.field(
+        default_factory=qb.DBSettings,
     )
 
     tracer: TracingProtocol | None = None
+
+    qbe: qb.QueryBuilderEnvironment = dataclasses.field(init=False)
+    qbq: qb.QueryQueueBuilder = dataclasses.field(init=False)
+    qbs: qb.QuerySchedulerBuilder = dataclasses.field(init=False)
 
     _jobs: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
     _log: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
@@ -77,6 +75,11 @@ class InMemoryQueries:
     _next_log_id: int = dataclasses.field(default=1, init=False)
     _next_schedule_id: int = dataclasses.field(default=1, init=False)
     _next_stats_id: int = dataclasses.field(default=1, init=False)
+
+    def __post_init__(self) -> None:
+        self.qbe = qb.QueryBuilderEnvironment(settings=self.settings)
+        self.qbq = qb.QueryQueueBuilder(settings=self.settings)
+        self.qbs = qb.QuerySchedulerBuilder(settings=self.settings)
 
     async def install(self) -> None:
         pass
@@ -701,21 +704,21 @@ class InMemoryQueries:
 
     async def notify_job_cancellation(self, ids: list[JobId]) -> None:
         event = models.CancellationEvent(
-            channel=self.qbq.settings.channel,
+            channel=self.settings.channel,
             ids=ids,
             sent_at=utc_now(),
             type="cancellation_event",
         )
-        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.settings.channel, event.model_dump_json())
 
     async def notify_health_check(self, health_check_event_id: uuid.UUID) -> None:
         event = models.HealthCheckEvent(
-            channel=self.qbq.settings.channel,
+            channel=self.settings.channel,
             sent_at=utc_now(),
             type="health_check_event",
             id=health_check_event_id,
         )
-        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.settings.channel, event.model_dump_json())
 
     async def insert_schedule(
         self,
@@ -1012,7 +1015,7 @@ class InMemoryQueries:
         return sum(1 for e in self._log if not e["aggregated"])
 
     async def schema_info(self) -> list[models.TableInfo]:
-        s = self.qbq.settings
+        s = self.settings
         tables = [
             (s.queue_table, len(self._jobs)),
             (s.queue_table_log, len(self._log)),
@@ -1036,10 +1039,10 @@ class InMemoryQueries:
 
     async def emit_table_changed(self, operation: models.OPERATIONS) -> None:
         event = models.TableChangedEvent(
-            channel=self.qbq.settings.channel,
+            channel=self.settings.channel,
             sent_at=utc_now(),
             type="table_changed_event",
             operation=operation,
-            table=self.qbe.settings.queue_table,
+            table=self.settings.queue_table,
         )
-        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.settings.channel, event.model_dump_json())

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -459,7 +459,7 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
 
 def create_mcp_server(
     dsn: str | None = None,
-    settings: DBSettings = DBSettings(),
+    settings: DBSettings | None = None,
     connection_settings: ConnectionSettings | None = None,
 ) -> FastMCP:
     """Factory that builds a fully-configured PgQueuer MCP server.
@@ -469,7 +469,8 @@ def create_mcp_server(
              PGQUEUER_DSN/PGDSN, else asyncpg reads standard libpq
              environment variables (PGHOST, PGPORT, PGUSER, PGPASSWORD,
              PGDATABASE) automatically.
-        settings: PgQueuer DBSettings (table names, channel, etc.).
+        settings: PgQueuer DBSettings (table names, channel, etc.). If None,
+             read from PGQUEUER_* env vars when the server starts.
         connection_settings: Pool sizing/timeouts. If None, read from
              PGQUEUER_* env vars at startup (PGQUEUER_POOL_MIN_SIZE,
              PGQUEUER_POOL_MAX_SIZE, PGQUEUER_CONNECT_TIMEOUT,
@@ -479,7 +480,7 @@ def create_mcp_server(
     @asynccontextmanager
     async def app_lifespan(server: FastMCP) -> AsyncIterator[PgQueuerDatabase]:
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
-            yield PgQueuerDatabase(pool, settings)
+            yield PgQueuerDatabase(pool, settings or DBSettings())
 
     mcp = FastMCP("pgqueuer", lifespan=app_lifespan)
 

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -43,22 +43,38 @@ def is_unique_violation(exc: Exception) -> bool:
 
 @dataclasses.dataclass
 class Queries:
-    """High-level job-queue operations: schema install/upgrade, enqueue/dequeue, log, stats."""
+    """High-level job-queue operations: schema install/upgrade, enqueue/dequeue, log, stats.
+
+    Usage example::
+
+        settings = DBSettings(prefix="billing_")
+        queries = Queries(driver, settings=settings)
+
+    The one ``settings`` instance names every generated DB object and the
+    NOTIFY/LISTEN channel; query builders derive from it and cannot be
+    injected separately.
+    """
 
     driver: Driver
 
-    qbe: qb.QueryBuilderEnvironment = dataclasses.field(
-        default_factory=qb.QueryBuilderEnvironment,
-    )
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-    qbs: qb.QuerySchedulerBuilder = dataclasses.field(
-        default_factory=qb.QuerySchedulerBuilder,
+    # Single source of truth for every generated object name and the NOTIFY
+    # channel; the query builders below are derived from it and cannot be
+    # injected separately.
+    settings: qb.DBSettings = dataclasses.field(
+        default_factory=qb.DBSettings,
     )
 
     # Optional injected tracer; falls back to the global ``tracing.TRACER.tracer``.
     tracer: TracingProtocol | None = None
+
+    qbe: qb.QueryBuilderEnvironment = dataclasses.field(init=False)
+    qbq: qb.QueryQueueBuilder = dataclasses.field(init=False)
+    qbs: qb.QuerySchedulerBuilder = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        self.qbe = qb.QueryBuilderEnvironment(settings=self.settings)
+        self.qbq = qb.QueryQueueBuilder(settings=self.settings)
+        self.qbs = qb.QuerySchedulerBuilder(settings=self.settings)
 
     @classmethod
     def from_asyncpg_connection(cls, connection: "asyncpg.Connection") -> "Queries":
@@ -448,9 +464,9 @@ class Queries:
     async def notify_job_cancellation(self, ids: list[models.JobId]) -> None:
         """Emit a ``cancellation_event`` NOTIFY carrying *ids*."""
         await self.driver.notify(
-            self.qbq.settings.channel,
+            self.settings.channel,
             models.CancellationEvent(
-                channel=self.qbq.settings.channel,
+                channel=self.settings.channel,
                 ids=ids,
                 sent_at=models.utc_now(),
                 type="cancellation_event",
@@ -460,9 +476,9 @@ class Queries:
     async def notify_health_check(self, health_check_event_id: uuid.UUID) -> None:
         """Emit a ``health_check_event`` NOTIFY tagged with ``health_check_event_id``."""
         await self.driver.notify(
-            self.qbq.settings.channel,
+            self.settings.channel,
             models.HealthCheckEvent(
-                channel=self.qbq.settings.channel,
+                channel=self.settings.channel,
                 sent_at=models.utc_now(),
                 type="health_check_event",
                 id=health_check_event_id,
@@ -687,12 +703,17 @@ class SyncQueries:
 
     driver: SyncDriver
 
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
+    settings: qb.DBSettings = dataclasses.field(
+        default_factory=qb.DBSettings,
     )
 
     # Optional injected tracer; falls back to the global ``tracing.TRACER.tracer``.
     tracer: TracingProtocol | None = None
+
+    qbq: qb.QueryQueueBuilder = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        self.qbq = qb.QueryQueueBuilder(settings=self.settings)
 
     @overload
     def enqueue(

--- a/pgqueuer/adapters/web/app.py
+++ b/pgqueuer/adapters/web/app.py
@@ -45,12 +45,7 @@ def create_web_app(
         settings = qb.DBSettings()
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
             driver = AsyncpgPoolDriver(pool)
-            app.state.pgq_queries = queries.Queries(
-                driver,
-                qbe=qb.QueryBuilderEnvironment(settings),
-                qbq=qb.QueryQueueBuilder(settings),
-                qbs=qb.QuerySchedulerBuilder(settings),
-            )
+            app.state.pgq_queries = queries.Queries(driver, settings=settings)
             broadcaster = Broadcaster(driver=driver, channel=settings.channel)
             await broadcaster.start()
             app.state.pgq_broadcaster = broadcaster

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -38,6 +38,14 @@ class PgQueuer:
     This class provides a unified interface for job queue management and task scheduling,
     leveraging PostgreSQL for managing job states and distributed processing.
 
+    Usage example::
+
+        pgq = PgQueuer(driver, settings=DBSettings(prefix="billing_"))
+
+    ``settings`` flows into the internally built ``Queries`` and determines
+    the LISTEN channel; pass it instead of pre-building ``Queries`` unless
+    you inject your own repository (the two are mutually exclusive).
+
     Resources:
         resources: Mutable mapping for user‑provided shared objects (DB pools, HTTP
             clients, caches, ML models) created once at startup and injected into
@@ -45,14 +53,15 @@ class PgQueuer:
     """
 
     connection: Driver
-    channel: Channel = dataclasses.field(
-        default=Channel(DBSettings().channel),
-    )
+    # Deprecated; the LISTEN channel derives from the queries' settings so it
+    # always matches the channel NOTIFYs are sent on. None means "derive".
+    channel: Channel | None = None
     # Shared resources mapping passed to QueueManager and propagated into each job Context.
     resources: MutableMapping = dataclasses.field(
         default_factory=dict,
     )
     queries: RepositoryPort | None = dataclasses.field(default=None)
+    settings: DBSettings | None = dataclasses.field(default=None)
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
         default_factory=asyncio.Event,
@@ -65,13 +74,20 @@ class PgQueuer:
     )
 
     def __post_init__(self) -> None:
+        if self.queries is not None and self.settings is not None:
+            raise ValueError(
+                "settings and queries are mutually exclusive; "
+                "configure settings on the injected queries"
+            )
         if self.queries is None:
-            self.queries = Queries(self.connection)
+            self.queries = Queries(self.connection, settings=self.settings or DBSettings())
+        # QueueManager owns the channel deprecation warning and conflict check.
         self.qm = QueueManager(
             self.queries,
             self.channel,
             resources=self.resources,
         )
+        self.channel = self.qm.channel
         self.sm = SchedulerManager(
             self.queries,
             resources=self.resources,
@@ -85,12 +101,14 @@ class PgQueuer:
         connection: "asyncpg.Connection",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over an asyncpg connection."""
         return cls._from_driver(
             driver=AsyncpgDriver(connection),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -99,12 +117,14 @@ class PgQueuer:
         pool: "asyncpg.Pool",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over an asyncpg pool."""
         return cls._from_driver(
             driver=AsyncpgPoolDriver(pool),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -113,12 +133,14 @@ class PgQueuer:
         connection: "psycopg.AsyncConnection",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over a psycopg async connection (must have autocommit=True)."""
         return cls._from_driver(
             driver=PsycopgDriver(connection),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -127,16 +149,21 @@ class PgQueuer:
         driver: Driver,
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
-        channel = channel or Channel(DBSettings().channel)
-        resources = resources or {}
-        return cls(connection=driver, channel=channel, resources=resources)
+        return cls(
+            connection=driver,
+            channel=channel,
+            resources=resources or {},
+            settings=settings,
+        )
 
     @classmethod
     def in_memory(
         cls,
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Create a PgQueuer backed entirely by in-memory data structures.
 
@@ -144,8 +171,7 @@ class PgQueuer:
         and short-lived batch-processing containers.
         """
         driver = InMemoryDriver()
-        channel = channel or Channel(DBSettings().channel)
-        inmem = InMemoryQueries(driver=driver)
+        inmem = InMemoryQueries(driver=driver, settings=settings or DBSettings())
         return cls(
             connection=driver,
             channel=channel,

--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -9,7 +9,6 @@ from itertools import chain
 
 from pgqueuer.core import tm
 from pgqueuer.domain import models
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports.driver import Driver
 from pgqueuer.ports.repository import QueueRepositoryPort
 
@@ -25,7 +24,9 @@ class CompletionWatcher:
 
     Usage example::
 
+        queries = Queries(driver)
         async with CompletionWatcher(driver,
+                                     queries=queries,
                                      refresh_interval=timedelta(seconds=2),
                                      debounce=timedelta(milliseconds=100)) as w:
             status = await w.wait_for(job_id)
@@ -70,7 +71,7 @@ class CompletionWatcher:
 
     async def __aenter__(self) -> "CompletionWatcher":
         self.task_manager.add(asyncio.create_task(self._poll_for_change()))
-        await self.driver.add_listener(DBSettings().channel, self._is_relevant_event)
+        await self.driver.add_listener(self.queries.settings.channel, self._is_relevant_event)
         self._schedule_refresh_waiters()
         return self
 

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -6,6 +6,7 @@ import dataclasses
 import random
 import sys
 import uuid
+import warnings
 from collections.abc import MutableMapping
 from contextlib import nullcontext, suppress
 from datetime import timedelta
@@ -23,7 +24,6 @@ from pgqueuer.core import (
     tm,
 )
 from pgqueuer.domain import errors, models, types
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports import RepositoryPort, tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
@@ -38,9 +38,9 @@ class QueueManager:
     """
 
     queries: RepositoryPort
-    channel: models.Channel = dataclasses.field(
-        default=models.Channel(DBSettings().channel),
-    )
+    # Deprecated; the LISTEN channel derives from the queries' settings so it
+    # always matches the channel NOTIFYs are sent on. None means "derive".
+    channel: models.Channel | None = None
 
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
@@ -84,6 +84,22 @@ class QueueManager:
         init=False,
         default=timedelta(seconds=0.1),
     )
+
+    def __post_init__(self) -> None:
+        derived = self.queries.settings.channel
+        if self.channel is not None:
+            warnings.warn(
+                "channel= is deprecated; the channel derives from the queries' settings "
+                "(Queries(driver, settings=DBSettings(channel=...)) or PGQUEUER_CHANNEL)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if self.channel != derived:
+                raise ValueError(
+                    f"channel {self.channel!r} conflicts with the queries' settings "
+                    f"channel {derived!r}; configure the channel via DBSettings"
+                )
+        self.channel = derived
 
     async def listener_healthy(
         self,
@@ -246,8 +262,8 @@ class QueueManager:
         """Assert that required tables, columns, indexes, enums, and triggers exist."""
 
         for table in (
-            self.queries.qbe.settings.queue_table,
-            self.queries.qbe.settings.statistics_table,
+            self.queries.settings.queue_table,
+            self.queries.settings.statistics_table,
         ):
             if not (await self.queries.has_table(table)):
                 raise RuntimeError(
@@ -255,20 +271,20 @@ class QueueManager:
                     f"Please run 'pgq install' to set up the necessary tables."
                 )
 
-        if not (await self.queries.has_table(self.queries.qbe.settings.queue_table_log)):
+        if not (await self.queries.has_table(self.queries.settings.queue_table_log)):
             raise RuntimeError(
-                f"The {self.queries.qbe.settings.queue_table_log} table is missing "
+                f"The {self.queries.settings.queue_table_log} table is missing "
                 "please run 'pgq upgrade'"
             )
 
         for table, column in (
-            (self.queries.qbe.settings.queue_table, "updated"),
-            (self.queries.qbe.settings.queue_table, "heartbeat"),
-            (self.queries.qbe.settings.queue_table, "queue_manager_id"),
-            (self.queries.qbe.settings.queue_table, "execute_after"),
-            (self.queries.qbe.settings.queue_table, "headers"),
-            (self.queries.qbe.settings.queue_table, "attempts"),
-            (self.queries.qbe.settings.queue_table_log, "traceback"),
+            (self.queries.settings.queue_table, "updated"),
+            (self.queries.settings.queue_table, "heartbeat"),
+            (self.queries.settings.queue_table, "queue_manager_id"),
+            (self.queries.settings.queue_table, "execute_after"),
+            (self.queries.settings.queue_table, "headers"),
+            (self.queries.settings.queue_table, "attempts"),
+            (self.queries.settings.queue_table_log, "traceback"),
         ):
             if not (await self.queries.table_has_column(table, column)):
                 raise RuntimeError(
@@ -277,8 +293,8 @@ class QueueManager:
                 )
 
         for key, enum in (
-            ("canceled", self.queries.qbe.settings.queue_status_type),
-            ("failed", self.queries.qbe.settings.queue_status_type),
+            ("canceled", self.queries.settings.queue_status_type),
+            ("failed", self.queries.settings.queue_status_type),
         ):
             if not (await self.queries.has_user_defined_enum(key, enum)):
                 raise RuntimeError(
@@ -287,8 +303,8 @@ class QueueManager:
 
         for table, index in (
             (
-                self.queries.qbe.settings.queue_table_log,
-                f"{self.queries.qbe.settings.queue_table_log}_job_id_status",
+                self.queries.settings.queue_table_log,
+                f"{self.queries.settings.queue_table_log}_job_id_status",
             ),
         ):
             if not (await self.queries.table_has_index(table, index)):
@@ -419,7 +435,7 @@ class QueueManager:
             notice_event_listener = listeners.PGNoticeEventListener()
             await listeners.initialize_notice_event_listener(
                 self.queries.driver,
-                self.channel,
+                self.queries.settings.channel,
                 listeners.default_event_router(
                     notice_event_queue=notice_event_listener,
                     canceled=self.job_context,

--- a/pgqueuer/core/sm.py
+++ b/pgqueuer/core/sm.py
@@ -91,15 +91,15 @@ class SchedulerManager:
 
     async def run(self) -> None:
         """Poll for due schedules and dispatch them until shutdown."""
-        if not (await self.queries.has_table(self.queries.qbe.settings.schedules_table)):
+        if not (await self.queries.has_table(self.queries.settings.schedules_table)):
             raise RuntimeError(
-                f"The {self.queries.qbe.settings.schedules_table} table is missing "
+                f"The {self.queries.settings.schedules_table} table is missing "
                 "please run 'pgq upgrade'"
             )
 
-        if not (await self.queries.has_table(self.queries.qbe.settings.queue_table_log)):
+        if not (await self.queries.has_table(self.queries.settings.queue_table_log)):
             raise RuntimeError(
-                f"The {self.queries.qbe.settings.queue_table_log} table is missing "
+                f"The {self.queries.settings.queue_table_log} table is missing "
                 "please run 'pgq upgrade'"
             )
 

--- a/pgqueuer/domain/settings.py
+++ b/pgqueuer/domain/settings.py
@@ -160,6 +160,7 @@ class DBSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="PGQUEUER_",
         extra="ignore",
+        frozen=True,
     )
 
     # Prepended to every object name not explicitly overridden; lets multiple
@@ -265,8 +266,8 @@ class DBSettings(BaseSettings):
         return f"{self.db_schema}.{name}" if self.db_schema else name
 
     # cached_property: query builders access this on every SQL render (the
-    # dequeue loop rebuilds its query each iteration). Safe because names are
-    # fixed once validation and apply_prefix have run.
+    # dequeue loop rebuilds its query each iteration). Safe because the model
+    # is frozen; names cannot change after validation.
     @functools.cached_property
     def qualified(self) -> QualifiedNames:
         return QualifiedNames(

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -29,6 +29,8 @@ class EntrypointExecutionParameter:
 class QueueRepositoryPort(Protocol):
     """Persistence operations for the job queue."""
 
+    settings: DBSettings
+
     async def dequeue(
         self,
         batch_size: int,

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -12,26 +12,21 @@ import async_timeout
 
 from pgqueuer import db
 from pgqueuer.adapters.persistence import qb
-from pgqueuer.adapters.persistence.queries import Queries
 from pgqueuer.models import Job
 from pgqueuer.ports import RepositoryPort
 
-# Tables whose id was int4 SERIAL before #671 and gets widened to BIGINT.
-WIDENED_ID_TABLES = [
-    qb.DBSettings().queue_table,
-    qb.DBSettings().statistics_table,
-    qb.DBSettings().schedules_table,
-]
 
+def widened_id_tables() -> list[str]:
+    """Tables whose id was int4 SERIAL before #671 and gets widened to BIGINT.
 
-def queries_for(driver: db.Driver, settings: qb.DBSettings) -> Queries:
-    """Queries wired to non-default DBSettings across all three builders."""
-    return Queries(
-        driver,
-        qbe=qb.QueryBuilderEnvironment(settings=settings),
-        qbq=qb.QueryQueueBuilder(settings=settings),
-        qbs=qb.QuerySchedulerBuilder(settings=settings),
-    )
+    Built at call time so PGQUEUER_* env vars set by fixtures are honored.
+    """
+    settings = qb.DBSettings()
+    return [
+        settings.queue_table,
+        settings.statistics_table,
+        settings.schedules_table,
+    ]
 
 
 async def id_data_type(driver: db.Driver, table: str, schema: str | None = None) -> str:

--- a/test/test_qb_upgrade_migration.py
+++ b/test/test_qb_upgrade_migration.py
@@ -8,10 +8,9 @@ only proves what we wrote, not what Postgres does with it.
 from __future__ import annotations
 
 from pgqueuer import db, queries
-from pgqueuer.adapters.persistence import qb
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import Channel
-from test.helpers import id_data_type, queries_for, simulate_legacy_serial
+from test.helpers import id_data_type, simulate_legacy_serial
 
 # Object names sharing no substring with the defaults: if any migration
 # statement hardcoded a default name, upgrading this schema would miss its
@@ -50,7 +49,7 @@ async def test_upgrade_targets_configured_names(apgdriver: db.Driver) -> None:
     # than silently hit the template's default-named tables.
     await queries.Queries(apgdriver).uninstall()
 
-    q = queries_for(apgdriver, CUSTOM)
+    q = queries.Queries(apgdriver, settings=CUSTOM)
     await q.install()
     for table in CUSTOM_WIDENED_TABLES:
         await simulate_legacy_serial(apgdriver, table)
@@ -70,7 +69,7 @@ async def test_widen_id_setting_controls_the_widen(apgdriver: db.Driver) -> None
     await simulate_legacy_serial(apgdriver, table)
 
     no_widen = DBSettings(widen_id=False)
-    q_no_widen = queries.Queries(apgdriver, qbe=qb.QueryBuilderEnvironment(settings=no_widen))
+    q_no_widen = queries.Queries(apgdriver, settings=no_widen)
     await q_no_widen.upgrade()
     assert await id_data_type(apgdriver, table) == "integer"
 

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -11,6 +11,7 @@ from pgqueuer import db
 from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core.cache import TTLCache
 from pgqueuer.core.tm import TaskManager
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.models import Job, Log
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
@@ -169,6 +170,8 @@ async def test_periodic_log_aggregation_loops_until_shutdown() -> None:
     qm: QueueManager
 
     class Stub:
+        settings = DBSettings()
+
         async def aggregate_logs(self) -> None:
             nonlocal calls
             calls += 1
@@ -187,6 +190,8 @@ async def test_periodic_log_aggregation_survives_aggregate_errors() -> None:
     qm: QueueManager
 
     class Stub:
+        settings = DBSettings()
+
         async def aggregate_logs(self) -> None:
             nonlocal calls
             calls += 1

--- a/test/test_schema_id_widen.py
+++ b/test/test_schema_id_widen.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pgqueuer import db, queries
-from test.helpers import WIDENED_ID_TABLES, id_data_type, simulate_legacy_serial
+from test.helpers import id_data_type, simulate_legacy_serial, widened_id_tables
 
 INT4_MAX = 2**31 - 1
 
@@ -13,24 +13,24 @@ async def test_upgrade_widens_legacy_int_id_columns(apgdriver: db.Driver) -> Non
     q = queries.Queries(apgdriver)
 
     # Simulate a legacy install whose id columns are still int4 SERIAL.
-    for table in WIDENED_ID_TABLES:
+    for table in widened_id_tables():
         await simulate_legacy_serial(apgdriver, table)
         assert await id_data_type(apgdriver, table) == "integer"
 
     await q.upgrade()
-    for table in WIDENED_ID_TABLES:
+    for table in widened_id_tables():
         assert await id_data_type(apgdriver, table) == "bigint"
 
     # Idempotent: a second upgrade leaves the already-widened columns alone.
     await q.upgrade()
-    for table in WIDENED_ID_TABLES:
+    for table in widened_id_tables():
         assert await id_data_type(apgdriver, table) == "bigint"
 
 
 async def test_upgrade_widens_legacy_serial_sequence(apgdriver: db.Driver) -> None:
     """Widening the column alone is not enough; the SERIAL sequence caps at 2^31-1 too."""
     q = queries.Queries(apgdriver)
-    table = WIDENED_ID_TABLES[0]
+    table = widened_id_tables()[0]
     await simulate_legacy_serial(apgdriver, table)
     await apgdriver.execute(f"SELECT setval('{table}_id_seq', {INT4_MAX - 1});")
 

--- a/test/test_schema_support.py
+++ b/test/test_schema_support.py
@@ -20,7 +20,7 @@ from pgqueuer.domain.settings import DBSettings
 from pgqueuer.models import AnyEvent, Channel, CronExpressionEntrypoint
 from pgqueuer.queries import EntrypointExecutionParameter
 from pgqueuer.types import CronEntrypoint, CronExpression
-from test.helpers import id_data_type, queries_for, simulate_legacy_serial
+from test.helpers import id_data_type, simulate_legacy_serial
 
 SCHEMA = "pgq_iso"
 
@@ -55,7 +55,7 @@ async def test_search_path_install_upgrades_via_db_schema(apgdriver: db.Driver) 
     await queries.Queries(apgdriver).install()
     await apgdriver.execute("SET search_path TO public;")
 
-    q = queries_for(apgdriver, DBSettings(db_schema=SCHEMA))
+    q = queries.Queries(apgdriver, settings=DBSettings(db_schema=SCHEMA))
     assert await q.has_table(q.qbe.settings.queue_table)
     await q.upgrade()
     await q.upgrade()
@@ -67,7 +67,7 @@ async def test_fresh_install_round_trip_in_schema(apgdriver: db.Driver) -> None:
     await queries.Queries(apgdriver).uninstall()
 
     settings = DBSettings(db_schema=SCHEMA, prefix="iso_")
-    q = queries_for(apgdriver, settings)
+    q = queries.Queries(apgdriver, settings=settings)
     await q.install()
 
     assert await table_schemas(apgdriver, settings.queue_table) == {SCHEMA}
@@ -91,7 +91,7 @@ async def test_widen_id_in_schema_with_prefix(apgdriver: db.Driver) -> None:
     await queries.Queries(apgdriver).uninstall()
 
     settings = DBSettings(db_schema=SCHEMA, prefix="iso_")
-    q = queries_for(apgdriver, settings)
+    q = queries.Queries(apgdriver, settings=settings)
     await q.install()
 
     widened = [settings.queue_table, settings.statistics_table, settings.schedules_table]
@@ -110,7 +110,7 @@ async def test_notify_channel_is_not_schema_qualified(apgdriver: db.Driver) -> N
     await queries.Queries(apgdriver).uninstall()
 
     settings = DBSettings(db_schema=SCHEMA)
-    q = queries_for(apgdriver, settings)
+    q = queries.Queries(apgdriver, settings=settings)
     await q.install()
 
     events = list[AnyEvent]()
@@ -130,7 +130,7 @@ async def test_schema_info_respects_db_schema(apgdriver: db.Driver) -> None:
     await queries.Queries(apgdriver).uninstall()
 
     settings = DBSettings(db_schema=SCHEMA)
-    q = queries_for(apgdriver, settings)
+    q = queries.Queries(apgdriver, settings=settings)
     await q.install()
 
     rows = await apgdriver.fetch(q.qbq.build_schema_info_query())
@@ -147,7 +147,7 @@ async def test_install_without_create_schema(apgdriver: db.Driver) -> None:
     await queries.Queries(apgdriver).uninstall()
 
     settings = DBSettings(db_schema=SCHEMA)
-    q = queries_for(apgdriver, settings)
+    q = queries.Queries(apgdriver, settings=settings)
 
     with pytest.raises(asyncpg.InvalidSchemaNameError):
         await q.install(create_schema=False)

--- a/test/test_settings_plumbing.py
+++ b/test/test_settings_plumbing.py
@@ -1,0 +1,315 @@
+"""Settings plumbing: one DBSettings instance flows from the composition root.
+
+Locks the single-source-of-truth invariant introduced with ``Queries(driver,
+settings=...)``: builders derive from the queries' settings, the LISTEN
+channel always matches the NOTIFY channel, and nothing reads PGQUEUER_* env
+vars at import time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import inspect
+import warnings
+from datetime import timedelta
+from typing import Callable
+
+import async_timeout
+import pytest
+
+from pgqueuer import PgQueuer, Queries, db
+from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
+from pgqueuer.adapters.persistence.queries import SyncQueries
+from pgqueuer.core.completion import CompletionWatcher
+from pgqueuer.core.qm import QueueManager
+from pgqueuer.core.tm import TaskManager
+from pgqueuer.domain import errors
+from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import Channel, QueueExecutionMode
+from pgqueuer.models import Job
+
+
+class RecorderDriver:
+    """Driver stub recording LISTEN channels; queries never hit a database."""
+
+    def __init__(self) -> None:
+        self.listened_channels: list[str] = []
+        self._shutdown = asyncio.Event()
+        self._tm = TaskManager()
+
+    async def fetch(self, query: str, *args: object) -> list[dict]:
+        return []
+
+    async def execute(self, query: str, *args: object) -> str:
+        return ""
+
+    async def add_listener(
+        self,
+        channel: str,
+        callback: Callable[[str | bytes | bytearray], None],
+    ) -> None:
+        self.listened_channels.append(channel)
+
+    async def notify(self, channel: str, payload: str) -> None:
+        pass
+
+    @property
+    def shutdown(self) -> asyncio.Event:
+        return self._shutdown
+
+    @property
+    def tm(self) -> TaskManager:
+        return self._tm
+
+    async def __aenter__(self) -> RecorderDriver:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        pass
+
+
+class SyncRecorderDriver:
+    """SyncDriver stub; SyncQueries never issues queries in these tests."""
+
+    def fetch(self, query: str, *args: object) -> list[dict]:
+        return []
+
+
+def assert_single_settings_instance(
+    queries: Queries | SyncQueries | InMemoryQueries,
+    settings: DBSettings,
+) -> None:
+    """Every field holding a settings-bearing object must share *settings*.
+
+    Iterating fields (rather than naming qbe/qbq/qbs) makes this cover any
+    future builder automatically.
+    """
+    builders_checked = 0
+    for field in dataclasses.fields(queries):
+        value = getattr(queries, field.name)
+        if value is settings:
+            continue
+        if hasattr(value, "settings"):
+            assert value.settings is settings, f"{field.name} holds a different DBSettings"
+            builders_checked += 1
+    assert builders_checked > 0, "no builders found; invariant test is vacuous"
+
+
+def test_queries_builders_share_the_settings_instance() -> None:
+    settings = DBSettings(prefix="custom_")
+    assert_single_settings_instance(Queries(RecorderDriver(), settings=settings), settings)
+
+
+def test_sync_queries_builders_share_the_settings_instance() -> None:
+    settings = DBSettings(prefix="custom_")
+    assert_single_settings_instance(SyncQueries(SyncRecorderDriver(), settings=settings), settings)
+
+
+def test_inmemory_queries_builders_share_the_settings_instance() -> None:
+    settings = DBSettings(prefix="custom_")
+    assert_single_settings_instance(
+        InMemoryQueries(driver=InMemoryDriver(), settings=settings),
+        settings,
+    )
+
+
+def test_queue_manager_channel_derives_from_queries_settings() -> None:
+    settings = DBSettings(prefix="custom_")
+    qm = QueueManager(Queries(RecorderDriver(), settings=settings))
+    assert qm.channel == settings.channel
+    assert str(qm.channel) == "custom_ch_pgqueuer"
+
+
+def test_queue_manager_channel_param_is_deprecated_but_works_when_matching() -> None:
+    settings = DBSettings(prefix="custom_")
+    queries = Queries(RecorderDriver(), settings=settings)
+    with pytest.warns(DeprecationWarning, match="channel= is deprecated"):
+        qm = QueueManager(queries, settings.channel)
+    assert qm.channel == settings.channel
+
+
+def test_queue_manager_conflicting_channel_raises() -> None:
+    queries = Queries(RecorderDriver(), settings=DBSettings(prefix="custom_"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="conflicts with the queries' settings"):
+            QueueManager(queries, Channel("some_other_channel"))
+
+
+def test_pgqueuer_threads_settings_into_queries_and_channel() -> None:
+    settings = DBSettings(prefix="custom_")
+    pgq = PgQueuer(RecorderDriver(), settings=settings)
+    assert isinstance(pgq.queries, Queries)
+    assert pgq.queries.settings is settings
+    assert pgq.channel == settings.channel
+    assert pgq.qm.channel == settings.channel
+
+
+def test_pgqueuer_rejects_settings_and_queries_together() -> None:
+    driver = RecorderDriver()
+    queries = Queries(driver, settings=DBSettings(prefix="a_"))
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        PgQueuer(driver, queries=queries, settings=DBSettings(prefix="b_"))
+
+
+def test_pgqueuer_default_construction_emits_no_deprecation_warning() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        PgQueuer(RecorderDriver())
+
+
+def test_pgqueuer_channel_param_still_works_when_matching() -> None:
+    with pytest.warns(DeprecationWarning, match="channel= is deprecated"):
+        pgq = PgQueuer(RecorderDriver(), channel=DBSettings().channel)
+    assert pgq.channel == DBSettings().channel
+
+
+def test_in_memory_pgqueuer_threads_settings() -> None:
+    settings = DBSettings(prefix="custom_")
+    pgq = PgQueuer.in_memory(settings=settings)
+    assert isinstance(pgq.queries, InMemoryQueries)
+    assert pgq.queries.settings is settings
+    assert pgq.channel == settings.channel
+
+
+def test_channel_defaults_are_not_frozen_at_import_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: qm.py/applications.py evaluated DBSettings() at import."""
+    monkeypatch.setenv("PGQUEUER_PREFIX", "zz_")
+    qm = QueueManager(Queries(RecorderDriver()))
+    assert str(qm.channel) == "zz_ch_pgqueuer"
+    pgq = PgQueuer(RecorderDriver())
+    assert str(pgq.channel) == "zz_ch_pgqueuer"
+
+
+async def test_completion_watcher_listens_on_the_queries_channel() -> None:
+    """Regression: CompletionWatcher hardcoded DBSettings().channel."""
+    settings = DBSettings(prefix="custom_")
+    driver = RecorderDriver()
+    queries = Queries(driver, settings=settings)
+    async with CompletionWatcher(driver, queries=queries):
+        pass
+    assert driver.listened_channels == ["custom_ch_pgqueuer"]
+
+
+def test_dbsettings_is_frozen() -> None:
+    settings = DBSettings()
+    with pytest.raises(Exception, match="frozen"):
+        settings.prefix = "nope"  # type: ignore[misc]
+
+
+def test_dbsettings_qualified_is_cached() -> None:
+    settings = DBSettings(prefix="custom_")
+    assert settings.qualified is settings.qualified
+    assert settings.qualified.queue_table == "custom_pgqueuer"
+
+
+def test_mcp_server_settings_default_is_resolved_at_startup() -> None:
+    from pgqueuer.adapters.mcp.server import create_mcp_server
+
+    default = inspect.signature(create_mcp_server).parameters["settings"].default
+    assert default is None
+
+
+async def test_queue_manager_listener_round_trip_under_custom_prefix(
+    apgdriver: db.Driver,
+) -> None:
+    """LISTEN and NOTIFY agree under a custom prefix (fails on the split-channel bug)."""
+    await Queries(apgdriver).uninstall()
+    settings = DBSettings(prefix="iso_")
+    queries = Queries(apgdriver, settings=settings)
+    await queries.install()
+
+    qm = QueueManager(queries)
+
+    @qm.entrypoint("noop")
+    async def noop(job: Job) -> None: ...
+
+    run_task = asyncio.create_task(qm.run(dequeue_timeout=timedelta(seconds=0.1)))
+    try:
+        async with async_timeout.timeout(10):
+            while True:
+                try:
+                    await qm.listener_healthy(timeout=timedelta(seconds=1))
+                    break
+                except errors.FailingListenerError:
+                    await asyncio.sleep(0.05)
+    finally:
+        qm.shutdown.set()
+        async with async_timeout.timeout(10):
+            await run_task
+
+
+async def test_completion_watcher_resolves_under_custom_prefix(
+    apgdriver: db.Driver,
+) -> None:
+    """wait_for resolves via NOTIFY under a custom prefix (fails on the hardcoded channel).
+
+    The safety-net poll is set far above the timeout so only the LISTEN path
+    can resolve the future.
+    """
+    await Queries(apgdriver).uninstall()
+    settings = DBSettings(prefix="iso_")
+    queries = Queries(apgdriver, settings=settings)
+    await queries.install()
+
+    qm = QueueManager(queries)
+
+    @qm.entrypoint("ep")
+    async def ep(job: Job) -> None: ...
+
+    (jid,) = await queries.enqueue("ep", None, 0)
+
+    async with (
+        async_timeout.timeout(10),
+        CompletionWatcher(
+            apgdriver,
+            queries=queries,
+            refresh_interval=timedelta(seconds=60),
+        ) as watcher,
+    ):
+        fut = watcher.wait_for(jid)
+        # Let the debounce check armed by wait_for run while the job is still
+        # queued; after this, only a NOTIFY on the right channel can resolve.
+        await asyncio.sleep(0.2)
+        assert not fut.done()
+        await qm.run(mode=QueueExecutionMode.drain)
+        async with async_timeout.timeout(2):
+            assert await fut == "successful"
+
+
+def test_cli_listen_honors_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: the --channel default was evaluated at import, before --prefix."""
+    import contextlib
+    from typing import AsyncGenerator
+
+    from typer.testing import CliRunner
+
+    from pgqueuer.adapters.cli import cli
+
+    captured: list[str] = []
+
+    @contextlib.asynccontextmanager
+    async def fake_yield_queries(
+        ctx: object,
+        settings: DBSettings,
+    ) -> AsyncGenerator[Queries, None]:
+        yield Queries(RecorderDriver(), settings=settings)
+
+    async def fake_display_pg_channel(connection: object, channel: Channel) -> None:
+        captured.append(str(channel))
+
+    monkeypatch.setattr(cli, "yield_queries", fake_yield_queries)
+    monkeypatch.setattr(cli, "display_pg_channel", fake_display_pg_channel)
+    monkeypatch.delenv("PGQUEUER_PREFIX", raising=False)
+
+    result = CliRunner().invoke(cli.app, ["--prefix", "foo_", "listen"])
+    assert result.exit_code == 0, result.output
+    assert captured == ["foo_ch_pgqueuer"]
+
+    captured.clear()
+    result = CliRunner().invoke(cli.app, ["--prefix", "foo_", "listen", "--channel", "explicit_ch"])
+    assert result.exit_code == 0, result.output
+    assert captured == ["explicit_ch"]


### PR DESCRIPTION
Components default-constructed their own DBSettings, so user-supplied settings at one level were silently ignored below. Worst cases: CompletionWatcher listened on the hardcoded default channel, and QueueManager/PgQueuer/CLI channel defaults were evaluated at import time — under a custom prefix, LISTEN and NOTIFY split and workers never woke.

Queries/SyncQueries/InMemoryQueries now own a settings field; query builders are derived state built in __post_init__. QueueRepositoryPort carries settings, so QueueManager, SchedulerManager, and CompletionWatcher derive table names and the NOTIFY/LISTEN channel from the injected queries. PgQueuer gains settings=; DBSettings is frozen and exported from the top-level package.

BREAKING CHANGE: qbe=/qbq=/qbs= constructor kwargs removed from Queries/SyncQueries/InMemoryQueries — pass
Queries(driver, settings=DBSettings(...)) instead; builders remain readable attributes. Queries positional arg #2 is now settings. DBSettings is frozen; build a new instance instead of mutating. Custom QueueRepositoryPort implementations must add a settings: DBSettings attribute. channel= on PgQueuer/QueueManager is deprecated: the channel derives from the queries' settings, a matching value warns, a conflicting value raises. pgq listen and create_mcp_server resolve settings at invocation instead of import.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
