### PR TITLE
refactor: scope DBSettings per application graph

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -2,6 +2,24 @@
 
 This page explains the key abstractions in PgQueuer.
 
+## Database settings
+
+`DBSettings` defines PgQueuer's table names, schema, prefix, durability, and
+notification channel. Create one instance for each logical queue and pass it to
+every PgQueuer object in that application graph:
+
+```python
+from pgqueuer import DBSettings, PgQueuer, Queries
+
+settings = DBSettings(prefix="billing_", db_schema="jobs")
+queries = Queries(driver, settings=settings)
+pgq = PgQueuer(driver, queries=queries, settings=settings)
+```
+
+When `settings` is omitted, `Queries` or `PgQueuer` creates one instance and
+reuses it across all query builders, managers, and default channels. Separate
+application graphs can use different settings in the same process.
+
 ---
 
 ## Jobs

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -107,11 +107,12 @@ If you use `PGQUEUER_PREFIX` or `PGQUEUER_SCHEMA` to namespace your tables, pass
 custom settings:
 
 ```python
+from pgqueuer import DBSettings
 from pgqueuer.adapters.mcp.server import create_mcp_server
-from pgqueuer.adapters.persistence.qb import DBSettings
 
 # reads PGQUEUER_PREFIX / PGQUEUER_SCHEMA
-server = create_mcp_server(settings=DBSettings())
+settings = DBSettings()
+server = create_mcp_server(settings=settings)
 server.run(transport="stdio")
 ```
 

--- a/docs/integrations/web-dashboard.md
+++ b/docs/integrations/web-dashboard.md
@@ -31,6 +31,17 @@ failure rates, a browsable job table with per-job detail, held failures with
 bulk requeue, workers, schedules, and system health. Orchestrators can hit
 `/healthz` for liveness.
 
+When creating the standalone app from Python, pass the same settings used by
+your workers so its queries and live-update channel stay aligned:
+
+```python
+from pgqueuer import DBSettings
+from pgqueuer.web import create_web_app
+
+settings = DBSettings(prefix="billing_", db_schema="jobs")
+app = create_web_app(settings=settings)
+```
+
 Live updates ride the `LISTEN/NOTIFY` channel PgQueuer already installs:
 queue-table changes push a debounced server-sent event and the affected
 screens re-render. Statistics-derived views (throughput, durations) refresh on

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -407,6 +407,9 @@ All commands accept the following connection options:
 | `--prefix` | `PGQUEUER_PREFIX` | Prefix for PgQueuer database objects |
 | `--schema` | `PGQUEUER_SCHEMA` | Postgres schema holding all PgQueuer objects |
 
+Each invocation resolves these options into one `DBSettings` instance and
+reuses it for every query builder and notification channel used by the command.
+
 When `--pg-dsn` is omitted, the database drivers (asyncpg / psycopg) read standard
 libpq environment variables automatically: `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`,
 `PGDATABASE`.

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -122,10 +122,11 @@ PgQueuer provides classmethods that handle driver instantiation automatically:
 
 ```python
 import asyncpg
-from pgqueuer import PgQueuer
+from pgqueuer import DBSettings, PgQueuer
 
 connection = await asyncpg.connect(dsn)
-pgq = PgQueuer.from_asyncpg_connection(connection)
+settings = DBSettings(prefix="billing_", db_schema="jobs")
+pgq = PgQueuer.from_asyncpg_connection(connection, settings=settings)
 
 # With optional shared resources
 pgq = PgQueuer.from_asyncpg_connection(
@@ -167,8 +168,9 @@ All classmethods accept:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `connection` / `pool` | Yes | The database connection or pool |
-| `channel` | No | Custom `Channel` configuration. Defaults to `Channel(DBSettings().channel)` |
+| `channel` | No | Custom `Channel`; defaults to the canonical settings channel |
 | `resources` | No | Mutable mapping for shared resources. Defaults to `{}` |
+| `settings` | No | A `DBSettings` instance shared by the repository, query builders, and managers |
 
 ## Best Practices
 

--- a/pgqueuer/__init__.py
+++ b/pgqueuer/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.applications import PgQueuer
 from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver, PsycopgDriver
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.errors import RetryRequested
 from pgqueuer.executors import DatabaseRetryEntrypointExecutor
 from pgqueuer.models import Job, JobId
@@ -19,6 +20,7 @@ __all__ = [
     "AsyncpgDriver",
     "AsyncpgPoolDriver",
     "DatabaseRetryEntrypointExecutor",
+    "DBSettings",
     "InMemoryDriver",
     "InMemoryQueries",
     "Job",

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -94,12 +94,28 @@ class AppConfig:
     schema: str = ""
     pg_dsn: str = ""
     factory_fn_ref: str | None = None
+    settings: qb.DBSettings | None = None
 
     def setup_env(self) -> None:
         if self.prefix:
             os.environ["PGQUEUER_PREFIX"] = self.prefix
         if self.schema:
             os.environ["PGQUEUER_SCHEMA"] = self.schema
+
+    def get_settings(
+        self,
+        *,
+        durability: qb.Durability | None = None,
+        widen_id: bool | None = None,
+    ) -> qb.DBSettings:
+        """Return this CLI invocation's database settings."""
+        if self.settings is None:
+            self.settings = qb.DBSettings()
+        if durability is not None:
+            self.settings.durability = durability
+        if widen_id is not None:
+            self.settings.widen_id = widen_id
+        return self.settings
 
 
 @app.callback()
@@ -143,9 +159,9 @@ def main(
 
 def create_default_queries_factory(
     config: AppConfig,
-    settings: qb.DBSettings,
 ) -> Callable[..., contextlib.AbstractAsyncContextManager[queries.Queries]]:
     """Default Queries factory: try asyncpg, fall back to psycopg."""
+    database_settings = config.get_settings()
 
     @contextlib.asynccontextmanager
     async def factory() -> AsyncGenerator[queries.Queries, None]:
@@ -156,9 +172,7 @@ def create_default_queries_factory(
             async with connect_asyncpg(dsn=config.pg_dsn or None) as connection:
                 yield queries.Queries(
                     AsyncpgDriver(connection),
-                    qbe=qb.QueryBuilderEnvironment(settings),
-                    qbq=qb.QueryQueueBuilder(settings),
-                    qbs=qb.QuerySchedulerBuilder(settings),
+                    settings=database_settings,
                 )
             return
         with contextlib.suppress(ImportError):
@@ -168,9 +182,7 @@ def create_default_queries_factory(
             async with connect_psycopg(dsn=config.pg_dsn or None) as connection:
                 yield queries.Queries(
                     PsycopgDriver(connection),
-                    qbe=qb.QueryBuilderEnvironment(settings),
-                    qbq=qb.QueryQueueBuilder(settings),
-                    qbs=qb.QuerySchedulerBuilder(settings),
+                    settings=database_settings,
                 )
             return
         raise RuntimeError("Neither asyncpg nor psycopg could be imported.")
@@ -181,14 +193,13 @@ def create_default_queries_factory(
 @contextlib.asynccontextmanager
 async def yield_queries(
     ctx: Context,
-    settings: qb.DBSettings,
 ) -> AsyncGenerator[queries.Queries, None]:
     """Yield Queries from the user-supplied factory or the built-in default."""
     config: AppConfig = ctx.obj
     if config.factory_fn_ref:
         factory_fn = factories.load_factory(config.factory_fn_ref)
     else:
-        factory_fn = create_default_queries_factory(config, settings)
+        factory_fn = create_default_queries_factory(config)
     async with factories.validate_factory_result(factory_fn()) as q:
         yield q
 
@@ -291,13 +302,14 @@ def install(
     durability: sql_cmd.DurabilityOption = qb.Durability.durable,
     create_schema: sql_cmd.CreateSchemaOption = True,
 ) -> None:
-    settings = qb.DBSettings(durability=durability)
+    config: AppConfig = ctx.obj
+    config.get_settings(durability=durability)
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_install(settings, create_schema))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_install(config.get_settings(), create_schema))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, settings) as q:
+        async with yield_queries(ctx) as q:
             await q.install(create_schema=create_schema)
 
     asyncio_run(run())
@@ -313,7 +325,7 @@ def verify(
     ),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             expect_present = expect == VerifyMode.PRESENT
             divergence = list[str]()
 
@@ -364,11 +376,11 @@ def uninstall(
     ),
 ) -> None:
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall())
+        emit_deprecated_dry_run(ctx, sql_cmd.render_uninstall(ctx.obj.get_settings()))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             await q.uninstall()
 
     asyncio_run(run())
@@ -387,13 +399,14 @@ def upgrade(
     durability: sql_cmd.DurabilityOption = qb.Durability.durable,
     widen_id: sql_cmd.WidenIdOption = True,
 ) -> None:
-    settings = qb.DBSettings(durability=durability, widen_id=widen_id)
+    config: AppConfig = ctx.obj
+    config.get_settings(durability=durability, widen_id=widen_id)
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_upgrade(settings))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_upgrade(config.get_settings()))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, settings) as q:
+        async with yield_queries(ctx) as q:
             await q.upgrade()
 
     asyncio_run(run())
@@ -417,7 +430,7 @@ def dashboard(
     interval_td = timedelta(seconds=interval) if interval is not None else None
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             await fetch_and_display(q, interval_td, limit)
 
     asyncio_run(run())
@@ -450,20 +463,27 @@ def web(
 
     logconfig.setup_fancy_logger(logconfig.LogLevel.INFO)
     config: AppConfig = ctx.obj
-    uvicorn.run(create_web_app(config.pg_dsn or None), host=host, port=port)
+    uvicorn.run(
+        create_web_app(config.pg_dsn or None, settings=config.get_settings()),
+        host=host,
+        port=port,
+    )
 
 
 @app.command(help="Listen to a PostgreSQL NOTIFY channel for debug purposes.")
 def listen(
     ctx: Context,
-    channel: str = typer.Option(
-        qb.DBSettings().channel,
+    channel: str | None = typer.Option(
+        None,
         "--channel",
     ),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
-            await display_pg_channel(q.driver, models.Channel(channel))
+        async with yield_queries(ctx) as q:
+            await display_pg_channel(
+                q.driver,
+                models.Channel(channel or q.settings.channel),
+            )
 
     asyncio_run(run())
 
@@ -563,7 +583,7 @@ def schedules(
     ),
 ) -> None:
     async def run_async() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             if remove:
                 schedule_ids = {models.ScheduleId(int(x)) for x in remove if x.isdigit()}
                 schedule_names = {types.CronEntrypoint(x) for x in remove if not x.isdigit()}
@@ -598,7 +618,7 @@ def queue(
     async def run_async() -> None:
         # For a single job, skip mode subsumes raise mode: a None result is
         # exactly the duplicate case, so on_conflict only decides the exit.
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             (job_id,) = await q.enqueue(
                 entrypoint,
                 None if payload is None else payload.encode(),
@@ -627,7 +647,7 @@ def failed(
     limit: int = typer.Option(25, "-n", "--limit", help="Maximum number of jobs to display."),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             jobs = await q.list_failed_jobs(limit=limit)
             if not jobs:
                 print("No failed jobs.")
@@ -659,7 +679,7 @@ def requeue(
     ids: list[int] = typer.Argument(..., help="Job IDs to re-queue."),
 ) -> None:
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             typed_ids = [types.JobId(i) for i in ids]
             await q.requeue_jobs(typed_ids)
             print(f"Re-queued {len(typed_ids)} job(s).")
@@ -679,13 +699,14 @@ def durability(
     ),
 ) -> None:
     """Switch durability level of PgQueuer tables without data loss."""
-    settings = qb.DBSettings(durability=durability)
+    config: AppConfig = ctx.obj
+    config.get_settings(durability=durability)
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_durability(settings))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_durability(config.get_settings()))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, settings) as q:
+        async with yield_queries(ctx) as q:
             await q.alter_durability()
 
     asyncio_run(run())
@@ -705,11 +726,11 @@ def optimize_autovacuum(
 ) -> None:
     """Apply or revert recommended autovacuum settings."""
     if dry_run:
-        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(rollback))
+        emit_deprecated_dry_run(ctx, sql_cmd.render_autovac(rollback, ctx.obj.get_settings()))
         return
 
     async def run() -> None:
-        async with yield_queries(ctx, qb.DBSettings()) as q:
+        async with yield_queries(ctx) as q:
             await (q.optimize_autovacuum_rollback() if rollback else q.optimize_autovacuum())
 
     asyncio_run(run())

--- a/pgqueuer/adapters/cli/sql_cmd.py
+++ b/pgqueuer/adapters/cli/sql_cmd.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import inspect
+from typing import Protocol, cast
 
 import typer
+from typer import Context
 from typing_extensions import Annotated
 
 from pgqueuer.adapters.persistence import qb
@@ -56,13 +58,36 @@ DurabilityArgument = Annotated[
 ]
 
 
+class SettingsContext(Protocol):
+    """CLI context object that owns database settings."""
+
+    def get_settings(
+        self,
+        *,
+        durability: qb.Durability | None = None,
+        widen_id: bool | None = None,
+    ) -> qb.DBSettings: ...
+
+
+def context_settings(
+    ctx: Context,
+    *,
+    durability: qb.Durability | None = None,
+    widen_id: bool | None = None,
+) -> qb.DBSettings:
+    """Return settings owned by the root CLI context."""
+    config = cast(SettingsContext, ctx.find_root().obj)
+    return config.get_settings(durability=durability, widen_id=widen_id)
+
+
 def render_install(settings: qb.DBSettings, create_schema: bool) -> str:
     qbe = qb.QueryBuilderEnvironment(settings)
     return inspect.cleandoc(qbe.build_install_query(create_schema=create_schema)).strip()
 
 
-def render_uninstall() -> str:
-    return inspect.cleandoc(qb.QueryBuilderEnvironment().build_uninstall_query()).strip()
+def render_uninstall(settings: qb.DBSettings) -> str:
+    qbe = qb.QueryBuilderEnvironment(settings)
+    return inspect.cleandoc(qbe.build_uninstall_query()).strip()
 
 
 def render_upgrade(settings: qb.DBSettings) -> str:
@@ -79,8 +104,8 @@ def render_durability(settings: qb.DBSettings) -> str:
     )
 
 
-def render_autovac(rollback: bool) -> str:
-    qbe = qb.QueryBuilderEnvironment()
+def render_autovac(rollback: bool, settings: qb.DBSettings) -> str:
+    qbe = qb.QueryBuilderEnvironment(settings)
     query = (
         qbe.build_optimize_autovacuum_rollback_query()
         if rollback
@@ -91,34 +116,47 @@ def render_autovac(rollback: bool) -> str:
 
 @sql_app.command(help="SQL to create the PgQueuer schema.")
 def install(
+    ctx: Context,
     durability: DurabilityOption = qb.Durability.durable,
     create_schema: CreateSchemaOption = True,
 ) -> None:
-    typer.echo(render_install(qb.DBSettings(durability=durability), create_schema))
+    typer.echo(
+        render_install(
+            context_settings(ctx, durability=durability),
+            create_schema,
+        )
+    )
 
 
 @sql_app.command(help="SQL to drop all PgQueuer objects.")
-def uninstall() -> None:
-    typer.echo(render_uninstall())
+def uninstall(ctx: Context) -> None:
+    typer.echo(render_uninstall(context_settings(ctx)))
 
 
 @sql_app.command(help="SQL to migrate an existing installation to the current version.")
 def upgrade(
+    ctx: Context,
     durability: DurabilityOption = qb.Durability.durable,
     widen_id: WidenIdOption = True,
 ) -> None:
-    typer.echo(render_upgrade(qb.DBSettings(durability=durability, widen_id=widen_id)))
+    typer.echo(
+        render_upgrade(
+            context_settings(ctx, durability=durability, widen_id=widen_id),
+        )
+    )
 
 
 @sql_app.command(help="SQL to switch table durability without data loss.")
 def durability(
+    ctx: Context,
     durability: DurabilityArgument,
 ) -> None:
-    typer.echo(render_durability(qb.DBSettings(durability=durability)))
+    typer.echo(render_durability(context_settings(ctx, durability=durability)))
 
 
 @sql_app.command(help="SQL for recommended autovacuum settings (--rollback to reset).")
 def autovac(
+    ctx: Context,
     rollback: bool = typer.Option(False, help="Reset to defaults instead."),
 ) -> None:
-    typer.echo(render_autovac(rollback))
+    typer.echo(render_autovac(rollback, context_settings(ctx)))

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -37,22 +37,14 @@ def percentile_cont(values: list[float], fraction: float) -> float:
     return ordered[lower] + (ordered[upper] - ordered[lower]) * (rank - lower)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(init=False)
 class InMemoryQueries:
     """Drop-in replacement for ``Queries`` backed by pure Python dicts."""
 
     driver: InMemoryDriver
-
-    qbe: qb.QueryBuilderEnvironment = dataclasses.field(
-        default_factory=qb.QueryBuilderEnvironment,
-    )
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-    qbs: qb.QuerySchedulerBuilder = dataclasses.field(
-        default_factory=qb.QuerySchedulerBuilder,
-    )
-
+    qbe: qb.QueryBuilderEnvironment
+    qbq: qb.QueryQueueBuilder
+    qbs: qb.QuerySchedulerBuilder
     tracer: TracingProtocol | None = None
 
     _jobs: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
@@ -77,6 +69,39 @@ class InMemoryQueries:
     _next_log_id: int = dataclasses.field(default=1, init=False)
     _next_schedule_id: int = dataclasses.field(default=1, init=False)
     _next_stats_id: int = dataclasses.field(default=1, init=False)
+
+    def __init__(
+        self,
+        driver: InMemoryDriver,
+        qbe: qb.QueryBuilderEnvironment | None = None,
+        qbq: qb.QueryQueueBuilder | None = None,
+        qbs: qb.QuerySchedulerBuilder | None = None,
+        tracer: TracingProtocol | None = None,
+        *,
+        settings: qb.DBSettings | None = None,
+    ) -> None:
+        _, self.qbe, self.qbq, self.qbs = qb.bind_repository_builders(
+            settings, qbe=qbe, qbq=qbq, qbs=qbs
+        )
+        self.driver = driver
+        self.tracer = tracer
+        self._jobs = {}
+        self._log = []
+        self._statistics = []
+        self._schedules = {}
+        self._dedupe_index = {}
+        self._dedupe_key_by_job = {}
+        self._ready_heaps = {}
+        self._deferred_heap = []
+        self._picked_ids = set()
+        self._next_job_id = 1
+        self._next_log_id = 1
+        self._next_schedule_id = 1
+        self._next_stats_id = 1
+
+    @property
+    def settings(self) -> qb.DBSettings:
+        return self.qbe.settings
 
     async def install(self) -> None:
         pass

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -17,6 +17,7 @@ from pgqueuer.adapters.persistence.qb import (
     DBSettings,
     QueryQueueBuilder,
     QuerySchedulerBuilder,
+    resolve_settings,
 )
 from pgqueuer.domain.settings import ConnectionSettings
 
@@ -459,7 +460,7 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
 
 def create_mcp_server(
     dsn: str | None = None,
-    settings: DBSettings = DBSettings(),
+    settings: DBSettings | None = None,
     connection_settings: ConnectionSettings | None = None,
 ) -> FastMCP:
     """Factory that builds a fully-configured PgQueuer MCP server.
@@ -476,10 +477,12 @@ def create_mcp_server(
              PGQUEUER_APPLICATION_NAME).
     """
 
+    database_settings = resolve_settings(settings)
+
     @asynccontextmanager
     async def app_lifespan(server: FastMCP) -> AsyncIterator[PgQueuerDatabase]:
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
-            yield PgQueuerDatabase(pool, settings)
+            yield PgQueuerDatabase(pool, database_settings)
 
     mcp = FastMCP("pgqueuer", lifespan=app_lifespan)
 

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Generator
+from typing import Generator, TypeAlias
 
 from typing_extensions import assert_never
 
@@ -22,6 +22,8 @@ __all__ = [
     "QueryBuilderEnvironment",
     "QueryQueueBuilder",
     "QuerySchedulerBuilder",
+    "bind_repository_builders",
+    "resolve_settings",
 ]
 
 
@@ -1081,3 +1083,44 @@ class QuerySchedulerBuilder:
 
     def build_truncate_schedule_query(self) -> str:
         return f"""TRUNCATE {self.qualified.schedules_table}"""
+
+
+QueryBuilder: TypeAlias = QueryBuilderEnvironment | QueryQueueBuilder | QuerySchedulerBuilder
+
+
+def resolve_settings(
+    settings: DBSettings | None,
+    *builders: QueryBuilder,
+) -> DBSettings:
+    """Resolve one settings instance and bind it onto every provided builder."""
+    if settings is not None:
+        for builder in builders:
+            builder.settings = settings
+        return settings
+
+    if not builders:
+        return DBSettings()
+
+    resolved = builders[0].settings
+    for builder in builders[1:]:
+        if builder.settings != resolved:
+            raise ValueError("Query builders must use equivalent DBSettings.")
+        builder.settings = resolved
+    return resolved
+
+
+def bind_repository_builders(
+    settings: DBSettings | None = None,
+    qbe: QueryBuilderEnvironment | None = None,
+    qbq: QueryQueueBuilder | None = None,
+    qbs: QuerySchedulerBuilder | None = None,
+) -> tuple[DBSettings, QueryBuilderEnvironment, QueryQueueBuilder, QuerySchedulerBuilder]:
+    """Return builders that all share one resolved DBSettings instance."""
+    present = tuple(builder for builder in (qbe, qbq, qbs) if builder is not None)
+    resolved = resolve_settings(settings, *present)
+    return (
+        resolved,
+        qbe or QueryBuilderEnvironment(resolved),
+        qbq or QueryQueueBuilder(resolved),
+        qbs or QuerySchedulerBuilder(resolved),
+    )

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -41,45 +41,71 @@ def is_unique_violation(exc: Exception) -> bool:
     return False
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(init=False)
 class Queries:
     """High-level job-queue operations: schema install/upgrade, enqueue/dequeue, log, stats."""
 
     driver: Driver
-
-    qbe: qb.QueryBuilderEnvironment = dataclasses.field(
-        default_factory=qb.QueryBuilderEnvironment,
-    )
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-    qbs: qb.QuerySchedulerBuilder = dataclasses.field(
-        default_factory=qb.QuerySchedulerBuilder,
-    )
-
-    # Optional injected tracer; falls back to the global ``tracing.TRACER.tracer``.
+    qbe: qb.QueryBuilderEnvironment
+    qbq: qb.QueryQueueBuilder
+    qbs: qb.QuerySchedulerBuilder
     tracer: TracingProtocol | None = None
 
+    def __init__(
+        self,
+        driver: Driver,
+        qbe: qb.QueryBuilderEnvironment | None = None,
+        qbq: qb.QueryQueueBuilder | None = None,
+        qbs: qb.QuerySchedulerBuilder | None = None,
+        tracer: TracingProtocol | None = None,
+        *,
+        settings: qb.DBSettings | None = None,
+    ) -> None:
+        _, self.qbe, self.qbq, self.qbs = qb.bind_repository_builders(
+            settings, qbe=qbe, qbq=qbq, qbs=qbs
+        )
+        self.driver = driver
+        self.tracer = tracer
+
+    @property
+    def settings(self) -> qb.DBSettings:
+        return self.qbe.settings
+
     @classmethod
-    def from_asyncpg_connection(cls, connection: "asyncpg.Connection") -> "Queries":
+    def from_asyncpg_connection(
+        cls,
+        connection: "asyncpg.Connection",
+        *,
+        settings: qb.DBSettings | None = None,
+    ) -> "Queries":
         """Build Queries over an asyncpg connection."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgDriver
 
-        return cls(AsyncpgDriver(connection))
+        return cls(AsyncpgDriver(connection), settings=settings)
 
     @classmethod
-    def from_asyncpg_pool(cls, pool: "asyncpg.Pool") -> "Queries":
+    def from_asyncpg_pool(
+        cls,
+        pool: "asyncpg.Pool",
+        *,
+        settings: qb.DBSettings | None = None,
+    ) -> "Queries":
         """Build Queries over an asyncpg pool."""
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        return cls(AsyncpgPoolDriver(pool))
+        return cls(AsyncpgPoolDriver(pool), settings=settings)
 
     @classmethod
-    def from_psycopg_connection(cls, connection: "psycopg.AsyncConnection") -> "Queries":
+    def from_psycopg_connection(
+        cls,
+        connection: "psycopg.AsyncConnection",
+        *,
+        settings: qb.DBSettings | None = None,
+    ) -> "Queries":
         """Build Queries over a psycopg async connection (must have autocommit=True)."""
         from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
 
-        return cls(PsycopgDriver(connection))
+        return cls(PsycopgDriver(connection), settings=settings)
 
     async def install(self, create_schema: bool = True) -> None:
         """Create the schema (when configured), tables, types, indexes, triggers, and functions."""
@@ -681,18 +707,29 @@ class Queries:
         ]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(init=False)
 class SyncQueries:
     """Synchronous subset of :class:`Queries` (currently enqueue + queue_size)."""
 
     driver: SyncDriver
-
-    qbq: qb.QueryQueueBuilder = dataclasses.field(
-        default_factory=qb.QueryQueueBuilder,
-    )
-
-    # Optional injected tracer; falls back to the global ``tracing.TRACER.tracer``.
+    qbq: qb.QueryQueueBuilder
     tracer: TracingProtocol | None = None
+
+    def __init__(
+        self,
+        driver: SyncDriver,
+        qbq: qb.QueryQueueBuilder | None = None,
+        tracer: TracingProtocol | None = None,
+        *,
+        settings: qb.DBSettings | None = None,
+    ) -> None:
+        _, _, self.qbq, _ = qb.bind_repository_builders(settings, qbq=qbq)
+        self.driver = driver
+        self.tracer = tracer
+
+    @property
+    def settings(self) -> qb.DBSettings:
+        return self.qbq.settings
 
     @overload
     def enqueue(

--- a/pgqueuer/adapters/web/app.py
+++ b/pgqueuer/adapters/web/app.py
@@ -15,12 +15,14 @@ from pgqueuer.adapters.web.auth import PASSWORD_ENV, USER_ENV, create_basic_auth
 from pgqueuer.adapters.web.routes import create_web_router
 from pgqueuer.adapters.web.sse import Broadcaster
 from pgqueuer.core import logconfig
-from pgqueuer.domain.settings import ConnectionSettings
+from pgqueuer.domain.settings import ConnectionSettings, DBSettings
 
 
 def create_web_app(
     dsn: str | None = None,
     connection_settings: ConnectionSettings | None = None,
+    *,
+    settings: DBSettings | None = None,
 ) -> FastAPI:
     """Standalone dashboard app: asyncpg pool, NOTIFY-driven SSE, optional Basic auth.
 
@@ -37,21 +39,17 @@ def create_web_app(
     Auth is enabled only when PGQUEUER_WEB_USER and PGQUEUER_WEB_PASSWORD are set.
     """
 
+    database_settings = qb.resolve_settings(settings)
+
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         from pgqueuer.adapters.connections import create_asyncpg_pool
         from pgqueuer.adapters.drivers.asyncpg import AsyncpgPoolDriver
 
-        settings = qb.DBSettings()
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
             driver = AsyncpgPoolDriver(pool)
-            app.state.pgq_queries = queries.Queries(
-                driver,
-                qbe=qb.QueryBuilderEnvironment(settings),
-                qbq=qb.QueryQueueBuilder(settings),
-                qbs=qb.QuerySchedulerBuilder(settings),
-            )
-            broadcaster = Broadcaster(driver=driver, channel=settings.channel)
+            app.state.pgq_queries = queries.Queries(driver, settings=database_settings)
+            broadcaster = Broadcaster(driver=driver, channel=database_settings.channel)
             await broadcaster.start()
             app.state.pgq_broadcaster = broadcaster
             async with driver:

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -45,14 +45,16 @@ class PgQueuer:
     """
 
     connection: Driver
-    channel: Channel = dataclasses.field(
-        default=Channel(DBSettings().channel),
-    )
+    channel: Channel | None = None
     # Shared resources mapping passed to QueueManager and propagated into each job Context.
     resources: MutableMapping = dataclasses.field(
         default_factory=dict,
     )
     queries: RepositoryPort | None = dataclasses.field(default=None)
+    settings: dataclasses.InitVar[DBSettings | None] = dataclasses.field(
+        default=None,
+        kw_only=True,
+    )
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
         default_factory=asyncio.Event,
@@ -64,9 +66,13 @@ class PgQueuer:
         init=False,
     )
 
-    def __post_init__(self) -> None:
+    def __post_init__(self, settings: DBSettings | None) -> None:
         if self.queries is None:
-            self.queries = Queries(self.connection)
+            self.queries = Queries(self.connection, settings=settings)
+        elif settings is not None and self.queries.qbe.settings != settings:
+            raise ValueError("Injected queries and PgQueuer must use equivalent DBSettings.")
+        if self.channel is None:
+            self.channel = Channel(self.queries.qbe.settings.channel)
         self.qm = QueueManager(
             self.queries,
             self.channel,
@@ -85,12 +91,15 @@ class PgQueuer:
         connection: "asyncpg.Connection",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        *,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over an asyncpg connection."""
         return cls._from_driver(
             driver=AsyncpgDriver(connection),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -99,12 +108,15 @@ class PgQueuer:
         pool: "asyncpg.Pool",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        *,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over an asyncpg pool."""
         return cls._from_driver(
             driver=AsyncpgPoolDriver(pool),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -113,12 +125,15 @@ class PgQueuer:
         connection: "psycopg.AsyncConnection",
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        *,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Build PgQueuer over a psycopg async connection (must have autocommit=True)."""
         return cls._from_driver(
             driver=PsycopgDriver(connection),
             channel=channel,
             resources=resources,
+            settings=settings,
         )
 
     @classmethod
@@ -127,16 +142,23 @@ class PgQueuer:
         driver: Driver,
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        *,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
-        channel = channel or Channel(DBSettings().channel)
-        resources = resources or {}
-        return cls(connection=driver, channel=channel, resources=resources)
+        return cls(
+            connection=driver,
+            channel=channel,
+            resources=resources if resources is not None else {},
+            settings=settings,
+        )
 
     @classmethod
     def in_memory(
         cls,
         channel: Channel | None = None,
         resources: MutableMapping | None = None,
+        *,
+        settings: DBSettings | None = None,
     ) -> "PgQueuer":
         """Create a PgQueuer backed entirely by in-memory data structures.
 
@@ -144,13 +166,13 @@ class PgQueuer:
         and short-lived batch-processing containers.
         """
         driver = InMemoryDriver()
-        channel = channel or Channel(DBSettings().channel)
-        inmem = InMemoryQueries(driver=driver)
+        inmem = InMemoryQueries(driver=driver, settings=settings)
         return cls(
             connection=driver,
             channel=channel,
             queries=inmem,
-            resources=resources or {},
+            resources=resources if resources is not None else {},
+            settings=settings,
         )
 
     async def run(

--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from datetime import timedelta
 from itertools import chain
 
@@ -11,7 +11,7 @@ from pgqueuer.core import tm
 from pgqueuer.domain import models
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports.driver import Driver
-from pgqueuer.ports.repository import QueueRepositoryPort
+from pgqueuer.ports.repository import QueueRepositoryPort, SettingsRepositoryPort
 
 
 @dataclass
@@ -34,6 +34,8 @@ class CompletionWatcher:
 
     driver: Driver
     queries: QueueRepositoryPort = field(kw_only=True)
+    settings: InitVar[DBSettings | None] = field(default=None, kw_only=True)
+    channel: models.Channel | None = field(default=None, kw_only=True)
     refresh_interval: timedelta = field(
         default_factory=lambda: timedelta(seconds=5),
     )
@@ -68,9 +70,19 @@ class CompletionWatcher:
         repr=False,
     )
 
+    def __post_init__(self, settings: DBSettings | None) -> None:
+        if self.channel is not None:
+            return
+        if settings is None and isinstance(self.queries, SettingsRepositoryPort):
+            settings = self.queries.settings
+        if settings is None:
+            settings = DBSettings()
+        self.channel = models.Channel(settings.channel)
+
     async def __aenter__(self) -> "CompletionWatcher":
+        assert self.channel is not None
         self.task_manager.add(asyncio.create_task(self._poll_for_change()))
-        await self.driver.add_listener(DBSettings().channel, self._is_relevant_event)
+        await self.driver.add_listener(self.channel, self._is_relevant_event)
         self._schedule_refresh_waiters()
         return self
 

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -23,7 +23,6 @@ from pgqueuer.core import (
     tm,
 )
 from pgqueuer.domain import errors, models, types
-from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports import RepositoryPort, tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
@@ -38,9 +37,7 @@ class QueueManager:
     """
 
     queries: RepositoryPort
-    channel: models.Channel = dataclasses.field(
-        default=models.Channel(DBSettings().channel),
-    )
+    channel: models.Channel | None = None
 
     shutdown: asyncio.Event = dataclasses.field(
         init=False,
@@ -89,6 +86,10 @@ class QueueManager:
         init=False,
         default=timedelta(seconds=0.1),
     )
+
+    def __post_init__(self) -> None:
+        if self.channel is None:
+            self.channel = models.Channel(self.queries.qbe.settings.channel)
 
     async def listener_healthy(
         self,
@@ -397,6 +398,9 @@ class QueueManager:
         if max_concurrent_tasks < 2 * batch_size:
             raise RuntimeError("max_concurrent_tasks must be at least twice the batch size.")
 
+        assert self.channel is not None
+        channel = self.channel
+
         async with (
             buffers.JobStatusLogBuffer(
                 max_size=batch_size,
@@ -430,7 +434,7 @@ class QueueManager:
             notice_event_listener = listeners.PGNoticeEventListener()
             await listeners.initialize_notice_event_listener(
                 self.queries.driver,
-                self.channel,
+                channel,
                 listeners.default_event_router(
                     notice_event_queue=notice_event_listener,
                     canceled=self.job_context,

--- a/pgqueuer/ports/__init__.py
+++ b/pgqueuer/ports/__init__.py
@@ -9,6 +9,7 @@ from pgqueuer.ports.repository import (
     QueueRepositoryPort,
     ScheduleRepositoryPort,
     SchemaManagementPort,
+    SettingsRepositoryPort,
 )
 from pgqueuer.ports.tracing import TracingProtocol
 
@@ -31,6 +32,7 @@ __all__ = [
     "RepositoryPort",
     "ScheduleRepositoryPort",
     "SchemaManagementPort",
+    "SettingsRepositoryPort",
     "SyncDriver",
     "TracingProtocol",
 ]

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import uuid
 from datetime import timedelta
-from typing import Literal, Protocol, overload
+from typing import Literal, Protocol, overload, runtime_checkable
 
 from pgqueuer.domain import models
 from pgqueuer.domain.settings import DBSettings
@@ -17,6 +17,14 @@ class QueryBuilderEnvironmentPort(Protocol):
     """Protocol for query builder environment used in schema operations."""
 
     settings: DBSettings
+
+
+@runtime_checkable
+class SettingsRepositoryPort(Protocol):
+    """Repository exposing its canonical database settings."""
+
+    @property
+    def settings(self) -> DBSettings: ...
 
 
 @dataclasses.dataclass

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -26,12 +26,7 @@ WIDENED_ID_TABLES = [
 
 def queries_for(driver: db.Driver, settings: qb.DBSettings) -> Queries:
     """Queries wired to non-default DBSettings across all three builders."""
-    return Queries(
-        driver,
-        qbe=qb.QueryBuilderEnvironment(settings=settings),
-        qbq=qb.QueryQueueBuilder(settings=settings),
-        qbs=qb.QuerySchedulerBuilder(settings=settings),
-    )
+    return Queries(driver, settings=settings)
 
 
 async def id_data_type(driver: db.Driver, table: str, schema: str | None = None) -> str:

--- a/test/test_cli_sql.py
+++ b/test/test_cli_sql.py
@@ -54,6 +54,23 @@ def test_sql_commands_are_deterministic() -> None:
     assert first == second
 
 
+def test_sql_command_creates_one_settings_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings_type = cli.qb.DBSettings
+    created = list[object]()
+
+    def create_settings() -> object:
+        settings = settings_type()
+        created.append(settings)
+        return settings
+
+    monkeypatch.setattr(cli.qb, "DBSettings", create_settings)
+
+    result = CliRunner().invoke(app, ["sql", "upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert len(created) == 1
+
+
 def test_sql_install_respects_prefix_and_schema(monkeypatch: pytest.MonkeyPatch) -> None:
     # AppConfig.setup_env writes PGQUEUER_* into os.environ. Clear them for a
     # clean starting state; the autouse _restore_pgqueuer_env fixture in

--- a/test/test_completion.py
+++ b/test/test_completion.py
@@ -7,11 +7,23 @@ from datetime import timedelta
 import pytest
 
 from pgqueuer import db
+from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.core.completion import CompletionWatcher
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.models import Job
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
 from pgqueuer.types import QueueExecutionMode
+
+
+def test_completion_watcher_derives_channel_from_repository_settings() -> None:
+    settings = DBSettings(prefix="completion_")
+    driver = InMemoryDriver()
+    queries = InMemoryQueries(driver, settings=settings)
+
+    watcher = CompletionWatcher(driver, queries=queries)
+
+    assert watcher.channel == settings.channel
 
 
 async def test_completion_successful(apgdriver: db.Driver) -> None:

--- a/test/test_connections.py
+++ b/test/test_connections.py
@@ -10,7 +10,6 @@ import pytest
 
 from pgqueuer.adapters import connections
 from pgqueuer.adapters.cli.cli import AppConfig, create_default_queries_factory
-from pgqueuer.adapters.persistence.qb import DBSettings
 from pgqueuer.domain.settings import ConnectionSettings
 
 pytestmark = pytest.mark.usefixtures("clean_connection_env")
@@ -118,7 +117,7 @@ async def run_cli_factory_capturing(
         return FakeConnection()  # AsyncpgDriver only stores the connection at init.
 
     monkeypatch.setattr(asyncpg, "connect", fake_connect)
-    factory = create_default_queries_factory(config, DBSettings())
+    factory = create_default_queries_factory(config)
     async with factory():
         pass
     return captured

--- a/test/test_inmemory.py
+++ b/test/test_inmemory.py
@@ -11,11 +11,24 @@ import time_machine
 
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.domain.errors import DuplicateJobError
+from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 # ---------------------------------------------------------------------------
 # Enqueue
 # ---------------------------------------------------------------------------
+
+
+def test_settings_are_shared_and_scoped_per_repository() -> None:
+    first_settings = DBSettings(prefix="first_")
+    second_settings = DBSettings(prefix="second_")
+    first = InMemoryQueries(InMemoryDriver(), settings=first_settings)
+    second = InMemoryQueries(InMemoryDriver(), settings=second_settings)
+
+    assert first.settings is first.qbe.settings is first.qbq.settings is first.qbs.settings
+    assert first.settings is first_settings
+    assert second.settings is second_settings
+    assert first.settings is not second.settings
 
 
 async def test_enqueue_single(queries: InMemoryQueries) -> None:

--- a/test/test_pgqueuer.py
+++ b/test/test_pgqueuer.py
@@ -12,6 +12,16 @@ from pgqueuer.models import CronExpressionEntrypoint, Job, Schedule
 from test.helpers import wait_until_empty_queue
 
 
+def test_pgqueuer_reuses_settings_for_repository_and_channel() -> None:
+    settings = DBSettings(prefix="custom_")
+    pgq = PgQueuer.in_memory(settings=settings)
+
+    assert pgq.queries is not None
+    assert pgq.queries.qbe.settings is settings
+    assert pgq.channel == settings.channel
+    assert pgq.qm.channel == settings.channel
+
+
 async def test_pgqueuer_delegates_to_queue_manager(apgdriver: db.Driver) -> None:
     """Smoke test: PgQueuer wiring delegates entrypoint registration and job
     processing to the underlying QueueManager correctly."""

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -12,7 +12,7 @@ from pgqueuer import db
 from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core.cache import TTLCache
 from pgqueuer.core.tm import TaskManager
-from pgqueuer.models import Job, Log
+from pgqueuer.models import Channel, Job, Log
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
 from pgqueuer.types import QueueExecutionMode
@@ -176,7 +176,7 @@ async def test_periodic_log_aggregation_loops_until_shutdown() -> None:
             if calls >= 3:
                 qm.shutdown.set()
 
-    qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
+    qm = QueueManager(queries=Stub(), channel=Channel("test"))  # type: ignore[arg-type]
 
     async def keep_marking_work() -> None:
         # Stands in for `_dispatch` incrementing `jobs_logged` concurrently;
@@ -208,7 +208,7 @@ async def test_periodic_log_aggregation_skips_when_idle() -> None:
             nonlocal calls
             calls += 1
 
-    qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
+    qm = QueueManager(queries=Stub(), channel=Channel("test"))  # type: ignore[arg-type]
     task = asyncio.ensure_future(qm._run_periodic_log_aggregation(timedelta(seconds=0)))
     try:
         for _ in range(3):
@@ -255,7 +255,7 @@ async def test_periodic_log_aggregation_survives_aggregate_errors() -> None:
                 qm.shutdown.set()
             raise RuntimeError("boom")
 
-    qm = QueueManager(queries=Stub())  # type: ignore[arg-type]
+    qm = QueueManager(queries=Stub(), channel=Channel("test"))  # type: ignore[arg-type]
     qm.jobs_logged = 1
     async with async_timeout.timeout(5):
         await qm._run_periodic_log_aggregation(timedelta(seconds=0))

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -978,6 +978,16 @@ async def test_enqueue_with_headers(apgdriver: db.Driver) -> None:
     await q.log_jobs([(jobs[0], "successful", None)])
 
 
+async def test_queries_share_injected_settings_across_builders(apgdriver: db.Driver) -> None:
+    settings = DBSettings(prefix="shared_")
+    q = queries.Queries(apgdriver, settings=settings)
+
+    assert q.settings is settings
+    assert q.qbe.settings is settings
+    assert q.qbq.settings is settings
+    assert q.qbs.settings is settings
+
+
 async def test_queries_from_asyncpg_connection(dsn: str) -> None:
     """Test creating Queries from an asyncpg connection."""
     connection = await asyncpg.connect(dsn=dsn)


### PR DESCRIPTION
## Summary
- Create one `DBSettings` instance per application/CLI graph and reuse it across query builders, managers, and listen channels
- Add optional `settings=` injection on public constructors (`Queries`, `PgQueuer`, web, MCP) and export `DBSettings` from `pgqueuer`
- Derive default channels from the canonical settings so custom prefixes/schemas cannot diverge mid call-chain

## Test plan
- [x] `uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy .`
- [x] Focused settings/CLI/completion/QM tests
- [x] Full pytest suite
- [ ] Confirm custom `DBSettings(prefix=..., db_schema=...)` flows through `Queries` → `PgQueuer` → listen channel
- [ ] Confirm `pgq --prefix/--schema sql install` and dry-run uninstall/autovac emit matching object names