### PR TITLE
feat(release): publish multi-arch docker images to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,43 @@ jobs:
       - name: Build package.
         run: python3 -m build . --sdist --wheel --outdir dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-docker-images:
+    name: Publish ${{ matrix.name }} Docker image.
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: prometheus
+            dockerfile: tools/prometheus/Dockerfile
+          - name: web
+            dockerfile: tools/web/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}-${{ matrix.name }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/docs/guides/docker-images.md
+++ b/docs/guides/docker-images.md
@@ -1,0 +1,112 @@
+# Docker Images
+
+Pre-built, multi-arch (`linux/amd64` + `linux/arm64`) images for the web dashboard
+and the standalone Prometheus exporter are published to the GitHub Container
+Registry on every release, tagged to match the PyPI version:
+
+| Image | Source | Tags |
+|---|---|---|
+| `ghcr.io/janbjorge/pgqueuer-web` | `tools/web/Dockerfile` | `vX.Y.Z`, `latest` |
+| `ghcr.io/janbjorge/pgqueuer-prometheus` | `tools/prometheus/Dockerfile` | `vX.Y.Z`, `latest` |
+
+Pin to a version tag in production; `latest` tracks the newest non-prerelease.
+
+## Web Dashboard
+
+```bash
+docker run -p 8080:8080 \
+  -e PGHOST=your-postgres-host \
+  -e PGUSER=your-username \
+  -e PGPASSWORD=your-password \
+  -e PGDATABASE=your-database \
+  -e PGQUEUER_WEB_USER=admin \
+  -e PGQUEUER_WEB_PASSWORD=change-me \
+  ghcr.io/janbjorge/pgqueuer-web:latest
+```
+
+Connection settings follow the same rules as `pgq web`: either `PGQUEUER_DSN`
+(or `PGDSN`), or the standard libpq variables (`PGHOST`, `PGUSER`,
+`PGPASSWORD`, `PGDATABASE`). `PGQUEUER_WEB_HOST` / `PGQUEUER_WEB_PORT` are
+already set in the image (`0.0.0.0:8080`); override only if you need a
+different bind.
+
+`PGQUEUER_WEB_USER` / `PGQUEUER_WEB_PASSWORD` are **not** set by the image.
+Without them the dashboard runs unauthenticated. It can cancel and requeue
+jobs, so never publish it without setting both. See
+[Web Dashboard → Authentication](../integrations/web-dashboard.md#authentication).
+
+## Prometheus Exporter
+
+```bash
+docker run -p 8000:8000 \
+  -e PGHOST=your-postgres-host \
+  -e PGUSER=your-username \
+  -e PGPASSWORD=your-password \
+  -e PGDATABASE=your-database \
+  ghcr.io/janbjorge/pgqueuer-prometheus:latest
+```
+
+Metrics are served at `http://localhost:8000/metrics`.
+
+!!! warning
+    This exporter connects with a bare `asyncpg.connect()`: it reads only
+    `PGHOST` / `PGPORT` / `PGUSER` / `PGPASSWORD` / `PGDATABASE`.
+    `PGQUEUER_DSN` / `PGDSN` are **not** read here, unlike the web dashboard
+    and every `pgq` CLI command. Setting only a DSN for this image will fail
+    to connect.
+
+## Docker Compose
+
+```yaml
+services:
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: pgqueuer
+      POSTGRES_PASSWORD: pgqueuer
+      POSTGRES_DB: pgqueuer
+
+  web:
+    image: ghcr.io/janbjorge/pgqueuer-web:latest
+    ports:
+      - "8080:8080"
+    environment:
+      PGHOST: db
+      PGUSER: pgqueuer
+      PGPASSWORD: pgqueuer
+      PGDATABASE: pgqueuer
+      PGQUEUER_WEB_USER: admin
+      PGQUEUER_WEB_PASSWORD: change-me
+    depends_on:
+      - db
+
+  prometheus-exporter:
+    image: ghcr.io/janbjorge/pgqueuer-prometheus:latest
+    ports:
+      - "8000:8000"
+    environment:
+      PGHOST: db
+      PGUSER: pgqueuer
+      PGPASSWORD: pgqueuer
+      PGDATABASE: pgqueuer
+    depends_on:
+      - db
+```
+
+A working example lives at `tools/web/docker-compose.yml`.
+
+## Building locally
+
+Both images build from the repo without registry access, useful for testing
+Dockerfile changes before a release:
+
+```bash
+docker build -f tools/web/Dockerfile -t pgqueuer-web .
+docker build -f tools/prometheus/Dockerfile -t pgqueuer-prometheus .
+```
+
+## Multi-arch builds in CI
+
+Images are built for `linux/amd64` and `linux/arm64` via `docker/build-push-action`
+with QEMU emulation in `.github/workflows/release.yml`, triggered on the same
+`release: created` event as the PyPI publish step.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
       - Performance & Deployment:
           - Performance Tuning: guides/performance-tuning.md
           - Deployment Patterns: guides/deployment.md
+          - Docker Images: guides/docker-images.md
   - Reference:
       - CLI: reference/cli.md
       - Architecture: reference/architecture.md


### PR DESCRIPTION
Add publish-docker-images job to release.yml: builds tools/web and tools/prometheus for linux/amd64+arm64 via buildx/qemu, pushes to ghcr.io tagged with the release version (+ latest), auth via the built-in GITHUB_TOKEN. Document usage in docs/guides/docker-images.md.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
