### PR TITLE
fix(cli): isolate supervisor cycle shutdown from process signals

### DIFF
--- a/pgqueuer/adapters/cli/supervisor.py
+++ b/pgqueuer/adapters/cli/supervisor.py
@@ -49,6 +49,12 @@ def setup_signal_handlers(shutdown: asyncio.Event) -> None:
         )
 
 
+async def forward_shutdown(source: asyncio.Event, target: asyncio.Event) -> None:
+    """Set *target* once *source* is set so a process signal stops the current cycle."""
+    await source.wait()
+    target.set()
+
+
 async def runit(
     factory: ManagerFactory,
     dequeue_timeout: timedelta,
@@ -63,6 +69,11 @@ async def runit(
 ) -> None:
     """Supervise a manager lifecycle; optionally restart after *restart_delay* on failure.
 
+    Each cycle gets its own shutdown event so a manager that sets ``shutdown`` on
+    exit (e.g. ``PgQueuer.run``'s ``finally``) cannot latch the process-level
+    event and defeat ``restart_on_failure``. Process signals still stop the
+    current cycle via :func:`forward_shutdown`.
+
     Raises ValueError when ``restart_delay`` is negative.
     """
     if restart_delay < timedelta(0):
@@ -71,9 +82,12 @@ async def runit(
     setup_signal_handlers(shutdown)
 
     while not shutdown.is_set():
+        cycle_shutdown = asyncio.Event()
+        forward_task = asyncio.create_task(forward_shutdown(shutdown, cycle_shutdown))
+        failed = False
         try:
             async with factories.validate_factory_result(factory()) as manager:
-                setup_shutdown_handlers(manager, shutdown)
+                setup_shutdown_handlers(manager, cycle_shutdown)
                 await run_manager(
                     manager,
                     dequeue_timeout,
@@ -86,13 +100,21 @@ async def runit(
         except Exception as exc:
             if not restart_on_failure:
                 raise
+            failed = True
             logconfig.logger.exception(
                 "Error during instance execution.",
                 exc_info=exc,
             )
+        finally:
+            forward_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await forward_task
 
-        if not shutdown.is_set():
-            await await_shutdown_or_timeout(shutdown, restart_delay)
+        # Clean completion (drain / signal) ends the supervisor; only failures restart.
+        if shutdown.is_set() or not failed:
+            break
+
+        await await_shutdown_or_timeout(shutdown, restart_delay)
 
 
 async def run_manager(

--- a/test/test_factory_supervisor_chain.py
+++ b/test/test_factory_supervisor_chain.py
@@ -237,12 +237,15 @@ async def test_shutdown_injected_into_pgqueuer() -> None:
         )
     )
     await asyncio.sleep(0.1)
-    assert pgq.shutdown is shutdown
-    assert pgq.qm.shutdown is shutdown
-    assert pgq.sm.shutdown is shutdown
+    # Process shutdown is forwarded into a per-cycle event (not identity-shared),
+    # so PgQueuer.run's finally cannot latch the supervisor loop.
+    assert not pgq.shutdown.is_set()
     shutdown.set()
     async with async_timeout.timeout(2):
+        await pgq.shutdown.wait()
         await task
+    assert pgq.qm.shutdown.is_set()
+    assert pgq.sm.shutdown.is_set()
 
 
 async def test_shutdown_injected_into_queue_manager() -> None:
@@ -267,9 +270,10 @@ async def test_shutdown_injected_into_queue_manager() -> None:
         )
     )
     await asyncio.sleep(0.1)
-    assert qm.shutdown is shutdown
+    assert not qm.shutdown.is_set()
     shutdown.set()
     async with async_timeout.timeout(2):
+        await qm.shutdown.wait()
         await task
 
 
@@ -295,9 +299,10 @@ async def test_shutdown_injected_into_scheduler_manager() -> None:
         )
     )
     await asyncio.sleep(0.1)
-    assert sm.shutdown is shutdown
+    assert not sm.shutdown.is_set()
     shutdown.set()
     async with async_timeout.timeout(2):
+        await sm.shutdown.wait()
         await task
 
 

--- a/test/test_superviser.py
+++ b/test/test_superviser.py
@@ -213,6 +213,102 @@ async def test_runit_restart_on_failure(
     assert calls > 1
 
 
+async def test_runit_restarts_when_pgqueuer_inner_run_fails() -> None:
+    """PgQueuer.run's finally must not latch process shutdown and defeat restart.
+
+    Replaces only ``qm.run`` so the real ``PgQueuer.run`` ``finally: shutdown.set()``
+    path executes — the case missed by patching ``PgQueuer.run`` wholesale.
+    """
+    calls = 0
+
+    @asynccontextmanager
+    async def factory():  # type: ignore
+        nonlocal calls
+        calls += 1
+        pgq = PgQueuer.in_memory()
+
+        async def boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError(f"qm failed on attempt {calls}")
+
+        pgq.qm.run = boom  # type: ignore[method-assign]
+        yield pgq
+
+    shutdown = asyncio.Event()
+    runit_task = asyncio.create_task(
+        supervisor.runit(
+            factory=factory,
+            dequeue_timeout=timedelta(seconds=1),
+            batch_size=10,
+            restart_delay=timedelta(seconds=0.05),
+            restart_on_failure=True,
+            shutdown=shutdown,
+            mode=QueueExecutionMode.continuous,
+            max_concurrent_tasks=None,
+            shutdown_on_listener_failure=False,
+        )
+    )
+
+    await asyncio.sleep(0.3)
+    assert not runit_task.done(), "supervisor exited instead of restarting"
+    assert not shutdown.is_set(), "PgQueuer.finally latched the process shutdown event"
+    assert calls > 1, f"expected multiple restart attempts, got {calls}"
+
+    shutdown.set()
+    async with async_timeout.timeout(2):
+        await runit_task
+
+
+async def test_runit_pgqueuer_failure_without_restart_still_raises() -> None:
+    """Without restart_on_failure, a real PgQueuer.run failure must propagate."""
+
+    @asynccontextmanager
+    async def factory():  # type: ignore
+        pgq = PgQueuer.in_memory()
+
+        async def boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("qm failed")
+
+        pgq.qm.run = boom  # type: ignore[method-assign]
+        yield pgq
+
+    with pytest.raises(RuntimeError, match="qm failed"):
+        await supervisor.runit(
+            factory=factory,
+            dequeue_timeout=timedelta(seconds=1),
+            batch_size=10,
+            restart_delay=timedelta(seconds=0.05),
+            restart_on_failure=False,
+            shutdown=asyncio.Event(),
+            mode=QueueExecutionMode.continuous,
+            max_concurrent_tasks=None,
+            shutdown_on_listener_failure=False,
+        )
+
+
+async def test_runit_drain_exits_once_with_restart_on_failure() -> None:
+    """Successful drain must not loop just because restart_on_failure is enabled."""
+    calls = 0
+
+    @asynccontextmanager
+    async def factory():  # type: ignore
+        nonlocal calls
+        calls += 1
+        yield PgQueuer.in_memory()
+
+    await supervisor.runit(
+        factory=factory,
+        dequeue_timeout=timedelta(seconds=0.1),
+        batch_size=10,
+        restart_delay=timedelta(seconds=0.05),
+        restart_on_failure=True,
+        shutdown=asyncio.Event(),
+        mode=QueueExecutionMode.drain,
+        max_concurrent_tasks=None,
+        shutdown_on_listener_failure=False,
+    )
+    assert calls == 1
+
+
 async def test_runit_no_restart_on_failure(
     pg_queuer: PgQueuer,
     shutdown_event: asyncio.Event,

--- a/test/test_superviser.py
+++ b/test/test_superviser.py
@@ -230,7 +230,7 @@ async def test_runit_restarts_when_pgqueuer_inner_run_fails() -> None:
         async def boom(*args: object, **kwargs: object) -> None:
             raise RuntimeError(f"qm failed on attempt {calls}")
 
-        pgq.qm.run = boom  # type: ignore[method-assign]
+        pgq.qm.run = boom
         yield pgq
 
     shutdown = asyncio.Event()
@@ -268,7 +268,7 @@ async def test_runit_pgqueuer_failure_without_restart_still_raises() -> None:
         async def boom(*args: object, **kwargs: object) -> None:
             raise RuntimeError("qm failed")
 
-        pgq.qm.run = boom  # type: ignore[method-assign]
+        pgq.qm.run = boom
         yield pgq
 
     with pytest.raises(RuntimeError, match="qm failed"):


### PR DESCRIPTION
## Summary
- Give each supervisor cycle its own shutdown event so `PgQueuer.run`'s `finally: shutdown.set()` cannot latch the process-level event and defeat `--restart-on-failure`
- Forward process SIGINT/SIGTERM into the current cycle via `forward_shutdown`; only failed cycles wait and restart
- Add regression tests that exercise the real `PgQueuer.run` finally path (only `qm.run` patched)

## Test plan
- [x] `uv run pytest test/test_superviser.py test/test_factory_supervisor_chain.py -n 0`
- [ ] Confirm `pgq run --restart-on-failure` restarts after a crash in a PgQueuer factory (not exit 0 after one failure)
- [ ] Confirm drain mode still exits after one successful pass with `--restart-on-failure`
- [ ] Confirm SIGTERM still stops the supervisor cleanly