### PR TITLE
docs(reliability): document log-aggregation gating and backlog caveat

### DIFF
--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -14,7 +14,7 @@ await pgq.run(batch_size=25, dequeue_timeout=timedelta(seconds=10))
 |-----------|---------|--------|
 | `batch_size` | `10` | Jobs fetched per dequeue round-trip |
 | `dequeue_timeout` | `30 s` | How long to wait for new NOTIFY before polling |
-| `log_aggregation_interval` | `30 s` | How often to roll `pgqueuer_log` into `pgqueuer_statistics`; `0` disables (aggregate on read) |
+| `log_aggregation_interval` | `30 s` | How often to roll `pgqueuer_log` into `pgqueuer_statistics`; skipped on ticks where the worker logged no jobs, `0` disables (aggregate on read) |
 
 **Tuning guidance:**
 - Increase `batch_size` when jobs are short-lived (< 1 s) and you see many dequeue round-trips

--- a/docs/guides/reliability.md
+++ b/docs/guides/reliability.md
@@ -203,13 +203,25 @@ timer while it processes jobs, so statistics stay current without anyone reading
 await pgq.run(log_aggregation_interval=timedelta(seconds=30))
 ```
 
-- Default interval is 30 seconds. The task runs on every worker, but a Postgres advisory
-  lock lets only one worker aggregate at a time, so counts are never doubled.
+- Default interval is 30 seconds. The task only calls the database when this worker has
+  actually dispatched a job since the last tick; an idle worker never round-trips an
+  aggregation query for nothing.
+- The task runs on every worker, but a Postgres advisory lock lets only one worker
+  aggregate at a time, so counts are never doubled.
 - Pass `timedelta(0)` to disable the background task. Aggregation then happens only
   on-demand, the first time statistics are read (CLI `pgq dashboard`, Prometheus metrics,
   or the MCP server).
 - Aggregation never deletes log rows; it flags them `aggregated = TRUE`. Log retention is
   still your responsibility (see the note above).
+
+!!! warning "Large pre-existing backlog"
+    The aggregation query folds every currently-unaggregated `pgqueuer_log` row in one
+    unbatched transaction; there is no `LIMIT`/chunking yet. If `pgqueuer_log` has built
+    up a large backlog before this runs for the first time (e.g. upgrading onto this
+    feature on a long-running deployment that never read statistics before), the first
+    tick that touches it can be a long-running transaction with matching lock/WAL
+    impact. Check `SELECT count(*) FROM pgqueuer_log WHERE NOT aggregated` before
+    upgrading a high-throughput deployment so this isn't a surprise.
 
 ## Summary
 


### PR DESCRIPTION
Note that the periodic aggregation task now skips ticks where the worker logged no jobs, and flag the known unbatched-backlog risk on first run against a pre-existing pgqueuer_log (upgrade scenario).

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
