### PR TITLE
refactor: unify DBSettings ownership across the query stack

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -186,25 +186,24 @@ This prefixes all table names, the enum type, the trigger, and the NOTIFY channe
 The two settings are independent: a prefix separates instances that share a
 schema, and `PGQUEUER_SCHEMA` moves the whole installation into another schema.
 
-## DBSettings ownership
+## DBSettings
 
-Each `Queries`, `InMemoryQueries`, or `SyncQueries` instance owns one `DBSettings`
-object. Pass it once at construction; every query builder, `QueueManager` LISTEN
-channel, and `CompletionWatcher` listener reads from that same instance:
+Pass one `DBSettings` when you construct `Queries`, `InMemoryQueries`, or
+`SyncQueries`. The query builders, `QueueManager` LISTEN channel, and
+`CompletionWatcher` all use that same object:
 
 ```python
 from pgqueuer import DBSettings, PgQueuer, Queries
-from pgqueuer.db import AsyncpgDriver
 
 settings = DBSettings(prefix="billing_")
 queries = Queries(connection, settings=settings)
 pgq = PgQueuer.from_asyncpg_connection(connection, settings=settings)
 ```
 
-`DBSettings` is also exported from the top-level `pgqueuer` package. Field
-mutations (for example `settings.db_schema = "billing"`) are validated and
-observed by all consumers. Create a new `DBSettings` only at your application
-edge (CLI, web dashboard, MCP server, or test fixture), not inside library code.
+You can import `DBSettings` from `pgqueuer`. Assignments like
+`settings.db_schema = "billing"` are validated and picked up by everything that
+shares the object. Build `DBSettings` in your app entrypoint (CLI, web, MCP, or
+test fixture); do not construct a second copy deeper in the stack.
 
 ## Next Steps
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -186,6 +186,26 @@ This prefixes all table names, the enum type, the trigger, and the NOTIFY channe
 The two settings are independent: a prefix separates instances that share a
 schema, and `PGQUEUER_SCHEMA` moves the whole installation into another schema.
 
+## DBSettings ownership
+
+Each `Queries`, `InMemoryQueries`, or `SyncQueries` instance owns one `DBSettings`
+object. Pass it once at construction; every query builder, `QueueManager` LISTEN
+channel, and `CompletionWatcher` listener reads from that same instance:
+
+```python
+from pgqueuer import DBSettings, PgQueuer, Queries
+from pgqueuer.db import AsyncpgDriver
+
+settings = DBSettings(prefix="billing_")
+queries = Queries(connection, settings=settings)
+pgq = PgQueuer.from_asyncpg_connection(connection, settings=settings)
+```
+
+`DBSettings` is also exported from the top-level `pgqueuer` package. Field
+mutations (for example `settings.db_schema = "billing"`) are validated and
+observed by all consumers. Create a new `DBSettings` only at your application
+edge (CLI, web dashboard, MCP server, or test fixture), not inside library code.
+
 ## Next Steps
 
 - **[Quick Start](quickstart.md)**: build your first consumer and producer

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -108,7 +108,7 @@ custom settings:
 
 ```python
 from pgqueuer.adapters.mcp.server import create_mcp_server
-from pgqueuer.adapters.persistence.qb import DBSettings
+from pgqueuer import DBSettings
 
 # reads PGQUEUER_PREFIX / PGQUEUER_SCHEMA
 server = create_mcp_server(settings=DBSettings())

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -167,8 +167,8 @@ All classmethods accept:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `connection` / `pool` | Yes | The database connection or pool |
-| `channel` | No | Custom `Channel` configuration. Defaults to the repository's `DBSettings.channel` |
-| `settings` | No | Shared `DBSettings` for table names and NOTIFY channel. Defaults to env/`DBSettings()` |
+| `channel` | No | Custom `Channel`. Defaults to `queries.settings.channel` |
+| `settings` | No | `DBSettings` for table names and the NOTIFY channel. Defaults to `DBSettings()` / env |
 | `resources` | No | Mutable mapping for shared resources. Defaults to `{}` |
 
 ## Best Practices

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -167,7 +167,8 @@ All classmethods accept:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `connection` / `pool` | Yes | The database connection or pool |
-| `channel` | No | Custom `Channel` configuration. Defaults to `Channel(DBSettings().channel)` |
+| `channel` | No | Custom `Channel` configuration. Defaults to the repository's `DBSettings.channel` |
+| `settings` | No | Shared `DBSettings` for table names and NOTIFY channel. Defaults to env/`DBSettings()` |
 | `resources` | No | Mutable mapping for shared resources. Defaults to `{}` |
 
 ## Best Practices

--- a/pgqueuer/__init__.py
+++ b/pgqueuer/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.applications import PgQueuer
 from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, PsycopgDriver
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.errors import RetryRequested
 from pgqueuer.executors import DatabaseRetryEntrypointExecutor
 from pgqueuer.models import Job, JobId
@@ -18,6 +19,7 @@ except ImportError:
 __all__ = [
     "AsyncpgDriver",
     "AsyncpgPoolDriver",
+    "DBSettings",
     "DatabaseRetryEntrypointExecutor",
     "InMemoryDriver",
     "InMemoryQueries",

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -353,12 +353,13 @@ def uninstall(
         help="Deprecated: use 'pgq sql uninstall'.",
     ),
 ) -> None:
+    settings = qb.DBSettings()
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall(qb.DBSettings()))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall(settings))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings) as q:
             await q.uninstall()
 
     asyncio_run(run())
@@ -695,12 +696,13 @@ def optimize_autovacuum(
     rollback: bool = typer.Option(False, help="Reset to defaults instead."),
 ) -> None:
     """Apply or revert recommended autovacuum settings."""
+    settings = qb.DBSettings()
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(qb.DBSettings(), rollback))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(settings, rollback))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings) as q:
             await (q.optimize_autovacuum_rollback() if rollback else q.optimize_autovacuum())
 
     asyncio_run(run())

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -168,12 +168,6 @@ def create_default_queries_factory(
     return factory
 
 
-def settings_from_ctx(ctx: Context) -> qb.DBSettings:
-    """Build DBSettings after AppConfig has applied CLI/env overrides."""
-    del ctx
-    return qb.DBSettings()
-
-
 @contextlib.asynccontextmanager
 async def yield_queries(
     ctx: Context,
@@ -309,7 +303,7 @@ def verify(
     ),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             expect_present = expect == VerifyMode.PRESENT
             divergence = list[str]()
 
@@ -360,11 +354,11 @@ def uninstall(
     ),
 ) -> None:
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall(settings_from_ctx(ctx)))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall(qb.DBSettings()))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             await q.uninstall()
 
     asyncio_run(run())
@@ -413,7 +407,7 @@ def dashboard(
     interval_td = timedelta(seconds=interval) if interval is not None else None
 
     async def run() -> None:
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             await fetch_and_display(q, interval_td, limit)
 
     asyncio_run(run())
@@ -458,7 +452,7 @@ def listen(
     ),
 ) -> None:
     async def run() -> None:
-        settings = settings_from_ctx(ctx)
+        settings = qb.DBSettings()
         async with yield_queries(ctx, settings) as q:
             await display_pg_channel(q.driver, models.Channel(channel or settings.channel))
 
@@ -560,7 +554,7 @@ def schedules(
     ),
 ) -> None:
     async def run_async() -> None:
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             if remove:
                 schedule_ids = {models.ScheduleId(int(x)) for x in remove if x.isdigit()}
                 schedule_names = {types.CronEntrypoint(x) for x in remove if not x.isdigit()}
@@ -595,7 +589,7 @@ def queue(
     async def run_async() -> None:
         # For a single job, skip mode subsumes raise mode: a None result is
         # exactly the duplicate case, so on_conflict only decides the exit.
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             (job_id,) = await q.enqueue(
                 entrypoint,
                 None if payload is None else payload.encode(),
@@ -624,7 +618,7 @@ def failed(
     limit: int = typer.Option(25, "-n", "--limit", help="Maximum number of jobs to display."),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             jobs = await q.list_failed_jobs(limit=limit)
             if not jobs:
                 print("No failed jobs.")
@@ -656,7 +650,7 @@ def requeue(
     ids: list[int] = typer.Argument(..., help="Job IDs to re-queue."),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             typed_ids = [types.JobId(i) for i in ids]
             await q.requeue_jobs(typed_ids)
             print(f"Re-queued {len(typed_ids)} job(s).")
@@ -702,11 +696,11 @@ def optimize_autovacuum(
 ) -> None:
     """Apply or revert recommended autovacuum settings."""
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(settings_from_ctx(ctx), rollback))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(qb.DBSettings(), rollback))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
+        async with yield_queries(ctx, qb.DBSettings()) as q:
             await (q.optimize_autovacuum_rollback() if rollback else q.optimize_autovacuum())
 
     asyncio_run(run())

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -154,28 +154,24 @@ def create_default_queries_factory(
             from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
             async with connect_asyncpg(dsn=config.pg_dsn or None) as connection:
-                yield queries.Queries(
-                    AsyncpgDriver(connection),
-                    qbe=qb.QueryBuilderEnvironment(settings),
-                    qbq=qb.QueryQueueBuilder(settings),
-                    qbs=qb.QuerySchedulerBuilder(settings),
-                )
+                yield queries.Queries(AsyncpgDriver(connection), settings=settings)
             return
         with contextlib.suppress(ImportError):
             from pgqueuer.adapters.connections import connect_psycopg
             from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
             async with connect_psycopg(dsn=config.pg_dsn or None) as connection:
-                yield queries.Queries(
-                    PsycopgDriver(connection),
-                    qbe=qb.QueryBuilderEnvironment(settings),
-                    qbq=qb.QueryQueueBuilder(settings),
-                    qbs=qb.QuerySchedulerBuilder(settings),
-                )
+                yield queries.Queries(PsycopgDriver(connection), settings=settings)
             return
         raise RuntimeError("Neither asyncpg nor psycopg could be imported.")
 
     return factory
+
+
+def settings_from_ctx(ctx: Context) -> qb.DBSettings:
+    """Build DBSettings after AppConfig has applied CLI/env overrides."""
+    del ctx
+    return qb.DBSettings()
 
 
 @contextlib.asynccontextmanager
@@ -313,15 +309,15 @@ def verify(
     ),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             expect_present = expect == VerifyMode.PRESENT
             divergence = list[str]()
 
             required_tables = [
-                q.qbe.settings.queue_table,
-                q.qbe.settings.statistics_table,
-                q.qbe.settings.schedules_table,
-                q.qbe.settings.queue_table_log,
+                q.settings.queue_table,
+                q.settings.statistics_table,
+                q.settings.schedules_table,
+                q.settings.queue_table_log,
             ]
 
             for table in required_tables:
@@ -330,15 +326,15 @@ def verify(
                     state = "missing" if expect_present else "unexpected"
                     divergence.append(f"{state} table '{table}'")
 
-            func_exists = await q.has_function(q.qbe.settings.function)
+            func_exists = await q.has_function(q.settings.function)
             if expect_present != func_exists:
                 state = "missing" if expect_present else "unexpected"
-                divergence.append(f"{state} function '{q.qbe.settings.function}'")
+                divergence.append(f"{state} function '{q.settings.function}'")
 
-            trig_exists = await q.has_trigger(q.qbe.settings.trigger)
+            trig_exists = await q.has_trigger(q.settings.trigger)
             if expect_present != trig_exists:
                 state = "missing" if expect_present else "unexpected"
-                divergence.append(f"{state} trigger '{q.qbe.settings.trigger}'")
+                divergence.append(f"{state} trigger '{q.settings.trigger}'")
 
             if divergence:
                 print("\n".join(divergence))
@@ -364,11 +360,11 @@ def uninstall(
     ),
 ) -> None:
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall())
+        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall(settings_from_ctx(ctx)))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             await q.uninstall()
 
     asyncio_run(run())
@@ -417,7 +413,7 @@ def dashboard(
     interval_td = timedelta(seconds=interval) if interval is not None else None
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             await fetch_and_display(q, interval_td, limit)
 
     asyncio_run(run())
@@ -456,14 +452,15 @@ def web(
 @app.command(help="Listen to a PostgreSQL NOTIFY channel for debug purposes.")
 def listen(
     ctx: Context,
-    channel: str = typer.Option(
-        qb.DBSettings().channel,
+    channel: str | None = typer.Option(
+        None,
         "--channel",
     ),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
-            await display_pg_channel(q.driver, models.Channel(channel))
+        settings = settings_from_ctx(ctx)
+        async with yield_queries(ctx, settings) as q:
+            await display_pg_channel(q.driver, models.Channel(channel or settings.channel))
 
     asyncio_run(run())
 
@@ -563,7 +560,7 @@ def schedules(
     ),
 ) -> None:
     async def run_async() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             if remove:
                 schedule_ids = {models.ScheduleId(int(x)) for x in remove if x.isdigit()}
                 schedule_names = {types.CronEntrypoint(x) for x in remove if not x.isdigit()}
@@ -598,7 +595,7 @@ def queue(
     async def run_async() -> None:
         # For a single job, skip mode subsumes raise mode: a None result is
         # exactly the duplicate case, so on_conflict only decides the exit.
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             (job_id,) = await q.enqueue(
                 entrypoint,
                 None if payload is None else payload.encode(),
@@ -627,7 +624,7 @@ def failed(
     limit: int = typer.Option(25, "-n", "--limit", help="Maximum number of jobs to display."),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             jobs = await q.list_failed_jobs(limit=limit)
             if not jobs:
                 print("No failed jobs.")
@@ -659,7 +656,7 @@ def requeue(
     ids: list[int] = typer.Argument(..., help="Job IDs to re-queue."),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             typed_ids = [types.JobId(i) for i in ids]
             await q.requeue_jobs(typed_ids)
             print(f"Re-queued {len(typed_ids)} job(s).")
@@ -705,11 +702,11 @@ def optimize_autovacuum(
 ) -> None:
     """Apply or revert recommended autovacuum settings."""
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(rollback))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(settings_from_ctx(ctx), rollback))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx, settings_from_ctx(ctx)) as q:
             await (q.optimize_autovacuum_rollback() if rollback else q.optimize_autovacuum())
 
     asyncio_run(run())

--- a/pgqueuer/adapters/cli/sql_cmd.py
+++ b/pgqueuer/adapters/cli/sql_cmd.py
@@ -61,8 +61,9 @@ def render_install(settings: qb.DBSettings, create_schema: bool) -> str:
     return inspect.cleandoc(qbe.build_install_query(create_schema=create_schema)).strip()
 
 
-def render_uninstall() -> str:
-    return inspect.cleandoc(qb.QueryBuilderEnvironment().build_uninstall_query()).strip()
+def render_uninstall(settings: qb.DBSettings | None = None) -> str:
+    qbe = qb.QueryBuilderEnvironment(settings or qb.DBSettings())
+    return inspect.cleandoc(qbe.build_uninstall_query()).strip()
 
 
 def render_upgrade(settings: qb.DBSettings) -> str:
@@ -79,8 +80,8 @@ def render_durability(settings: qb.DBSettings) -> str:
     )
 
 
-def render_autovac(rollback: bool) -> str:
-    qbe = qb.QueryBuilderEnvironment()
+def render_autovac(settings: qb.DBSettings, rollback: bool) -> str:
+    qbe = qb.QueryBuilderEnvironment(settings)
     query = (
         qbe.build_optimize_autovacuum_rollback_query()
         if rollback
@@ -99,7 +100,7 @@ def install(
 
 @sql_app.command(help="SQL to drop all PgQueuer objects.")
 def uninstall() -> None:
-    typer.echo(render_uninstall())
+    typer.echo(render_uninstall(qb.DBSettings()))
 
 
 @sql_app.command(help="SQL to migrate an existing installation to the current version.")
@@ -121,4 +122,4 @@ def durability(
 def autovac(
     rollback: bool = typer.Option(False, help="Reset to defaults instead."),
 ) -> None:
-    typer.echo(render_autovac(rollback))
+    typer.echo(render_autovac(qb.DBSettings(), rollback))

--- a/pgqueuer/adapters/cli/sql_cmd.py
+++ b/pgqueuer/adapters/cli/sql_cmd.py
@@ -61,8 +61,8 @@ def render_install(settings: qb.DBSettings, create_schema: bool) -> str:
     return inspect.cleandoc(qbe.build_install_query(create_schema=create_schema)).strip()
 
 
-def render_uninstall(settings: qb.DBSettings | None = None) -> str:
-    qbe = qb.QueryBuilderEnvironment(settings or qb.DBSettings())
+def render_uninstall(settings: qb.DBSettings) -> str:
+    qbe = qb.QueryBuilderEnvironment(settings)
     return inspect.cleandoc(qbe.build_uninstall_query()).strip()
 
 

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -38,60 +38,44 @@ def percentile_cont(values: list[float], fraction: float) -> float:
     return ordered[lower] + (ordered[upper] - ordered[lower]) * (rank - lower)
 
 
-@dataclasses.dataclass(init=False)
+@dataclasses.dataclass
 class InMemoryQueries:
     """Drop-in replacement for ``Queries`` backed by pure Python dicts."""
 
     driver: InMemoryDriver
-    settings: DBSettings
-    qbe: qb.QueryBuilderEnvironment
-    qbq: qb.QueryQueueBuilder
-    qbs: qb.QuerySchedulerBuilder
-    tracer: TracingProtocol | None
-    _jobs: dict[int, dict[str, Any]]
-    _log: list[dict[str, Any]]
-    _statistics: list[dict[str, Any]]
-    _schedules: dict[int, dict[str, Any]]
-    _dedupe_index: dict[str, int]
-    _dedupe_key_by_job: dict[int, str]
-    _ready_heaps: dict[str, list[tuple[int, int]]]
-    _deferred_heap: list[tuple[datetime, int, str]]
-    _picked_ids: set[int]
-    _next_job_id: int
-    _next_log_id: int
-    _next_schedule_id: int
-    _next_stats_id: int
+    settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+    tracer: TracingProtocol | None = None
+    qbe: qb.QueryBuilderEnvironment = dataclasses.field(init=False)
+    qbq: qb.QueryQueueBuilder = dataclasses.field(init=False)
+    qbs: qb.QuerySchedulerBuilder = dataclasses.field(init=False)
 
-    def __init__(
-        self,
-        driver: InMemoryDriver,
-        settings: DBSettings | None = None,
-        tracer: TracingProtocol | None = None,
-    ) -> None:
-        settings = settings if settings is not None else DBSettings()
-        self.driver = driver
-        self.settings = settings
-        self.qbe = qb.QueryBuilderEnvironment(settings)
-        self.qbq = qb.QueryQueueBuilder(settings)
-        self.qbs = qb.QuerySchedulerBuilder(settings)
-        self.tracer = tracer
-        self._jobs = {}
-        self._log = []
-        self._statistics = []
-        self._schedules = {}
-        self._dedupe_index = {}
-        self._dedupe_key_by_job = {}
-        self._ready_heaps = {}
-        self._deferred_heap = []
-        self._picked_ids = set()
-        self._next_job_id = 1
-        self._next_log_id = 1
-        self._next_schedule_id = 1
-        self._next_stats_id = 1
+    _jobs: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
+    _log: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
+    _statistics: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
+    _schedules: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
+    _dedupe_index: dict[str, int] = dataclasses.field(default_factory=dict, init=False)
+    _dedupe_key_by_job: dict[int, str] = dataclasses.field(default_factory=dict, init=False)
 
     # Dequeue indexes. Heap entries are never removed eagerly; validity is
     # re-checked against ``_jobs`` on pop, so entries for jobs that were
     # cancelled, cleared, or re-queued are skipped as tombstones.
+    _ready_heaps: dict[str, list[tuple[int, int]]] = dataclasses.field(
+        default_factory=dict, init=False
+    )
+    _deferred_heap: list[tuple[datetime, int, str]] = dataclasses.field(
+        default_factory=list, init=False
+    )
+    _picked_ids: set[int] = dataclasses.field(default_factory=set, init=False)
+
+    _next_job_id: int = dataclasses.field(default=1, init=False)
+    _next_log_id: int = dataclasses.field(default=1, init=False)
+    _next_schedule_id: int = dataclasses.field(default=1, init=False)
+    _next_stats_id: int = dataclasses.field(default=1, init=False)
+
+    def __post_init__(self) -> None:
+        self.qbe = qb.QueryBuilderEnvironment(self.settings)
+        self.qbq = qb.QueryQueueBuilder(self.settings)
+        self.qbs = qb.QuerySchedulerBuilder(self.settings)
 
     async def install(self) -> None:
         pass

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -20,6 +20,7 @@ from pgqueuer.adapters.persistence import qb, query_helpers
 from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
 from pgqueuer.domain import errors, models
 from pgqueuer.domain.models import utc_now
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import CronEntrypoint, JobId, OnConflict, ScheduleId, SortOrder
 from pgqueuer.ports import tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
@@ -37,46 +38,61 @@ def percentile_cont(values: list[float], fraction: float) -> float:
     return ordered[lower] + (ordered[upper] - ordered[lower]) * (rank - lower)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(init=False)
 class InMemoryQueries:
     """Drop-in replacement for ``Queries`` backed by pure Python dicts."""
 
     driver: InMemoryDriver
+    settings: DBSettings
+    qbe: qb.QueryBuilderEnvironment
+    qbq: qb.QueryQueueBuilder
+    qbs: qb.QuerySchedulerBuilder
+    tracer: TracingProtocol | None
+    _jobs: dict[int, dict[str, Any]]
+    _log: list[dict[str, Any]]
+    _statistics: list[dict[str, Any]]
+    _schedules: dict[int, dict[str, Any]]
+    _dedupe_index: dict[str, int]
+    _dedupe_key_by_job: dict[int, str]
+    _ready_heaps: dict[str, list[tuple[int, int]]]
+    _deferred_heap: list[tuple[datetime, int, str]]
+    _picked_ids: set[int]
+    _next_job_id: int
+    _next_log_id: int
+    _next_schedule_id: int
+    _next_stats_id: int
 
-    qbe: qb.QueryBuilderEnvironment = dataclasses.field(
-        default_factory=qb.QueryBuilderEnvironment,
-    )
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-    qbs: qb.QuerySchedulerBuilder = dataclasses.field(
-        default_factory=qb.QuerySchedulerBuilder,
-    )
-
-    tracer: TracingProtocol | None = None
-
-    _jobs: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
-    _log: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
-    _statistics: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
-    _schedules: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
-    _dedupe_index: dict[str, int] = dataclasses.field(default_factory=dict, init=False)
-    _dedupe_key_by_job: dict[int, str] = dataclasses.field(default_factory=dict, init=False)
+    def __init__(
+        self,
+        driver: InMemoryDriver,
+        settings: DBSettings | None = None,
+        qbe: qb.QueryBuilderEnvironment | None = None,
+        qbq: qb.QueryQueueBuilder | None = None,
+        qbs: qb.QuerySchedulerBuilder | None = None,
+        tracer: TracingProtocol | None = None,
+    ) -> None:
+        self.driver = driver
+        self.tracer = tracer
+        canonical = qb.resolve_canonical_settings(settings or DBSettings(), qbe, qbq, qbs)
+        self.settings = canonical
+        self.qbe, self.qbq, self.qbs = qb.wire_query_builders(canonical)
+        self._jobs = {}
+        self._log = []
+        self._statistics = []
+        self._schedules = {}
+        self._dedupe_index = {}
+        self._dedupe_key_by_job = {}
+        self._ready_heaps = {}
+        self._deferred_heap = []
+        self._picked_ids = set()
+        self._next_job_id = 1
+        self._next_log_id = 1
+        self._next_schedule_id = 1
+        self._next_stats_id = 1
 
     # Dequeue indexes. Heap entries are never removed eagerly; validity is
     # re-checked against ``_jobs`` on pop, so entries for jobs that were
     # cancelled, cleared, or re-queued are skipped as tombstones.
-    _ready_heaps: dict[str, list[tuple[int, int]]] = dataclasses.field(
-        default_factory=dict, init=False
-    )
-    _deferred_heap: list[tuple[datetime, int, str]] = dataclasses.field(
-        default_factory=list, init=False
-    )
-    _picked_ids: set[int] = dataclasses.field(default_factory=set, init=False)
-
-    _next_job_id: int = dataclasses.field(default=1, init=False)
-    _next_log_id: int = dataclasses.field(default=1, init=False)
-    _next_schedule_id: int = dataclasses.field(default=1, init=False)
-    _next_stats_id: int = dataclasses.field(default=1, init=False)
 
     async def install(self) -> None:
         pass

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -700,21 +700,21 @@ class InMemoryQueries:
 
     async def notify_job_cancellation(self, ids: list[JobId]) -> None:
         event = models.CancellationEvent(
-            channel=self.qbq.settings.channel,
+            channel=self.settings.channel,
             ids=ids,
             sent_at=utc_now(),
             type="cancellation_event",
         )
-        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.settings.channel, event.model_dump_json())
 
     async def notify_health_check(self, health_check_event_id: uuid.UUID) -> None:
         event = models.HealthCheckEvent(
-            channel=self.qbq.settings.channel,
+            channel=self.settings.channel,
             sent_at=utc_now(),
             type="health_check_event",
             id=health_check_event_id,
         )
-        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.settings.channel, event.model_dump_json())
 
     async def insert_schedule(
         self,
@@ -1011,7 +1011,7 @@ class InMemoryQueries:
         return sum(1 for e in self._log if not e["aggregated"])
 
     async def schema_info(self) -> list[models.TableInfo]:
-        s = self.qbq.settings
+        s = self.settings
         tables = [
             (s.queue_table, len(self._jobs)),
             (s.queue_table_log, len(self._log)),
@@ -1035,10 +1035,10 @@ class InMemoryQueries:
 
     async def emit_table_changed(self, operation: models.OPERATIONS) -> None:
         event = models.TableChangedEvent(
-            channel=self.qbq.settings.channel,
+            channel=self.settings.channel,
             sent_at=utc_now(),
             type="table_changed_event",
             operation=operation,
-            table=self.qbe.settings.queue_table,
+            table=self.settings.queue_table,
         )
-        await self.driver.notify(self.qbq.settings.channel, event.model_dump_json())
+        await self.driver.notify(self.settings.channel, event.model_dump_json())

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -66,16 +66,15 @@ class InMemoryQueries:
         self,
         driver: InMemoryDriver,
         settings: DBSettings | None = None,
-        qbe: qb.QueryBuilderEnvironment | None = None,
-        qbq: qb.QueryQueueBuilder | None = None,
-        qbs: qb.QuerySchedulerBuilder | None = None,
         tracer: TracingProtocol | None = None,
     ) -> None:
+        settings = settings if settings is not None else DBSettings()
         self.driver = driver
+        self.settings = settings
+        self.qbe = qb.QueryBuilderEnvironment(settings)
+        self.qbq = qb.QueryQueueBuilder(settings)
+        self.qbs = qb.QuerySchedulerBuilder(settings)
         self.tracer = tracer
-        canonical = qb.resolve_canonical_settings(settings or DBSettings(), qbe, qbq, qbs)
-        self.settings = canonical
-        self.qbe, self.qbq, self.qbs = qb.wire_query_builders(canonical)
         self._jobs = {}
         self._log = []
         self._statistics = []

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -459,7 +459,7 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
 
 def create_mcp_server(
     dsn: str | None = None,
-    settings: DBSettings = DBSettings(),
+    settings: DBSettings | None = None,
     connection_settings: ConnectionSettings | None = None,
 ) -> FastMCP:
     """Factory that builds a fully-configured PgQueuer MCP server.
@@ -475,11 +475,12 @@ def create_mcp_server(
              PGQUEUER_POOL_MAX_SIZE, PGQUEUER_CONNECT_TIMEOUT,
              PGQUEUER_APPLICATION_NAME).
     """
+    resolved_settings = settings or DBSettings()
 
     @asynccontextmanager
     async def app_lifespan(server: FastMCP) -> AsyncIterator[PgQueuerDatabase]:
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
-            yield PgQueuerDatabase(pool, settings)
+            yield PgQueuerDatabase(pool, resolved_settings)
 
     mcp = FastMCP("pgqueuer", lifespan=app_lifespan)
 

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -475,7 +475,7 @@ def create_mcp_server(
              PGQUEUER_POOL_MAX_SIZE, PGQUEUER_CONNECT_TIMEOUT,
              PGQUEUER_APPLICATION_NAME).
     """
-    resolved_settings = settings if settings is not None else DBSettings()
+    resolved_settings = settings or DBSettings()
 
     @asynccontextmanager
     async def app_lifespan(server: FastMCP) -> AsyncIterator[PgQueuerDatabase]:

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -475,7 +475,7 @@ def create_mcp_server(
              PGQUEUER_POOL_MAX_SIZE, PGQUEUER_CONNECT_TIMEOUT,
              PGQUEUER_APPLICATION_NAME).
     """
-    resolved_settings = settings or DBSettings()
+    resolved_settings = settings if settings is not None else DBSettings()
 
     @asynccontextmanager
     async def app_lifespan(server: FastMCP) -> AsyncIterator[PgQueuerDatabase]:

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -22,6 +22,8 @@ __all__ = [
     "QueryBuilderEnvironment",
     "QueryQueueBuilder",
     "QuerySchedulerBuilder",
+    "resolve_canonical_settings",
+    "wire_query_builders",
 ]
 
 
@@ -1081,3 +1083,30 @@ class QuerySchedulerBuilder:
 
     def build_truncate_schedule_query(self) -> str:
         return f"""TRUNCATE {self.qualified.schedules_table}"""
+
+
+def resolve_canonical_settings(
+    settings: DBSettings,
+    qbe: QueryBuilderEnvironment | None = None,
+    qbq: QueryQueueBuilder | None = None,
+    qbs: QuerySchedulerBuilder | None = None,
+) -> DBSettings:
+    """Return the single DBSettings instance implied by settings or legacy builder args."""
+    if qbe is not None:
+        return qbe.settings
+    if qbq is not None:
+        return qbq.settings
+    if qbs is not None:
+        return qbs.settings
+    return settings
+
+
+def wire_query_builders(
+    settings: DBSettings,
+) -> tuple[QueryBuilderEnvironment, QueryQueueBuilder, QuerySchedulerBuilder]:
+    """Bind every query builder to the same DBSettings instance."""
+    return (
+        QueryBuilderEnvironment(settings=settings),
+        QueryQueueBuilder(settings=settings),
+        QuerySchedulerBuilder(settings=settings),
+    )

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -22,8 +22,6 @@ __all__ = [
     "QueryBuilderEnvironment",
     "QueryQueueBuilder",
     "QuerySchedulerBuilder",
-    "resolve_canonical_settings",
-    "wire_query_builders",
 ]
 
 
@@ -31,7 +29,7 @@ __all__ = [
 class QueryBuilderEnvironment:
     """DDL/utility query builder bound to a :class:`DBSettings`."""
 
-    settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+    settings: DBSettings
 
     @property
     def qualified(self) -> QualifiedNames:
@@ -459,7 +457,7 @@ ALTER TABLE {self.qualified.statistics_table} RESET (
 
 @dataclasses.dataclass
 class QueryQueueBuilder:
-    settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+    settings: DBSettings
 
     @property
     def qualified(self) -> QualifiedNames:
@@ -1021,7 +1019,7 @@ SELECT * FROM claimed ORDER BY priority DESC, id ASC;
 
 @dataclasses.dataclass
 class QuerySchedulerBuilder:
-    settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+    settings: DBSettings
 
     @property
     def qualified(self) -> QualifiedNames:
@@ -1083,30 +1081,3 @@ class QuerySchedulerBuilder:
 
     def build_truncate_schedule_query(self) -> str:
         return f"""TRUNCATE {self.qualified.schedules_table}"""
-
-
-def resolve_canonical_settings(
-    settings: DBSettings,
-    qbe: QueryBuilderEnvironment | None = None,
-    qbq: QueryQueueBuilder | None = None,
-    qbs: QuerySchedulerBuilder | None = None,
-) -> DBSettings:
-    """Return the single DBSettings instance implied by settings or legacy builder args."""
-    if qbe is not None:
-        return qbe.settings
-    if qbq is not None:
-        return qbq.settings
-    if qbs is not None:
-        return qbs.settings
-    return settings
-
-
-def wire_query_builders(
-    settings: DBSettings,
-) -> tuple[QueryBuilderEnvironment, QueryQueueBuilder, QuerySchedulerBuilder]:
-    """Bind every query builder to the same DBSettings instance."""
-    return (
-        QueryBuilderEnvironment(settings=settings),
-        QueryQueueBuilder(settings=settings),
-        QuerySchedulerBuilder(settings=settings),
-    )

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -17,6 +17,7 @@ from typing_extensions import assert_never
 from pgqueuer.adapters.persistence import qb, query_helpers
 from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
 from pgqueuer.domain import errors, models, types
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import CronEntrypoint
 from pgqueuer.ports import tracing
 from pgqueuer.ports.driver import Driver, SyncDriver
@@ -41,44 +42,69 @@ def is_unique_violation(exc: Exception) -> bool:
     return False
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(init=False)
 class Queries:
     """High-level job-queue operations: schema install/upgrade, enqueue/dequeue, log, stats."""
 
     driver: Driver
+    settings: DBSettings
+    qbe: qb.QueryBuilderEnvironment
+    qbq: qb.QueryQueueBuilder
+    qbs: qb.QuerySchedulerBuilder
+    tracer: TracingProtocol | None
 
-    qbe: qb.QueryBuilderEnvironment = dataclasses.field(
-        default_factory=qb.QueryBuilderEnvironment,
-    )
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-    qbs: qb.QuerySchedulerBuilder = dataclasses.field(
-        default_factory=qb.QuerySchedulerBuilder,
-    )
-
-    # Optional injected tracer; falls back to the global ``tracing.TRACER.tracer``.
-    tracer: TracingProtocol | None = None
+    def __init__(
+        self,
+        driver: Driver,
+        settings: DBSettings | None = None,
+        qbe: qb.QueryBuilderEnvironment | None = None,
+        qbq: qb.QueryQueueBuilder | None = None,
+        qbs: qb.QuerySchedulerBuilder | None = None,
+        tracer: TracingProtocol | None = None,
+    ) -> None:
+        self.driver = driver
+        self.tracer = tracer
+        canonical = qb.resolve_canonical_settings(settings or DBSettings(), qbe, qbq, qbs)
+        self.settings = canonical
+        self.qbe, self.qbq, self.qbs = qb.wire_query_builders(canonical)
 
     @classmethod
-    def from_asyncpg_connection(cls, connection: "asyncpg.Connection") -> "Queries":
+    def from_asyncpg_connection(
+        cls,
+        connection: "asyncpg.Connection",
+        settings: DBSettings | None = None,
+    ) -> "Queries":
         """Build Queries over an asyncpg connection."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
+        if settings is not None:
+            return cls(AsyncpgDriver(connection), settings=settings)
         return cls(AsyncpgDriver(connection))
 
     @classmethod
-    def from_asyncpg_pool(cls, pool: "asyncpg.Pool") -> "Queries":
+    def from_asyncpg_pool(
+        cls,
+        pool: "asyncpg.Pool",
+        settings: DBSettings | None = None,
+    ) -> "Queries":
         """Build Queries over an asyncpg pool."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
+        if settings is not None:
+            return cls(AsyncpgPoolDriver(pool), settings=settings)
         return cls(AsyncpgPoolDriver(pool))
 
     @classmethod
-    def from_psycopg_connection(cls, connection: "psycopg.AsyncConnection") -> "Queries":
+    def from_psycopg_connection(
+        cls,
+        connection: "psycopg.AsyncConnection",
+        settings: DBSettings | None = None,
+    ) -> "Queries":
         """Build Queries over a psycopg async connection (must have autocommit=True)."""
         from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
+        if settings is not None:
+            return cls(PsycopgDriver(connection), settings=settings)
         return cls(PsycopgDriver(connection))
 
     async def install(self, create_schema: bool = True) -> None:
@@ -681,18 +707,27 @@ class Queries:
         ]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(init=False)
 class SyncQueries:
     """Synchronous subset of :class:`Queries` (currently enqueue + queue_size)."""
 
     driver: SyncDriver
+    settings: DBSettings
+    qbq: qb.QueryQueueBuilder
+    tracer: TracingProtocol | None
 
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-
-    # Optional injected tracer; falls back to the global ``tracing.TRACER.tracer``.
-    tracer: TracingProtocol | None = None
+    def __init__(
+        self,
+        driver: SyncDriver,
+        settings: DBSettings | None = None,
+        qbq: qb.QueryQueueBuilder | None = None,
+        tracer: TracingProtocol | None = None,
+    ) -> None:
+        self.driver = driver
+        self.tracer = tracer
+        canonical = qbq.settings if qbq is not None else (settings or DBSettings())
+        self.settings = canonical
+        self.qbq = qb.QueryQueueBuilder(settings=canonical)
 
     @overload
     def enqueue(

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -67,9 +67,7 @@ class Queries:
         """Build Queries over an asyncpg connection."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
-        if settings is None:
-            return cls(AsyncpgDriver(connection))
-        return cls(AsyncpgDriver(connection), settings=settings)
+        return cls(AsyncpgDriver(connection), settings=settings or DBSettings())
 
     @classmethod
     def from_asyncpg_pool(
@@ -80,9 +78,7 @@ class Queries:
         """Build Queries over an asyncpg pool."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        if settings is None:
-            return cls(AsyncpgPoolDriver(pool))
-        return cls(AsyncpgPoolDriver(pool), settings=settings)
+        return cls(AsyncpgPoolDriver(pool), settings=settings or DBSettings())
 
     @classmethod
     def from_psycopg_connection(
@@ -93,9 +89,7 @@ class Queries:
         """Build Queries over a psycopg async connection (must have autocommit=True)."""
         from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
-        if settings is None:
-            return cls(PsycopgDriver(connection))
-        return cls(PsycopgDriver(connection), settings=settings)
+        return cls(PsycopgDriver(connection), settings=settings or DBSettings())
 
     async def install(self, create_schema: bool = True) -> None:
         """Create the schema (when configured), tables, types, indexes, triggers, and functions."""
@@ -464,9 +458,9 @@ class Queries:
     async def notify_job_cancellation(self, ids: list[models.JobId]) -> None:
         """Emit a ``cancellation_event`` NOTIFY carrying *ids*."""
         await self.driver.notify(
-            self.qbq.settings.channel,
+            self.settings.channel,
             models.CancellationEvent(
-                channel=self.qbq.settings.channel,
+                channel=self.settings.channel,
                 ids=ids,
                 sent_at=models.utc_now(),
                 type="cancellation_event",
@@ -476,9 +470,9 @@ class Queries:
     async def notify_health_check(self, health_check_event_id: uuid.UUID) -> None:
         """Emit a ``health_check_event`` NOTIFY tagged with ``health_check_event_id``."""
         await self.driver.notify(
-            self.qbq.settings.channel,
+            self.settings.channel,
             models.HealthCheckEvent(
-                channel=self.qbq.settings.channel,
+                channel=self.settings.channel,
                 sent_at=models.utc_now(),
                 type="health_check_event",
                 id=health_check_event_id,

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -42,30 +42,21 @@ def is_unique_violation(exc: Exception) -> bool:
     return False
 
 
-@dataclasses.dataclass(init=False)
+@dataclasses.dataclass
 class Queries:
     """High-level job-queue operations: schema install/upgrade, enqueue/dequeue, log, stats."""
 
     driver: Driver
-    settings: DBSettings
-    qbe: qb.QueryBuilderEnvironment
-    qbq: qb.QueryQueueBuilder
-    qbs: qb.QuerySchedulerBuilder
-    tracer: TracingProtocol | None
+    settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+    tracer: TracingProtocol | None = None
+    qbe: qb.QueryBuilderEnvironment = dataclasses.field(init=False)
+    qbq: qb.QueryQueueBuilder = dataclasses.field(init=False)
+    qbs: qb.QuerySchedulerBuilder = dataclasses.field(init=False)
 
-    def __init__(
-        self,
-        driver: Driver,
-        settings: DBSettings | None = None,
-        tracer: TracingProtocol | None = None,
-    ) -> None:
-        settings = settings if settings is not None else DBSettings()
-        self.driver = driver
-        self.settings = settings
-        self.qbe = qb.QueryBuilderEnvironment(settings)
-        self.qbq = qb.QueryQueueBuilder(settings)
-        self.qbs = qb.QuerySchedulerBuilder(settings)
-        self.tracer = tracer
+    def __post_init__(self) -> None:
+        self.qbe = qb.QueryBuilderEnvironment(self.settings)
+        self.qbq = qb.QueryQueueBuilder(self.settings)
+        self.qbs = qb.QuerySchedulerBuilder(self.settings)
 
     @classmethod
     def from_asyncpg_connection(
@@ -76,8 +67,9 @@ class Queries:
         """Build Queries over an asyncpg connection."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
-        settings = settings if settings is not None else DBSettings()
-        return cls(AsyncpgDriver(connection), settings)
+        if settings is None:
+            return cls(AsyncpgDriver(connection))
+        return cls(AsyncpgDriver(connection), settings=settings)
 
     @classmethod
     def from_asyncpg_pool(
@@ -88,8 +80,9 @@ class Queries:
         """Build Queries over an asyncpg pool."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        settings = settings if settings is not None else DBSettings()
-        return cls(AsyncpgPoolDriver(pool), settings)
+        if settings is None:
+            return cls(AsyncpgPoolDriver(pool))
+        return cls(AsyncpgPoolDriver(pool), settings=settings)
 
     @classmethod
     def from_psycopg_connection(
@@ -100,8 +93,9 @@ class Queries:
         """Build Queries over a psycopg async connection (must have autocommit=True)."""
         from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
-        settings = settings if settings is not None else DBSettings()
-        return cls(PsycopgDriver(connection), settings)
+        if settings is None:
+            return cls(PsycopgDriver(connection))
+        return cls(PsycopgDriver(connection), settings=settings)
 
     async def install(self, create_schema: bool = True) -> None:
         """Create the schema (when configured), tables, types, indexes, triggers, and functions."""
@@ -703,26 +697,17 @@ class Queries:
         ]
 
 
-@dataclasses.dataclass(init=False)
+@dataclasses.dataclass
 class SyncQueries:
     """Synchronous subset of :class:`Queries` (currently enqueue + queue_size)."""
 
     driver: SyncDriver
-    settings: DBSettings
-    qbq: qb.QueryQueueBuilder
-    tracer: TracingProtocol | None
+    settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+    tracer: TracingProtocol | None = None
+    qbq: qb.QueryQueueBuilder = dataclasses.field(init=False)
 
-    def __init__(
-        self,
-        driver: SyncDriver,
-        settings: DBSettings | None = None,
-        tracer: TracingProtocol | None = None,
-    ) -> None:
-        settings = settings if settings is not None else DBSettings()
-        self.driver = driver
-        self.settings = settings
-        self.qbq = qb.QueryQueueBuilder(settings)
-        self.tracer = tracer
+    def __post_init__(self) -> None:
+        self.qbq = qb.QueryQueueBuilder(self.settings)
 
     @overload
     def enqueue(

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -57,16 +57,15 @@ class Queries:
         self,
         driver: Driver,
         settings: DBSettings | None = None,
-        qbe: qb.QueryBuilderEnvironment | None = None,
-        qbq: qb.QueryQueueBuilder | None = None,
-        qbs: qb.QuerySchedulerBuilder | None = None,
         tracer: TracingProtocol | None = None,
     ) -> None:
+        settings = settings if settings is not None else DBSettings()
         self.driver = driver
+        self.settings = settings
+        self.qbe = qb.QueryBuilderEnvironment(settings)
+        self.qbq = qb.QueryQueueBuilder(settings)
+        self.qbs = qb.QuerySchedulerBuilder(settings)
         self.tracer = tracer
-        canonical = qb.resolve_canonical_settings(settings or DBSettings(), qbe, qbq, qbs)
-        self.settings = canonical
-        self.qbe, self.qbq, self.qbs = qb.wire_query_builders(canonical)
 
     @classmethod
     def from_asyncpg_connection(
@@ -77,9 +76,8 @@ class Queries:
         """Build Queries over an asyncpg connection."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
-        if settings is not None:
-            return cls(AsyncpgDriver(connection), settings=settings)
-        return cls(AsyncpgDriver(connection))
+        settings = settings if settings is not None else DBSettings()
+        return cls(AsyncpgDriver(connection), settings)
 
     @classmethod
     def from_asyncpg_pool(
@@ -90,9 +88,8 @@ class Queries:
         """Build Queries over an asyncpg pool."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        if settings is not None:
-            return cls(AsyncpgPoolDriver(pool), settings=settings)
-        return cls(AsyncpgPoolDriver(pool))
+        settings = settings if settings is not None else DBSettings()
+        return cls(AsyncpgPoolDriver(pool), settings)
 
     @classmethod
     def from_psycopg_connection(
@@ -103,9 +100,8 @@ class Queries:
         """Build Queries over a psycopg async connection (must have autocommit=True)."""
         from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
-        if settings is not None:
-            return cls(PsycopgDriver(connection), settings=settings)
-        return cls(PsycopgDriver(connection))
+        settings = settings if settings is not None else DBSettings()
+        return cls(PsycopgDriver(connection), settings)
 
     async def install(self, create_schema: bool = True) -> None:
         """Create the schema (when configured), tables, types, indexes, triggers, and functions."""
@@ -720,14 +716,13 @@ class SyncQueries:
         self,
         driver: SyncDriver,
         settings: DBSettings | None = None,
-        qbq: qb.QueryQueueBuilder | None = None,
         tracer: TracingProtocol | None = None,
     ) -> None:
+        settings = settings if settings is not None else DBSettings()
         self.driver = driver
+        self.settings = settings
+        self.qbq = qb.QueryQueueBuilder(settings)
         self.tracer = tracer
-        canonical = qbq.settings if qbq is not None else (settings or DBSettings())
-        self.settings = canonical
-        self.qbq = qb.QueryQueueBuilder(settings=canonical)
 
     @overload
     def enqueue(

--- a/pgqueuer/adapters/web/app.py
+++ b/pgqueuer/adapters/web/app.py
@@ -43,7 +43,7 @@ def create_web_app(
         from pgqueuer.adapters.connections import create_asyncpg_pool
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        resolved_settings = settings if settings is not None else qb.DBSettings()
+        resolved_settings = settings or qb.DBSettings()
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
             driver = AsyncpgPoolDriver(pool)
             app.state.pgq_queries = queries.Queries(driver, settings=resolved_settings)

--- a/pgqueuer/adapters/web/app.py
+++ b/pgqueuer/adapters/web/app.py
@@ -21,6 +21,7 @@ from pgqueuer.domain.settings import ConnectionSettings
 def create_web_app(
     dsn: str | None = None,
     connection_settings: ConnectionSettings | None = None,
+    settings: qb.DBSettings | None = None,
 ) -> FastAPI:
     """Standalone dashboard app: asyncpg pool, NOTIFY-driven SSE, optional Basic auth.
 
@@ -42,16 +43,11 @@ def create_web_app(
         from pgqueuer.adapters.connections import create_asyncpg_pool
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        settings = qb.DBSettings()
+        resolved_settings = settings or qb.DBSettings()
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
             driver = AsyncpgPoolDriver(pool)
-            app.state.pgq_queries = queries.Queries(
-                driver,
-                qbe=qb.QueryBuilderEnvironment(settings),
-                qbq=qb.QueryQueueBuilder(settings),
-                qbs=qb.QuerySchedulerBuilder(settings),
-            )
-            broadcaster = Broadcaster(driver=driver, channel=settings.channel)
+            app.state.pgq_queries = queries.Queries(driver, settings=resolved_settings)
+            broadcaster = Broadcaster(driver=driver, channel=resolved_settings.channel)
             await broadcaster.start()
             app.state.pgq_broadcaster = broadcaster
             async with driver:

--- a/pgqueuer/adapters/web/app.py
+++ b/pgqueuer/adapters/web/app.py
@@ -43,7 +43,7 @@ def create_web_app(
         from pgqueuer.adapters.connections import create_asyncpg_pool
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        resolved_settings = settings or qb.DBSettings()
+        resolved_settings = settings if settings is not None else qb.DBSettings()
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
             driver = AsyncpgPoolDriver(pool)
             app.state.pgq_queries = queries.Queries(driver, settings=resolved_settings)

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -46,12 +46,12 @@ class PgQueuer:
 
     connection: Driver
     channel: Channel | None = None
-    settings: DBSettings | None = None
     # Shared resources mapping passed to QueueManager and propagated into each job Context.
     resources: MutableMapping = dataclasses.field(
         default_factory=dict,
     )
     queries: RepositoryPort | None = dataclasses.field(default=None)
+    settings: DBSettings | None = None
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
         default_factory=asyncio.Event,
@@ -65,11 +65,17 @@ class PgQueuer:
 
     def __post_init__(self) -> None:
         if self.queries is None:
-            self.queries = Queries(self.connection, settings=self.settings or DBSettings())
-        if self.channel is not None:
-            self.queries.settings.channel = self.channel
+            settings = self.settings if self.settings is not None else DBSettings()
+            self.queries = Queries(self.connection, settings)
         else:
-            self.channel = Channel(self.queries.settings.channel)
+            if self.settings is not None and self.settings is not self.queries.settings:
+                raise ValueError("settings must be the same object as queries.settings")
+            settings = self.queries.settings
+        self.settings = settings
+        if self.channel is not None:
+            settings.channel = self.channel
+        else:
+            self.channel = Channel(settings.channel)
         self.qm = QueueManager(
             self.queries,
             self.channel,
@@ -158,7 +164,7 @@ class PgQueuer:
         and short-lived batch-processing containers.
         """
         driver = InMemoryDriver()
-        resolved_settings = settings or DBSettings()
+        resolved_settings = settings if settings is not None else DBSettings()
         inmem = InMemoryQueries(driver=driver, settings=resolved_settings)
         return cls(
             connection=driver,

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -74,15 +74,8 @@ class PgQueuer:
             self.settings.channel = self.channel
         else:
             self.channel = Channel(self.settings.channel)
-        self.qm = QueueManager(
-            self.queries,
-            channel=self.channel,
-            resources=self.resources,
-        )
-        self.sm = SchedulerManager(
-            self.queries,
-            resources=self.resources,
-        )
+        self.qm = QueueManager(self.queries, resources=self.resources)
+        self.sm = SchedulerManager(self.queries, resources=self.resources)
         self.qm.shutdown = self.shutdown
         self.sm.shutdown = self.shutdown
 

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -45,9 +45,8 @@ class PgQueuer:
     """
 
     connection: Driver
-    channel: Channel = dataclasses.field(
-        default=Channel(DBSettings().channel),
-    )
+    channel: Channel | None = None
+    settings: DBSettings | None = None
     # Shared resources mapping passed to QueueManager and propagated into each job Context.
     resources: MutableMapping = dataclasses.field(
         default_factory=dict,
@@ -66,7 +65,11 @@ class PgQueuer:
 
     def __post_init__(self) -> None:
         if self.queries is None:
-            self.queries = Queries(self.connection)
+            self.queries = Queries(self.connection, settings=self.settings or DBSettings())
+        if self.channel is not None:
+            self.queries.settings.channel = self.channel
+        else:
+            self.channel = Channel(self.queries.settings.channel)
         self.qm = QueueManager(
             self.queries,
             self.channel,
@@ -85,12 +88,14 @@ class PgQueuer:
         connection: "asyncpg.Connection",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over an asyncpg connection."""
         return cls._from_driver(
             driver=AsyncpgDriver(connection),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -99,12 +104,14 @@ class PgQueuer:
         pool: "asyncpg.Pool",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over an asyncpg pool."""
         return cls._from_driver(
             driver=AsyncpgPoolDriver(pool),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -113,12 +120,14 @@ class PgQueuer:
         connection: "psycopg.AsyncConnection",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over a psycopg async connection (must have autocommit=True)."""
         return cls._from_driver(
             driver=PsycopgDriver(connection),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -127,16 +136,21 @@ class PgQueuer:
         driver: Driver,
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
-        channel = channel or Channel(DBSettings().channel)
-        resources = resources or {}
-        return cls(connection=driver, channel=channel, resources=resources)
+        return cls(
+            connection=driver,
+            channel=channel,
+            resources=resources or {},
+            settings=settings,
+        )
 
     @classmethod
     def in_memory(
         cls,
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Create a PgQueuer backed entirely by in-memory data structures.
 
@@ -144,13 +158,14 @@ class PgQueuer:
         and short-lived batch-processing containers.
         """
         driver = InMemoryDriver()
-        channel = channel or Channel(DBSettings().channel)
-        inmem = InMemoryQueries(driver=driver)
+        resolved_settings = settings or DBSettings()
+        inmem = InMemoryQueries(driver=driver, settings=resolved_settings)
         return cls(
             connection=driver,
             channel=channel,
             queries=inmem,
             resources=resources or {},
+            settings=resolved_settings,
         )
 
     async def run(

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -65,20 +65,18 @@ class PgQueuer:
 
     def __post_init__(self) -> None:
         if self.queries is None:
-            settings = self.settings if self.settings is not None else DBSettings()
-            self.queries = Queries(self.connection, settings)
-        else:
-            if self.settings is not None and self.settings is not self.queries.settings:
-                raise ValueError("settings must be the same object as queries.settings")
-            settings = self.queries.settings
-        self.settings = settings
+            self.queries = Queries(
+                self.connection,
+                settings=self.settings or DBSettings(),
+            )
+        self.settings = self.queries.settings
         if self.channel is not None:
-            settings.channel = self.channel
+            self.settings.channel = self.channel
         else:
-            self.channel = Channel(settings.channel)
+            self.channel = Channel(self.settings.channel)
         self.qm = QueueManager(
             self.queries,
-            self.channel,
+            channel=self.channel,
             resources=self.resources,
         )
         self.sm = SchedulerManager(
@@ -164,14 +162,14 @@ class PgQueuer:
         and short-lived batch-processing containers.
         """
         driver = InMemoryDriver()
-        resolved_settings = settings if settings is not None else DBSettings()
-        inmem = InMemoryQueries(driver=driver, settings=resolved_settings)
         return cls(
             connection=driver,
             channel=channel,
-            queries=inmem,
+            queries=InMemoryQueries(
+                driver=driver,
+                settings=settings or DBSettings(),
+            ),
             resources=resources or {},
-            settings=resolved_settings,
         )
 
     async def run(

--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -9,7 +9,6 @@ from itertools import chain
 
 from pgqueuer.core import tm
 from pgqueuer.domain import models
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports.driver import Driver
 from pgqueuer.ports.repository import QueueRepositoryPort
 
@@ -70,7 +69,7 @@ class CompletionWatcher:
 
     async def __aenter__(self) -> "CompletionWatcher":
         self.task_manager.add(asyncio.create_task(self._poll_for_change()))
-        await self.driver.add_listener(DBSettings().channel, self._is_relevant_event)
+        await self.driver.add_listener(self.queries.settings.channel, self._is_relevant_event)
         self._schedule_refresh_waiters()
         return self
 

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -27,7 +27,7 @@ from pgqueuer.ports import RepositoryPort, tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
-@dataclasses.dataclass(init=False)
+@dataclasses.dataclass
 class QueueManager:
     """Dequeue jobs and dispatch them to registered entrypoint executors.
 
@@ -37,7 +37,7 @@ class QueueManager:
     """
 
     queries: RepositoryPort
-    channel: models.Channel
+    channel: dataclasses.InitVar[models.Channel | None] = None
 
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
@@ -87,28 +87,9 @@ class QueueManager:
         default=timedelta(seconds=0.1),
     )
 
-    def __init__(
-        self,
-        queries: RepositoryPort,
-        channel: models.Channel | None = None,
-        resources: MutableMapping | None = None,
-        tracer: tracing.TracingProtocol | None = None,
-    ) -> None:
-        self.queries = queries
-        self.shutdown = asyncio.Event()
-        self.entrypoint_registry = {}
-        self.queue_manager_id = uuid.uuid4()
-        self.resources = resources or {}
-        self.tracer = tracer
-        self.job_context = {}
-        self.pending_health_check = {}
-        self.jobs_logged = 0
-        self.min_dequeue_poll_interval = timedelta(seconds=0.1)
+    def __post_init__(self, channel: models.Channel | None) -> None:
         if channel is not None:
-            queries.settings.channel = channel
-            self.channel = channel
-        else:
-            self.channel = models.Channel(queries.settings.channel)
+            self.queries.settings.channel = channel
 
     async def listener_healthy(
         self,
@@ -450,7 +431,7 @@ class QueueManager:
             notice_event_listener = listeners.PGNoticeEventListener()
             await listeners.initialize_notice_event_listener(
                 self.queries.driver,
-                self.channel,
+                self.queries.settings.channel,
                 listeners.default_event_router(
                     notice_event_queue=notice_event_listener,
                     canceled=self.job_context,

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -23,12 +23,11 @@ from pgqueuer.core import (
     tm,
 )
 from pgqueuer.domain import errors, models, types
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports import RepositoryPort, tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(init=False)
 class QueueManager:
     """Dequeue jobs and dispatch them to registered entrypoint executors.
 
@@ -38,9 +37,7 @@ class QueueManager:
     """
 
     queries: RepositoryPort
-    channel: models.Channel = dataclasses.field(
-        default=models.Channel(DBSettings().channel),
-    )
+    channel: models.Channel
 
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
@@ -89,6 +86,29 @@ class QueueManager:
         init=False,
         default=timedelta(seconds=0.1),
     )
+
+    def __init__(
+        self,
+        queries: RepositoryPort,
+        channel: models.Channel | None = None,
+        resources: MutableMapping | None = None,
+        tracer: tracing.TracingProtocol | None = None,
+    ) -> None:
+        self.queries = queries
+        self.shutdown = asyncio.Event()
+        self.entrypoint_registry = {}
+        self.queue_manager_id = uuid.uuid4()
+        self.resources = resources or {}
+        self.tracer = tracer
+        self.job_context = {}
+        self.pending_health_check = {}
+        self.jobs_logged = 0
+        self.min_dequeue_poll_interval = timedelta(seconds=0.1)
+        if channel is not None:
+            queries.settings.channel = channel
+            self.channel = channel
+        else:
+            self.channel = models.Channel(queries.settings.channel)
 
     async def listener_healthy(
         self,
@@ -257,8 +277,8 @@ class QueueManager:
         """Assert that required tables, columns, indexes, enums, and triggers exist."""
 
         for table in (
-            self.queries.qbe.settings.queue_table,
-            self.queries.qbe.settings.statistics_table,
+            self.queries.settings.queue_table,
+            self.queries.settings.statistics_table,
         ):
             if not (await self.queries.has_table(table)):
                 raise RuntimeError(
@@ -266,20 +286,20 @@ class QueueManager:
                     f"Please run 'pgq install' to set up the necessary tables."
                 )
 
-        if not (await self.queries.has_table(self.queries.qbe.settings.queue_table_log)):
+        if not (await self.queries.has_table(self.queries.settings.queue_table_log)):
             raise RuntimeError(
-                f"The {self.queries.qbe.settings.queue_table_log} table is missing "
+                f"The {self.queries.settings.queue_table_log} table is missing "
                 "please run 'pgq upgrade'"
             )
 
         for table, column in (
-            (self.queries.qbe.settings.queue_table, "updated"),
-            (self.queries.qbe.settings.queue_table, "heartbeat"),
-            (self.queries.qbe.settings.queue_table, "queue_manager_id"),
-            (self.queries.qbe.settings.queue_table, "execute_after"),
-            (self.queries.qbe.settings.queue_table, "headers"),
-            (self.queries.qbe.settings.queue_table, "attempts"),
-            (self.queries.qbe.settings.queue_table_log, "traceback"),
+            (self.queries.settings.queue_table, "updated"),
+            (self.queries.settings.queue_table, "heartbeat"),
+            (self.queries.settings.queue_table, "queue_manager_id"),
+            (self.queries.settings.queue_table, "execute_after"),
+            (self.queries.settings.queue_table, "headers"),
+            (self.queries.settings.queue_table, "attempts"),
+            (self.queries.settings.queue_table_log, "traceback"),
         ):
             if not (await self.queries.table_has_column(table, column)):
                 raise RuntimeError(
@@ -288,8 +308,8 @@ class QueueManager:
                 )
 
         for key, enum in (
-            ("canceled", self.queries.qbe.settings.queue_status_type),
-            ("failed", self.queries.qbe.settings.queue_status_type),
+            ("canceled", self.queries.settings.queue_status_type),
+            ("failed", self.queries.settings.queue_status_type),
         ):
             if not (await self.queries.has_user_defined_enum(key, enum)):
                 raise RuntimeError(
@@ -298,8 +318,8 @@ class QueueManager:
 
         for table, index in (
             (
-                self.queries.qbe.settings.queue_table_log,
-                f"{self.queries.qbe.settings.queue_table_log}_job_id_status",
+                self.queries.settings.queue_table_log,
+                f"{self.queries.settings.queue_table_log}_job_id_status",
             ),
         ):
             if not (await self.queries.table_has_index(table, index)):

--- a/pgqueuer/core/sm.py
+++ b/pgqueuer/core/sm.py
@@ -91,15 +91,15 @@ class SchedulerManager:
 
     async def run(self) -> None:
         """Poll for due schedules and dispatch them until shutdown."""
-        if not (await self.queries.has_table(self.queries.qbe.settings.schedules_table)):
+        if not (await self.queries.has_table(self.queries.settings.schedules_table)):
             raise RuntimeError(
-                f"The {self.queries.qbe.settings.schedules_table} table is missing "
+                f"The {self.queries.settings.schedules_table} table is missing "
                 "please run 'pgq upgrade'"
             )
 
-        if not (await self.queries.has_table(self.queries.qbe.settings.queue_table_log)):
+        if not (await self.queries.has_table(self.queries.settings.queue_table_log)):
             raise RuntimeError(
-                f"The {self.queries.qbe.settings.queue_table_log} table is missing "
+                f"The {self.queries.settings.queue_table_log} table is missing "
                 "please run 'pgq upgrade'"
             )
 

--- a/pgqueuer/domain/settings.py
+++ b/pgqueuer/domain/settings.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import dataclasses
-import functools
 import os
 import re
 import warnings
@@ -160,6 +159,7 @@ class DBSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="PGQUEUER_",
         extra="ignore",
+        validate_assignment=True,
     )
 
     # Prepended to every object name not explicitly overridden; lets multiple
@@ -264,10 +264,7 @@ class DBSettings(BaseSettings):
         """Schema-qualified reference for *name*; bare when no db_schema is set."""
         return f"{self.db_schema}.{name}" if self.db_schema else name
 
-    # cached_property: query builders access this on every SQL render (the
-    # dequeue loop rebuilds its query each iteration). Safe because names are
-    # fixed once validation and apply_prefix have run.
-    @functools.cached_property
+    @property
     def qualified(self) -> QualifiedNames:
         return QualifiedNames(
             queue_table=self.qualify(self.queue_table),

--- a/pgqueuer/ports/__init__.py
+++ b/pgqueuer/ports/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports.driver import Driver, SyncDriver
 from pgqueuer.ports.repository import (
     NotificationPort,
@@ -22,8 +21,6 @@ class RepositoryPort(
     Protocol,
 ):
     """Combined repository protocol for drop-in adapter implementations."""
-
-    settings: DBSettings
 
 
 __all__ = [

--- a/pgqueuer/ports/__init__.py
+++ b/pgqueuer/ports/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports.driver import Driver, SyncDriver
 from pgqueuer.ports.repository import (
     NotificationPort,
@@ -21,6 +22,8 @@ class RepositoryPort(
     Protocol,
 ):
     """Combined repository protocol for drop-in adapter implementations."""
+
+    settings: DBSettings
 
 
 __all__ = [

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -29,6 +29,8 @@ class EntrypointExecutionParameter:
 class QueueRepositoryPort(Protocol):
     """Persistence operations for the job queue."""
 
+    settings: DBSettings
+
     async def dequeue(
         self,
         batch_size: int,

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -26,12 +26,7 @@ WIDENED_ID_TABLES = [
 
 def queries_for(driver: db.Driver, settings: qb.DBSettings) -> Queries:
     """Queries wired to non-default DBSettings across all three builders."""
-    return Queries(
-        driver,
-        qbe=qb.QueryBuilderEnvironment(settings=settings),
-        qbq=qb.QueryQueueBuilder(settings=settings),
-        qbs=qb.QuerySchedulerBuilder(settings=settings),
-    )
+    return Queries(driver, settings=settings)
 
 
 async def id_data_type(driver: db.Driver, table: str, schema: str | None = None) -> str:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -25,7 +25,7 @@ WIDENED_ID_TABLES = [
 
 
 def queries_for(driver: db.Driver, settings: qb.DBSettings) -> Queries:
-    """Queries wired to non-default DBSettings across all three builders."""
+    """Queries bound to a non-default DBSettings instance."""
     return Queries(driver, settings=settings)
 
 

--- a/test/test_drivers.py
+++ b/test/test_drivers.py
@@ -9,6 +9,7 @@ import psycopg
 import pytest
 
 from pgqueuer.adapters.persistence.qb import (
+    DBSettings,
     QueryBuilderEnvironment,
     QueryQueueBuilder,
     QuerySchedulerBuilder,
@@ -129,15 +130,15 @@ async def test_notify(
     "query, name",
     (
         [
-            (getattr(QueryQueueBuilder(), name), name)
+            (getattr(QueryQueueBuilder(DBSettings()), name), name)
             for name in get_user_defined_functions(QueryQueueBuilder)
         ]
         + [
-            (getattr(QueryBuilderEnvironment(), name), name)
+            (getattr(QueryBuilderEnvironment(DBSettings()), name), name)
             for name in get_user_defined_functions(QueryBuilderEnvironment)
         ]
         + [
-            (getattr(QuerySchedulerBuilder(), name), name)
+            (getattr(QuerySchedulerBuilder(DBSettings()), name), name)
             for name in get_user_defined_functions(QuerySchedulerBuilder)
         ]
     ),

--- a/test/test_issue_536_minimal.py
+++ b/test/test_issue_536_minimal.py
@@ -17,7 +17,7 @@ def test_issue_536_heartbeat_in_query() -> None:
     This prevents the race condition where multiple scheduler instances
     execute the same scheduled task multiple times instead of once.
     """
-    builder = qb.QuerySchedulerBuilder()
+    builder = qb.QuerySchedulerBuilder(qb.DBSettings())
     query = builder.build_fetch_schedule_query()
 
     assert "heartbeat = NOW()" in query, (

--- a/test/test_qb_upgrade_migration.py
+++ b/test/test_qb_upgrade_migration.py
@@ -8,7 +8,6 @@ only proves what we wrote, not what Postgres does with it.
 from __future__ import annotations
 
 from pgqueuer import db, queries
-from pgqueuer.adapters.persistence import qb
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import Channel
 from test.helpers import id_data_type, queries_for, simulate_legacy_serial
@@ -70,7 +69,7 @@ async def test_widen_id_setting_controls_the_widen(apgdriver: db.Driver) -> None
     await simulate_legacy_serial(apgdriver, table)
 
     no_widen = DBSettings(widen_id=False)
-    q_no_widen = queries.Queries(apgdriver, qbe=qb.QueryBuilderEnvironment(settings=no_widen))
+    q_no_widen = queries.Queries(apgdriver, settings=no_widen)
     await q_no_widen.upgrade()
     assert await id_data_type(apgdriver, table) == "integer"
 

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -12,6 +12,7 @@ from pgqueuer import db
 from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core.cache import TTLCache
 from pgqueuer.core.tm import TaskManager
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.models import Job, Log
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
@@ -170,6 +171,8 @@ async def test_periodic_log_aggregation_loops_until_shutdown() -> None:
     qm: QueueManager
 
     class Stub:
+        settings = DBSettings()
+
         async def aggregate_logs(self) -> None:
             nonlocal calls
             calls += 1
@@ -204,6 +207,8 @@ async def test_periodic_log_aggregation_skips_when_idle() -> None:
     qm: QueueManager
 
     class Stub:
+        settings = DBSettings()
+
         async def aggregate_logs(self) -> None:
             nonlocal calls
             calls += 1
@@ -248,6 +253,8 @@ async def test_periodic_log_aggregation_survives_aggregate_errors() -> None:
     qm: QueueManager
 
     class Stub:
+        settings = DBSettings()
+
         async def aggregate_logs(self) -> None:
             nonlocal calls
             calls += 1

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -107,9 +107,11 @@ def test_qualified_names_without_schema_are_bare() -> None:
     assert settings.qualify("anything") == "anything"
 
 
-def test_qualified_is_cached() -> None:
+def test_qualified_reflects_assignment() -> None:
     settings = DBSettings(db_schema="billing")
-    assert settings.qualified is settings.qualified
+    assert settings.qualified.queue_table == "billing.pgqueuer"
+    settings.db_schema = None
+    assert settings.qualified.queue_table == "pgqueuer"
 
 
 def test_dotted_name_conflicts_with_db_schema() -> None:

--- a/test/test_settings_ownership.py
+++ b/test/test_settings_ownership.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from pgqueuer import db
+from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
+from pgqueuer.adapters.persistence import qb
+from pgqueuer.adapters.persistence.queries import Queries, SyncQueries
+from pgqueuer.applications import PgQueuer
+from pgqueuer.core.completion import CompletionWatcher
+from pgqueuer.core.qm import QueueManager
+from pgqueuer.domain.models import Channel
+from pgqueuer.domain.settings import DBSettings
+
+
+def test_queries_shares_one_settings_object() -> None:
+    settings = DBSettings(prefix="acme_")
+    q = Queries(InMemoryDriver(), settings=settings)
+
+    assert q.settings is settings
+    assert q.qbe.settings is settings
+    assert q.qbq.settings is settings
+    assert q.qbs.settings is settings
+
+
+def test_queries_legacy_builder_injection_uses_builder_settings() -> None:
+    settings = DBSettings(prefix="legacy_")
+    q = Queries(
+        InMemoryDriver(),
+        qbe=qb.QueryBuilderEnvironment(settings=settings),
+    )
+
+    assert q.settings is settings
+    assert q.qbq.settings is settings
+    assert q.qbs.settings is settings
+
+
+def test_inmemory_queries_shares_one_settings_object() -> None:
+    settings = DBSettings(prefix="mem_")
+    q = InMemoryQueries(InMemoryDriver(), settings=settings)
+
+    assert q.settings is settings
+    assert q.qbe.settings is settings
+    assert q.qbq.settings is settings
+    assert q.qbs.settings is settings
+
+
+def test_sync_queries_shares_one_settings_object(pgdriver: db.SyncDriver) -> None:
+    settings = DBSettings(prefix="sync_")
+    q = SyncQueries(pgdriver, settings=settings)
+
+    assert q.settings is settings
+    assert q.qbq.settings is settings
+
+
+def test_settings_mutation_updates_qualified_sql() -> None:
+    settings = DBSettings()
+    q = Queries(InMemoryDriver(), settings=settings)
+    before = q.qbq.build_dequeue_query()
+
+    settings.db_schema = "billing"
+    after = q.qbq.build_dequeue_query()
+
+    assert before != after
+    assert "billing." in after
+
+
+def test_queue_manager_channel_override_updates_repository_settings() -> None:
+    settings = DBSettings()
+    queries = Queries(InMemoryDriver(), settings=settings)
+    custom = Channel("custom_notify")
+
+    qm = QueueManager(queries, channel=custom)
+
+    assert qm.channel == custom
+    assert queries.settings.channel == custom
+
+
+def test_queue_manager_defaults_channel_from_repository_settings() -> None:
+    settings = DBSettings(prefix="qm_")
+    queries = Queries(InMemoryDriver(), settings=settings)
+
+    qm = QueueManager(queries)
+
+    assert qm.channel == settings.channel
+
+
+def test_pgqueuer_channel_override_updates_queries_settings() -> None:
+    custom = Channel("edge_channel")
+    pgq = PgQueuer.in_memory(channel=custom)
+
+    assert pgq.channel == custom
+    assert pgq.queries is not None
+    assert pgq.queries.settings.channel == custom
+
+
+async def test_completion_watcher_listens_on_repository_channel() -> None:
+    settings = DBSettings(prefix="watch_")
+    driver = InMemoryDriver()
+    queries = Queries(driver, settings=settings)
+    watcher = CompletionWatcher(driver, queries=queries)
+
+    async with watcher:
+        assert driver._listeners[settings.channel]
+
+
+@pytest.mark.parametrize("invalid_schema", ["bad.schema", "bad;drop"])
+def test_settings_assignment_validates(invalid_schema: str) -> None:
+    settings = DBSettings()
+    with pytest.raises(ValueError, match="db_schema"):
+        settings.db_schema = invalid_schema

--- a/test/test_settings_ownership.py
+++ b/test/test_settings_ownership.py
@@ -4,7 +4,6 @@ import pytest
 
 from pgqueuer import db
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
-from pgqueuer.adapters.persistence import qb
 from pgqueuer.adapters.persistence.queries import Queries, SyncQueries
 from pgqueuer.applications import PgQueuer
 from pgqueuer.core.completion import CompletionWatcher
@@ -19,18 +18,6 @@ def test_queries_shares_one_settings_object() -> None:
 
     assert q.settings is settings
     assert q.qbe.settings is settings
-    assert q.qbq.settings is settings
-    assert q.qbs.settings is settings
-
-
-def test_queries_legacy_builder_injection_uses_builder_settings() -> None:
-    settings = DBSettings(prefix="legacy_")
-    q = Queries(
-        InMemoryDriver(),
-        qbe=qb.QueryBuilderEnvironment(settings=settings),
-    )
-
-    assert q.settings is settings
     assert q.qbq.settings is settings
     assert q.qbs.settings is settings
 
@@ -92,6 +79,18 @@ def test_pgqueuer_channel_override_updates_queries_settings() -> None:
     assert pgq.channel == custom
     assert pgq.queries is not None
     assert pgq.queries.settings.channel == custom
+
+
+def test_pgqueuer_passes_settings_to_the_repository() -> None:
+    settings = DBSettings(prefix="app_")
+    pgq = PgQueuer.in_memory(settings=settings)
+
+    assert pgq.settings is settings
+    assert isinstance(pgq.queries, InMemoryQueries)
+    assert pgq.queries.settings is settings
+    assert pgq.queries.qbe.settings is settings
+    assert pgq.queries.qbq.settings is settings
+    assert pgq.queries.qbs.settings is settings
 
 
 async def test_completion_watcher_listens_on_repository_channel() -> None:

--- a/test/test_settings_ownership.py
+++ b/test/test_settings_ownership.py
@@ -57,9 +57,8 @@ def test_queue_manager_channel_override_updates_repository_settings() -> None:
     queries = Queries(InMemoryDriver(), settings=settings)
     custom = Channel("custom_notify")
 
-    qm = QueueManager(queries, channel=custom)
+    QueueManager(queries, channel=custom)
 
-    assert qm.channel == custom
     assert queries.settings.channel == custom
 
 
@@ -67,9 +66,9 @@ def test_queue_manager_defaults_channel_from_repository_settings() -> None:
     settings = DBSettings(prefix="qm_")
     queries = Queries(InMemoryDriver(), settings=settings)
 
-    qm = QueueManager(queries)
+    QueueManager(queries)
 
-    assert qm.channel == settings.channel
+    assert queries.settings.channel == settings.channel
 
 
 def test_pgqueuer_channel_override_updates_queries_settings() -> None:


### PR DESCRIPTION
## Summary
- Give each `Queries` / `InMemoryQueries` / `SyncQueries` stack one canonical mutable `DBSettings`, shared by all query builders
- Derive LISTEN channels in `QueueManager`, `PgQueuer`, and `CompletionWatcher` from repository settings so custom prefix/channel no longer drifts from NOTIFY
- Create settings once at CLI/web/MCP/SQL edges, export `DBSettings` from the package root, and document the ownership contract

## Test plan
- [x] `uv run pytest test/test_settings_ownership.py test/test_settings.py`
- [x] `uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy .`
- [x] Full suite: `uv run pytest` (1064 passed)
- [ ] Confirm custom `DBSettings(prefix=...)` wires LISTEN and NOTIFY to the same channel end-to-end
- [ ] Spot-check `pgq install` / `pgq sql install` with `--prefix` / `--schema`