### PR TITLE
fix(release): pin docker images to the released pgqueuer version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
   publish-docker-images:
     name: Publish ${{ matrix.name }} Docker image.
+    needs: publish-pypi-package
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -40,6 +41,9 @@ jobs:
             dockerfile: tools/web/Dockerfile
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve pgqueuer version.
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -62,5 +66,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: PGQUEUER_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/tools/prometheus/Dockerfile
+++ b/tools/prometheus/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 
 FROM ghcr.io/astral-sh/uv:python3.13-alpine AS builder
+ARG PGQUEUER_VERSION=
 WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --no-cache-dir "pgqueuer[asyncpg]" fastapi uvicorn
+    uv pip install --system --no-cache-dir "pgqueuer[asyncpg]${PGQUEUER_VERSION:+==${PGQUEUER_VERSION}}" fastapi uvicorn
 COPY tools/prometheus /app/prometheus
 
 FROM python:3.13-alpine

--- a/tools/web/Dockerfile
+++ b/tools/web/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 
 FROM ghcr.io/astral-sh/uv:python3.13-alpine AS builder
+ARG PGQUEUER_VERSION=
 WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --no-cache-dir "pgqueuer[web,asyncpg]"
+    uv pip install --system --no-cache-dir "pgqueuer[web,asyncpg]${PGQUEUER_VERSION:+==${PGQUEUER_VERSION}}"
 
 FROM python:3.13-alpine
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
Both Dockerfiles installed "pgqueuer[...]" unpinned, so a build always grabbed whatever was newest on PyPI rather than the tagged release - tag v1.5.0 could silently ship v1.4.0's code if PyPI hadn't finished publishing yet. Pass the release tag through as a PGQUEUER_VERSION build-arg and pin the install to it, and add needs: publish-pypi-package so the docker job runs after (not racing) the PyPI publish.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `make check` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
