### PR TITLE
fix: derive LISTEN channel from the queries' settings

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -195,7 +195,8 @@ Listen to PostgreSQL NOTIFY channels for debugging.
 
 **Options:**
 
-- `--channel`: Channel name to listen on (default: `ch_pgqueuer`).
+- `--channel`: Channel name to listen on. Defaults to the channel from the
+  settings, so `--prefix` and `PGQUEUER_CHANNEL` are honored.
 
 ```bash
 pgq listen

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -167,7 +167,7 @@ All classmethods accept:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `connection` / `pool` | Yes | The database connection or pool |
-| `channel` | No | Custom `Channel` configuration. Defaults to `Channel(DBSettings().channel)` |
+| `channel` | No | Custom `Channel` configuration. Defaults to the channel from the queries' settings, so LISTEN matches NOTIFY |
 | `resources` | No | Mutable mapping for shared resources. Defaults to `{}` |
 
 ## Best Practices

--- a/docs/reference/ports-and-adapters.md
+++ b/docs/reference/ports-and-adapters.md
@@ -120,9 +120,8 @@ as the first positional parameter. The underlying driver is accessed via
 @dataclasses.dataclass
 class QueueManager:
     queries: RepositoryPort
-    channel: models.Channel = dataclasses.field(
-        default=models.Channel(DBSettings().channel),
-    )
+    # None derives the channel from the queries' settings.
+    channel: models.Channel | None = None
 ```
 
 Callers construct concrete adapters at the composition root:

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -456,14 +456,18 @@ def web(
 @app.command(help="Listen to a PostgreSQL NOTIFY channel for debug purposes.")
 def listen(
     ctx: Context,
-    channel: str = typer.Option(
-        qb.DBSettings().channel,
+    channel: str | None = typer.Option(
+        None,
         "--channel",
+        show_default="channel from settings",
     ),
 ) -> None:
     async def run() -> None:
         async with yield_queries(ctx, qb.DBSettings()) as q:
-            await display_pg_channel(q.driver, models.Channel(channel))
+            await display_pg_channel(
+                q.driver,
+                models.Channel(channel) if channel else q.qbe.settings.channel,
+            )
 
     asyncio_run(run())
 

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -459,7 +459,7 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
 
 def create_mcp_server(
     dsn: str | None = None,
-    settings: DBSettings = DBSettings(),
+    settings: DBSettings | None = None,
     connection_settings: ConnectionSettings | None = None,
 ) -> FastMCP:
     """Factory that builds a fully-configured PgQueuer MCP server.
@@ -469,7 +469,8 @@ def create_mcp_server(
              PGQUEUER_DSN/PGDSN, else asyncpg reads standard libpq
              environment variables (PGHOST, PGPORT, PGUSER, PGPASSWORD,
              PGDATABASE) automatically.
-        settings: PgQueuer DBSettings (table names, channel, etc.).
+        settings: PgQueuer DBSettings (table names, channel, etc.). If None,
+             read from PGQUEUER_* env vars when the server starts.
         connection_settings: Pool sizing/timeouts. If None, read from
              PGQUEUER_* env vars at startup (PGQUEUER_POOL_MIN_SIZE,
              PGQUEUER_POOL_MAX_SIZE, PGQUEUER_CONNECT_TIMEOUT,
@@ -479,7 +480,7 @@ def create_mcp_server(
     @asynccontextmanager
     async def app_lifespan(server: FastMCP) -> AsyncIterator[PgQueuerDatabase]:
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
-            yield PgQueuerDatabase(pool, settings)
+            yield PgQueuerDatabase(pool, settings or DBSettings())
 
     mcp = FastMCP("pgqueuer", lifespan=app_lifespan)
 

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -20,7 +20,6 @@ from pgqueuer.core.executors import (
 from pgqueuer.core.qm import QueueManager
 from pgqueuer.core.sm import SchedulerManager
 from pgqueuer.domain.models import Channel
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import OnFailure, QueueExecutionMode
 from pgqueuer.ports import RepositoryPort
 from pgqueuer.ports.driver import Driver
@@ -45,9 +44,9 @@ class PgQueuer:
     """
 
     connection: Driver
-    channel: Channel = dataclasses.field(
-        default=Channel(DBSettings().channel),
-    )
+    # None derives the channel from the queries' settings, so LISTEN always
+    # matches the channel NOTIFYs are sent on. An explicit value wins.
+    channel: Channel | None = None
     # Shared resources mapping passed to QueueManager and propagated into each job Context.
     resources: MutableMapping = dataclasses.field(
         default_factory=dict,
@@ -72,6 +71,7 @@ class PgQueuer:
             self.channel,
             resources=self.resources,
         )
+        self.channel = self.qm.channel
         self.sm = SchedulerManager(
             self.queries,
             resources=self.resources,
@@ -128,9 +128,7 @@ class PgQueuer:
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
     ) -> "PgQueuer":
-        channel = channel or Channel(DBSettings().channel)
-        resources = resources or {}
-        return cls(connection=driver, channel=channel, resources=resources)
+        return cls(connection=driver, channel=channel, resources=resources or {})
 
     @classmethod
     def in_memory(
@@ -144,7 +142,6 @@ class PgQueuer:
         and short-lived batch-processing containers.
         """
         driver = InMemoryDriver()
-        channel = channel or Channel(DBSettings().channel)
         inmem = InMemoryQueries(driver=driver)
         return cls(
             connection=driver,

--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -9,9 +9,8 @@ from itertools import chain
 
 from pgqueuer.core import tm
 from pgqueuer.domain import models
-from pgqueuer.domain.settings import DBSettings
+from pgqueuer.ports import RepositoryPort
 from pgqueuer.ports.driver import Driver
-from pgqueuer.ports.repository import QueueRepositoryPort
 
 
 @dataclass
@@ -25,7 +24,9 @@ class CompletionWatcher:
 
     Usage example::
 
+        queries = Queries(driver)
         async with CompletionWatcher(driver,
+                                     queries=queries,
                                      refresh_interval=timedelta(seconds=2),
                                      debounce=timedelta(milliseconds=100)) as w:
             status = await w.wait_for(job_id)
@@ -33,7 +34,7 @@ class CompletionWatcher:
     """
 
     driver: Driver
-    queries: QueueRepositoryPort = field(kw_only=True)
+    queries: RepositoryPort = field(kw_only=True)
     refresh_interval: timedelta = field(
         default_factory=lambda: timedelta(seconds=5),
     )
@@ -70,7 +71,10 @@ class CompletionWatcher:
 
     async def __aenter__(self) -> "CompletionWatcher":
         self.task_manager.add(asyncio.create_task(self._poll_for_change()))
-        await self.driver.add_listener(DBSettings().channel, self._is_relevant_event)
+        await self.driver.add_listener(
+            self.queries.qbe.settings.channel,
+            self._is_relevant_event,
+        )
         self._schedule_refresh_waiters()
         return self
 

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -23,7 +23,6 @@ from pgqueuer.core import (
     tm,
 )
 from pgqueuer.domain import errors, models, types
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports import RepositoryPort, tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
@@ -38,9 +37,9 @@ class QueueManager:
     """
 
     queries: RepositoryPort
-    channel: models.Channel = dataclasses.field(
-        default=models.Channel(DBSettings().channel),
-    )
+    # None derives the channel from the queries' settings, so LISTEN always
+    # matches the channel NOTIFYs are sent on. An explicit value wins.
+    channel: models.Channel | None = None
 
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
@@ -84,6 +83,10 @@ class QueueManager:
         init=False,
         default=timedelta(seconds=0.1),
     )
+
+    def __post_init__(self) -> None:
+        if self.channel is None:
+            self.channel = self.queries.qbe.settings.channel
 
     async def listener_healthy(
         self,
@@ -380,6 +383,8 @@ class QueueManager:
         on stats reads; pass ``timedelta(0)`` to disable (pure on-demand).
         """
         await self.verify_structure()
+
+        assert self.channel is not None  # Derived in __post_init__.
 
         max_concurrent_tasks = max_concurrent_tasks or sys.maxsize
 

--- a/test/test_channel_derivation.py
+++ b/test/test_channel_derivation.py
@@ -1,0 +1,202 @@
+"""The LISTEN channel must follow the queries' settings, not a separate default.
+
+Regression tests for three bugs with custom prefixes/channels:
+
+- QueueManager/PgQueuer evaluated their channel default at import time from an
+  independent DBSettings(), so LISTEN and NOTIFY could disagree and workers
+  never woke.
+- CompletionWatcher listened on a hardcoded default channel, ignoring the
+  settings of its injected queries, so wait_for() never resolved via NOTIFY.
+- ``pgq listen`` resolved its --channel default at import, before --prefix was
+  exported to the environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import Callable
+
+import async_timeout
+import pytest
+
+from pgqueuer import PgQueuer, db
+from pgqueuer.adapters.inmemory.driver import InMemoryDriver
+from pgqueuer.core.completion import CompletionWatcher
+from pgqueuer.core.qm import QueueManager
+from pgqueuer.domain import errors
+from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import Channel, QueueExecutionMode
+from pgqueuer.models import Job
+from pgqueuer.queries import Queries
+from test.helpers import queries_for
+
+
+class RecorderDriver(InMemoryDriver):
+    """InMemoryDriver that records LISTEN channels and tolerates SQL calls."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.listened_channels: list[str] = []
+
+    async def fetch(self, query: str, *args: object) -> list[dict]:
+        return []
+
+    async def execute(self, query: str, *args: object) -> str:
+        return ""
+
+    async def add_listener(
+        self,
+        channel: str,
+        callback: Callable[[str], None],
+    ) -> None:
+        self.listened_channels.append(channel)
+        await super().add_listener(channel, callback)
+
+
+def test_queue_manager_channel_derives_from_queries_settings() -> None:
+    settings = DBSettings(prefix="custom_")
+    qm = QueueManager(queries_for(RecorderDriver(), settings))
+    assert str(qm.channel) == "custom_ch_pgqueuer"
+
+
+def test_queue_manager_explicit_channel_still_wins() -> None:
+    settings = DBSettings(prefix="custom_")
+    qm = QueueManager(queries_for(RecorderDriver(), settings), Channel("explicit_ch"))
+    assert str(qm.channel) == "explicit_ch"
+
+
+def test_pgqueuer_channel_derives_from_queries_settings() -> None:
+    settings = DBSettings(prefix="custom_")
+    pgq = PgQueuer(RecorderDriver(), queries=queries_for(RecorderDriver(), settings))
+    assert str(pgq.channel) == "custom_ch_pgqueuer"
+    assert pgq.channel == pgq.qm.channel
+
+
+def test_channel_defaults_are_not_frozen_at_import_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env vars set after import must reach the default channel."""
+    monkeypatch.setenv("PGQUEUER_PREFIX", "zz_")
+    assert str(QueueManager(Queries(RecorderDriver())).channel) == "zz_ch_pgqueuer"
+    assert str(PgQueuer(RecorderDriver()).channel) == "zz_ch_pgqueuer"
+
+
+async def test_completion_watcher_listens_on_the_queries_channel() -> None:
+    settings = DBSettings(prefix="custom_")
+    driver = RecorderDriver()
+    async with CompletionWatcher(driver, queries=queries_for(driver, settings)):
+        pass
+    assert driver.listened_channels == ["custom_ch_pgqueuer"]
+
+
+async def test_queue_manager_listener_round_trip_under_custom_prefix(
+    apgdriver: db.Driver,
+) -> None:
+    """LISTEN and NOTIFY agree under a custom prefix (fails on the split-channel bug)."""
+    await Queries(apgdriver).uninstall()
+    settings = DBSettings(prefix="iso_")
+    queries = queries_for(apgdriver, settings)
+    await queries.install()
+
+    qm = QueueManager(queries)
+
+    @qm.entrypoint("noop")
+    async def noop(job: Job) -> None: ...
+
+    run_task = asyncio.create_task(qm.run(dequeue_timeout=timedelta(seconds=0.1)))
+    try:
+        async with async_timeout.timeout(10):
+            while True:
+                try:
+                    await qm.listener_healthy(timeout=timedelta(seconds=1))
+                    break
+                except errors.FailingListenerError:
+                    await asyncio.sleep(0.05)
+    finally:
+        qm.shutdown.set()
+        async with async_timeout.timeout(10):
+            await run_task
+
+
+async def test_completion_watcher_resolves_under_custom_prefix(
+    apgdriver: db.Driver,
+) -> None:
+    """wait_for resolves via NOTIFY under a custom prefix (fails on the hardcoded channel).
+
+    The safety-net poll is set far above the timeout so only the LISTEN path
+    can resolve the future.
+    """
+    await Queries(apgdriver).uninstall()
+    settings = DBSettings(prefix="iso_")
+    queries = queries_for(apgdriver, settings)
+    await queries.install()
+
+    qm = QueueManager(queries)
+
+    @qm.entrypoint("ep")
+    async def ep(job: Job) -> None: ...
+
+    (jid,) = await queries.enqueue("ep", None, 0)
+
+    async with (
+        async_timeout.timeout(10),
+        CompletionWatcher(
+            apgdriver,
+            queries=queries,
+            refresh_interval=timedelta(seconds=60),
+        ) as watcher,
+    ):
+        fut = watcher.wait_for(jid)
+        # Let the debounce check armed by wait_for run while the job is still
+        # queued; after this, only a NOTIFY on the right channel can resolve.
+        await asyncio.sleep(0.2)
+        assert not fut.done()
+        await qm.run(mode=QueueExecutionMode.drain)
+        async with async_timeout.timeout(2):
+            assert await fut == "successful"
+
+
+def test_cli_listen_honors_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: the --channel default was evaluated at import, before --prefix."""
+    import contextlib
+    from typing import AsyncGenerator
+
+    from typer.testing import CliRunner
+
+    from pgqueuer.adapters.cli import cli
+    from pgqueuer.adapters.persistence import qb
+
+    captured: list[str] = []
+
+    @contextlib.asynccontextmanager
+    async def fake_yield_queries(
+        ctx: object,
+        settings: qb.DBSettings,
+    ) -> AsyncGenerator[Queries, None]:
+        yield queries_for(RecorderDriver(), settings)
+
+    async def fake_display_pg_channel(connection: object, channel: Channel) -> None:
+        captured.append(str(channel))
+
+    monkeypatch.setattr(cli, "yield_queries", fake_yield_queries)
+    monkeypatch.setattr(cli, "display_pg_channel", fake_display_pg_channel)
+    monkeypatch.delenv("PGQUEUER_PREFIX", raising=False)
+
+    result = CliRunner().invoke(cli.app, ["--prefix", "foo_", "listen"])
+    assert result.exit_code == 0, result.output
+    assert captured == ["foo_ch_pgqueuer"]
+
+    captured.clear()
+    result = CliRunner().invoke(cli.app, ["--prefix", "foo_", "listen", "--channel", "explicit_ch"])
+    assert result.exit_code == 0, result.output
+    assert captured == ["explicit_ch"]
+
+
+def test_mcp_server_settings_default_is_resolved_at_startup() -> None:
+    import inspect
+
+    from pgqueuer.adapters.mcp.server import create_mcp_server
+
+    default = inspect.signature(create_mcp_server).parameters["settings"].default
+    assert default is None

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -9,6 +9,7 @@ import pytest
 
 from pgqueuer import db
 from pgqueuer.adapters.inmemory import InMemoryQueries
+from pgqueuer.adapters.persistence import qb
 from pgqueuer.core.cache import TTLCache
 from pgqueuer.core.tm import TaskManager
 from pgqueuer.models import Job, Log
@@ -169,6 +170,8 @@ async def test_periodic_log_aggregation_loops_until_shutdown() -> None:
     qm: QueueManager
 
     class Stub:
+        qbe = qb.QueryBuilderEnvironment()
+
         async def aggregate_logs(self) -> None:
             nonlocal calls
             calls += 1
@@ -187,6 +190,8 @@ async def test_periodic_log_aggregation_survives_aggregate_errors() -> None:
     qm: QueueManager
 
     class Stub:
+        qbe = qb.QueryBuilderEnvironment()
+
         async def aggregate_logs(self) -> None:
             nonlocal calls
             calls += 1


### PR DESCRIPTION
QueueManager, PgQueuer, and CompletionWatcher each built their own channel from an independent DBSettings() — evaluated at import time in the dataclass defaults — while NOTIFYs go to the channel of the queries' settings. Under a custom prefix or PGQUEUER_CHANNEL the two diverged: workers never woke, CompletionWatcher.wait_for() never resolved, and env vars set after import were ignored.

The channel now defaults to None and derives from the injected queries (queries.qbe.settings.channel) at construction time; an explicit channel= still wins. pgq listen resolves its --channel default at invocation, after --prefix is exported, and create_mcp_server reads env-derived settings at startup instead of import.

CompletionWatcher.queries is now annotated RepositoryPort (was QueueRepositoryPort) to reach the settings; runtime behavior for all shipped repositories is unchanged.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
