### PR TITLE
fix(ci): drop pytest-xdist workers from 4 to 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ uv run ruff format . --check  # Format check
 uv run lint-imports         # Hexagonal architecture boundary validation
 uv run mypy .               # Type checking (strict, targets Python 3.10)
 
-# Run all tests (parallel by default: 4 xdist workers, one Postgres container each)
+# Run all tests (parallel by default: 2 xdist workers, one Postgres container each)
 uv run pytest
 
 # Run tests serially (disable pytest-xdist)
@@ -243,7 +243,7 @@ When a comment explains a non-obvious workaround, keep it short and put it adjac
 
 ## Testing Conventions
 
-- **pytest config**: `asyncio_mode = "auto"`, 20s timeout per test, `--durations=15`, `-n 4` (pytest-xdist)
+- **pytest config**: `asyncio_mode = "auto"`, 20s timeout per test, `--durations=15`, `-n 2` (pytest-xdist)
 - Tests run in parallel via **pytest-xdist**: session-scoped fixtures are per-worker, so each worker starts its own Postgres container and template database. Pass `-n 0` to run serially, or `-n <N>` to change worker count.
 - Keep tests xdist-safe: no fixed ports, no shared files, no cross-test state. Database isolation comes from the per-test `CREATE DATABASE ... TEMPLATE` fixture.
 - Declare async tests as `async def test_...` -- no `@pytest.mark.asyncio` decorator needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,9 +161,10 @@ explicit_package_bases = true
 asyncio_mode = "auto"
 timeout = "20"
 timeout_func_only = true
-# -n 4: modest parallelism; each xdist worker gets its own session-scoped
+# -n 2: modest parallelism; each xdist worker gets its own session-scoped
 # Postgres container, so this scales the suite across a few extra servers.
-addopts = "--durations=15 -n 4"
+# Dropped from 4 after CI instability (see 9d9ce3c).
+addopts = "--durations=15 -n 2"
 
 # ---------------------------------------------------------------------------
 # Import-linter: enforce hexagonal architecture boundaries


### PR DESCRIPTION
CI unstable at 4 workers since 9d9ce3c. Each worker spins up its own Postgres container; 4 concurrent containers overloads CI runners.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
