### PR TITLE
docs: tighten prose on the landing and getting-started pages

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -1,7 +1,5 @@
 # Core Concepts
 
-This page explains the key abstractions in PgQueuer.
-
 ---
 
 ## Jobs
@@ -50,7 +48,7 @@ When a job with `entrypoint="send_email"` is dequeued, PgQueuer calls this funct
         await asyncio.to_thread(cpu_bound_resize, job.payload)
     ```
 
-### Entrypoint Parameters
+### Entrypoint parameters
 
 The `@entrypoint()` decorator accepts several parameters that control how jobs are processed:
 
@@ -64,7 +62,7 @@ The `@entrypoint()` decorator accepts several parameters that control how jobs a
 
 ---
 
-## Job Status Lifecycle
+## Job status lifecycle
 
 Every job transitions through a series of states. The status is stored as the
 `pgqueuer_status` PostgreSQL enum with seven values:
@@ -184,7 +182,7 @@ asyncio event loop.
 
 ---
 
-## Database Tables
+## Database tables
 
 PgQueuer creates four tables:
 
@@ -200,9 +198,7 @@ See [Database Setup](../reference/database-setup.md) for full schema details and
 
 ---
 
-## Next Steps
-
-Now that you understand the building blocks:
+## Next steps
 
 - **[Row Locking & SKIP LOCKED](../reference/skip-locked.md)**: how workers claim jobs without colliding
 - **[Scheduling](../guides/scheduling.md)**: set up cron-style recurring tasks

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Install the Package
+## Install the package
 
 PgQueuer supports two PostgreSQL drivers. Choose the one that fits your stack:
 
@@ -49,7 +49,7 @@ PgQueuer supports two PostgreSQL drivers. Choose the one that fits your stack:
     pip install pgqueuer[asyncpg,logfire]
     ```
 
-## Set Up the Database Schema
+## Set up the database schema
 
 PgQueuer stores jobs, schedules, and logs in PostgreSQL tables. Create them with the CLI:
 
@@ -78,7 +78,7 @@ This creates the following objects in your database:
     pgq sql install | psql -v ON_ERROR_STOP=1
     ```
 
-## Verify the Installation
+## Verify the installation
 
 Confirm all PgQueuer objects are present:
 
@@ -88,7 +88,7 @@ pgq verify --expect present
 
 This exits with code 0 if the schema is correctly installed, or code 1 if anything is missing.
 
-## Connection Configuration
+## Connection configuration
 
 PgQueuer is bring-your-own-connection: your application opens the connection
 or pool with asyncpg/psycopg directly and wraps it in a driver. PgQueuer never
@@ -106,7 +106,7 @@ The drivers read the standard PostgreSQL environment variables:
 | `PGPASSWORD` | Database password | (none) |
 | `PGDATABASE` | Database name | same as user |
 
-### Pool and Connection Tuning
+### Pool and connection tuning
 
 When the `pgq` CLI and the MCP server open their own connection, they read
 `PGQUEUER_*` variables. Passing your own factory (`pgq --factory`) skips
@@ -136,7 +136,7 @@ async with create_asyncpg_pool(settings=ConnectionSettings(pool_max_size=10)) as
     ...
 ```
 
-### libpq Environment Variable Support
+### libpq environment variable support
 
 psycopg links the real libpq, so every libpq variable works there. asyncpg
 reimplements the parsing and supports a subset:
@@ -156,7 +156,7 @@ On the asyncpg path PgQueuer fills the `PGCONNECT_TIMEOUT` gap itself:
 `PGQUEUER_CONNECT_TIMEOUT` takes precedence, then `PGCONNECT_TIMEOUT`, then
 the driver default.
 
-## Custom Schema
+## Custom schema
 
 To keep PgQueuer objects out of `public`, install into a dedicated Postgres schema:
 
@@ -172,7 +172,7 @@ through that schema, so the setting works regardless of the connection's
 `search_path`. The NOTIFY channel is unaffected: channels are global to the
 database, not schema-scoped.
 
-## Table Prefix
+## Table prefix
 
 To run multiple isolated PgQueuer instances in the same database (or the same
 schema), set a custom prefix:
@@ -186,7 +186,7 @@ This prefixes all table names, the enum type, the trigger, and the NOTIFY channe
 The two settings are independent: a prefix separates instances that share a
 schema, and `PGQUEUER_SCHEMA` moves the whole installation into another schema.
 
-## Next Steps
+## Next steps
 
 - **[Quick Start](quickstart.md)**: build your first consumer and producer
 - **[Core Concepts](core-concepts.md)**: understand the mental model behind PgQueuer

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,7 +8,7 @@ if you haven't done that yet.
 
 ---
 
-## 1. Define a Consumer
+## 1. Define a consumer
 
 Create a file called `myapp.py`. PgQueuer uses a factory pattern: you write an
 `@asynccontextmanager` function that yields a configured `PgQueuer` instance.
@@ -120,7 +120,7 @@ Create a file called `myapp.py`. PgQueuer uses a factory pattern: you write an
 
 ---
 
-## 2. Run the Consumer
+## 2. Run the consumer
 
 ```bash
 pgq run myapp:main
@@ -136,7 +136,7 @@ The `run` command:
 
 ---
 
-## 3. Enqueue Jobs
+## 3. Enqueue jobs
 
 From another process or script, push jobs into the queue:
 
@@ -198,7 +198,7 @@ This refreshes every 5 seconds and shows jobs per entrypoint, status counts, and
 
 ---
 
-## What's Next?
+## What's next?
 
 You now have a working PgQueuer setup. Here's where to go from here:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,9 @@ That gives you:
 - **One fewer service** to provision, monitor, and keep available
 - **Transactional enqueuing**: commit a job in the same transaction as your application data
 - **Consistent state**: your queue and your data always agree because they share the same database
-- **Lower latency**: jobs stay local, no round-trip to an external broker
+- **Lower latency**: jobs stay in the database instead of round-tripping to an external broker
 
-## How PgQueuer Works
+## How PgQueuer works
 
 PgQueuer builds on standard PostgreSQL primitives to deliver jobs safely and fast:
 
@@ -48,7 +48,7 @@ PgQueuer builds on standard PostgreSQL primitives to deliver jobs safely and fas
                               └────────────────────────────────┘
 ```
 
-## A Taste of PgQueuer
+## A taste of PgQueuer
 
 Define a consumer, register job handlers, and run:
 
@@ -75,13 +75,13 @@ pgq install          # create the schema
 pgq run myapp:main   # start processing
 ```
 
-That's it. Just PostgreSQL and your application code.
+That is the whole setup: PostgreSQL and your application code.
 
 [Full Quick Start Guide](getting-started/quickstart.md){ .md-button }
 
 ---
 
-## Key Features
+## Key features
 
 <div class="grid cards" markdown>
 
@@ -90,8 +90,8 @@ That's it. Just PostgreSQL and your application code.
     ---
 
     PostgreSQL `LISTEN/NOTIFY` pushes jobs to workers instantly.
-    A trigger on the queue table fires `pg_notify()` on every insert --
-    workers wake up immediately without polling.
+    A trigger on the queue table fires `pg_notify()` on every insert, so
+    workers wake up immediately instead of polling.
 
 -   **Concurrency Control**
 
@@ -168,7 +168,7 @@ That's it. Just PostgreSQL and your application code.
 
 ---
 
-## PgQueuer vs Celery at a Glance
+## PgQueuer vs Celery at a glance
 
 | Concern | PgQueuer | Celery |
 |---------|----------|--------|
@@ -187,7 +187,7 @@ are backed by PostgreSQL and you want a simpler operational footprint.
 
 ---
 
-## Next Steps
+## Next steps
 
 - **[Installation](getting-started/installation.md)**: install PgQueuer and set up the database schema
 - **[Quick Start](getting-started/quickstart.md)**: build your first consumer and producer in 5 minutes


### PR DESCRIPTION
Cut the intro lines that restated their own heading, replace the double hyphen standing in for an em dash, and reword the setup summary. Section headings below the page title move to sentence case.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
