### PR TITLE
test(scheduler): use InMemoryQueries for most unit tests, keep DB tests for concurrency

### DIFF
--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from pgqueuer.db import AsyncpgDriver, Driver
+from pgqueuer.adapters.inmemory import InMemoryQueries
+from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.executors import (
     ScheduleExecutor,
@@ -26,14 +27,13 @@ async def inspect_schedule(
 ) -> list[Schedule]:
     if isinstance(scheduler_or_driver, SchedulerManager):
         return await scheduler_or_driver.queries.peek_schedule()
-    else:
-        # Legacy path for integration tests that inspect raw DB
-        query = f"SELECT * FROM {DBSettings().schedules_table} ORDER BY id"
-        return [Schedule.model_validate(dict(x)) for x in await scheduler_or_driver.fetch(query)]
+    # Legacy path for integration tests that inspect raw DB
+    query = f"SELECT * FROM {DBSettings().schedules_table} ORDER BY id"
+    return [Schedule.model_validate(dict(x)) for x in await scheduler_or_driver.fetch(query)]
 
 
 @pytest.fixture
-def scheduler(queries) -> SchedulerManager:
+def scheduler(queries: InMemoryQueries) -> SchedulerManager:
     return SchedulerManager(queries)
 
 

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -21,14 +21,20 @@ from pgqueuer.queries import Queries
 from pgqueuer.sm import SchedulerManager
 
 
-async def inspect_schedule(connection: Driver) -> list[Schedule]:
-    query = f"SELECT * FROM {DBSettings().schedules_table} ORDER BY id"
-    return [Schedule.model_validate(dict(x)) for x in await connection.fetch(query)]
+async def inspect_schedule(
+    scheduler_or_driver: SchedulerManager | AsyncpgDriver,
+) -> list[Schedule]:
+    if isinstance(scheduler_or_driver, SchedulerManager):
+        return await scheduler_or_driver.queries.peek_schedule()
+    else:
+        # Legacy path for integration tests that inspect raw DB
+        query = f"SELECT * FROM {DBSettings().schedules_table} ORDER BY id"
+        return [Schedule.model_validate(dict(x)) for x in await scheduler_or_driver.fetch(query)]
 
 
 @pytest.fixture
-async def scheduler(apgdriver: AsyncpgDriver) -> SchedulerManager:
-    return SchedulerManager(Queries(apgdriver))
+def scheduler(queries) -> SchedulerManager:
+    return SchedulerManager(queries)
 
 
 async def shutdown_Scheduler_after(
@@ -199,14 +205,14 @@ async def test_heartbeat_updates(scheduler: SchedulerManager, mocker: Mock) -> N
 
     scheduler.schedule("sample_task", "* * * * *")(sample_task)
 
-    before = await inspect_schedule(scheduler.queries.driver)
+    before = await inspect_schedule(scheduler)
     await asyncio.gather(
         *[
             scheduler.run(),
             shutdown_Scheduler_after(scheduler, timedelta(seconds=1)),
         ],
     )
-    after = await inspect_schedule(scheduler.queries.driver)
+    after = await inspect_schedule(scheduler)
 
     assert all(a.heartbeat > b.heartbeat for a, b in zip(after, before))
 

--- a/test/test_scheduler_heartbeat.py
+++ b/test/test_scheduler_heartbeat.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import patch
 
-from pgqueuer import db
 from pgqueuer.domain.types import ScheduleId
-from pgqueuer.queries import Queries
 from pgqueuer.sm import SchedulerManager
 
 
-async def test_scheduler_heartbeat_batches(apgdriver: db.Driver) -> None:
+async def test_scheduler_heartbeat_batches(queries) -> None:
     """The heartbeat loop must send batched updates for all active schedule IDs."""
-    sm = SchedulerManager(Queries(apgdriver))
+    sm = SchedulerManager(queries)
 
     captured_calls: list[set[ScheduleId]] = []
 
@@ -43,9 +41,9 @@ async def test_scheduler_heartbeat_batches(apgdriver: db.Driver) -> None:
     )
 
 
-async def test_scheduler_heartbeat_skips_when_empty(apgdriver: db.Driver) -> None:
+async def test_scheduler_heartbeat_skips_when_empty(queries) -> None:
     """The heartbeat loop must not call update when no schedules are active."""
-    sm = SchedulerManager(Queries(apgdriver))
+    sm = SchedulerManager(queries)
 
     call_count = 0
 

--- a/test/test_scheduler_heartbeat.py
+++ b/test/test_scheduler_heartbeat.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import patch
 
+from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.domain.types import ScheduleId
 from pgqueuer.sm import SchedulerManager
 
 
-async def test_scheduler_heartbeat_batches(queries) -> None:
+async def test_scheduler_heartbeat_batches(queries: InMemoryQueries) -> None:
     """The heartbeat loop must send batched updates for all active schedule IDs."""
     sm = SchedulerManager(queries)
 
@@ -41,7 +42,7 @@ async def test_scheduler_heartbeat_batches(queries) -> None:
     )
 
 
-async def test_scheduler_heartbeat_skips_when_empty(queries) -> None:
+async def test_scheduler_heartbeat_skips_when_empty(queries: InMemoryQueries) -> None:
     """The heartbeat loop must not call update when no schedules are active."""
     sm = SchedulerManager(queries)
 


### PR DESCRIPTION
Move scheduler subsystem to hex-style testing:
- 14 scheduler tests now run fast via InMemoryQueries (~0.2s each)
- Verify domain behavior (registration, execution, dispatch, heartbeat batching) without DB container overhead
- Keep 2 integration tests on real Postgres:
  - test_multi_instance_single_task_execution (Issue #536: race condition proof)
  - test_schedule_clean_old (DB transactional semantics)

Changes:
- scheduler fixture: AsyncpgDriver → queries (InMemoryQueries)
- inspect_schedule helper: polymorphic (SchedulerManager or AsyncpgDriver)
- test_scheduler_heartbeat: both tests now use InMemoryQueries

Port conformance (test_port_conformance.py) still green. Full suite 1044 pass.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
