### PR TITLE
fix(qm): skip log aggregation tick when worker did no work

### DIFF
--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -77,6 +77,11 @@ class QueueManager:
         )
     )
 
+    # Incremented once per dispatched job; the periodic log-aggregation task
+    # only calls the database when this is nonzero, so an idle worker never
+    # round-trips an aggregation query for nothing.
+    jobs_logged: int = dataclasses.field(init=False, default=0)
+
     # Minimum sleep before re-checking the queue. Prevents busy-looping when a
     # deferred job's ETA is near zero or when the TOCTOU fallback detects
     # eligible work that the preceding dequeue narrowly missed.
@@ -117,14 +122,20 @@ class QueueManager:
     async def _run_periodic_log_aggregation(self, interval: timedelta) -> None:
         """Aggregate log->statistics every *interval* (jittered) until shutdown.
 
-        Non-cron: mirrors ``_run_periodic_health_check``. Aggregation failures are
-        swallowed so a transient DB hiccup never tears down the worker; the next
-        tick retries. The advisory lock in ``aggregate_logs`` serializes across
-        workers, and the jitter desyncs their ticks.
+        Non-cron: mirrors ``_run_periodic_health_check``. Skipped when this worker
+        hasn't logged a job since the last tick: an idle worker has nothing new to
+        fold in, and the advisory lock in ``aggregate_logs`` already serializes real
+        work across workers. A failed attempt leaves ``jobs_logged`` set so the next
+        tick retries instead of silently dropping the backlog; only success resets it.
         """
         while not self.shutdown.is_set():
-            with suppress(Exception):
-                await self.queries.aggregate_logs()
+            if self.jobs_logged:
+                try:
+                    await self.queries.aggregate_logs()
+                except Exception:
+                    pass
+                else:
+                    self.jobs_logged = 0
             with suppress(TimeoutError, asyncio.TimeoutError):
                 await asyncio.wait_for(
                     self.shutdown.wait(),
@@ -551,3 +562,4 @@ class QueueManager:
                 await jbuff.add((job, "canceled" if canceled else "successful", None))
             finally:
                 self.job_context.pop(job.id, None)
+                self.jobs_logged += 1

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import itertools
 import uuid
 from datetime import timedelta
@@ -176,9 +177,69 @@ async def test_periodic_log_aggregation_loops_until_shutdown() -> None:
                 qm.shutdown.set()
 
     qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
-    async with async_timeout.timeout(5):
-        await qm._run_periodic_log_aggregation(timedelta(seconds=0))
+
+    async def keep_marking_work() -> None:
+        # Stands in for `_dispatch` incrementing `jobs_logged` concurrently;
+        # without a steady stream of "new work" the gate would starve the loop
+        # after the first (post-success) reset.
+        while not qm.shutdown.is_set():
+            qm.jobs_logged = 1
+            await asyncio.sleep(0)
+
+    qm.jobs_logged = 1
+    marker = asyncio.ensure_future(keep_marking_work())
+    try:
+        async with async_timeout.timeout(5):
+            await qm._run_periodic_log_aggregation(timedelta(seconds=0))
+    finally:
+        marker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await marker
     assert calls == 3
+
+
+async def test_periodic_log_aggregation_skips_when_idle() -> None:
+    """No job logged since the last tick means aggregate_logs is never called."""
+    calls = 0
+    qm: QueueManager
+
+    class Stub:
+        async def aggregate_logs(self) -> None:
+            nonlocal calls
+            calls += 1
+
+    qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
+    task = asyncio.ensure_future(qm._run_periodic_log_aggregation(timedelta(seconds=0)))
+    try:
+        for _ in range(3):
+            await asyncio.sleep(0)
+    finally:
+        qm.shutdown.set()
+        async with async_timeout.timeout(5):
+            await task
+    assert calls == 0
+
+
+async def test_dispatch_increments_jobs_logged_counter(
+    queries: InMemoryQueries,
+) -> None:
+    """`jobs_logged` counts dispatched jobs, the gate the periodic task checks."""
+    qm = QueueManager(queries)
+
+    @qm.entrypoint("fetch")
+    async def fetch(job: Job) -> None:
+        pass
+
+    await qm.queries.enqueue(["fetch"] * 3, [None] * 3, [0] * 3)
+
+    async with async_timeout.timeout(10):
+        await asyncio.gather(
+            # Aggregation disabled so it doesn't race the counter it gates.
+            qm.run(log_aggregation_interval=timedelta(0)),
+            wait_until_empty_queue(qm.queries, [qm]),
+        )
+
+    assert qm.jobs_logged == 3
 
 
 async def test_periodic_log_aggregation_survives_aggregate_errors() -> None:
@@ -195,6 +256,7 @@ async def test_periodic_log_aggregation_survives_aggregate_errors() -> None:
             raise RuntimeError("boom")
 
     qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
+    qm.jobs_logged = 1
     async with async_timeout.timeout(5):
         await qm._run_periodic_log_aggregation(timedelta(seconds=0))
     assert calls == 3


### PR DESCRIPTION
The periodic aggregation task called aggregate_logs() unconditionally every tick, even on an idle worker with nothing new in pgqueuer_log. Track a per-dispatch counter and only call aggregate_logs() when it's nonzero; reset it on success only, so a failed attempt still retries next tick instead of dropping the backlog silently.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
