### PR TITLE
docs: rewrite reference-page intros in plain prose

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,10 +1,10 @@
 # Architecture
 
-This overview explains how data flows from a producer to a consumer in PgQueuer.
-It highlights how entrypoints route jobs and how PostgreSQL notifications keep
-consumers up to date.
+A job travels from producer to consumer through PostgreSQL: the producer inserts a
+row, a trigger fires a notification, and a consumer claims the row and runs the
+matching entrypoint.
 
-## Job Flow Diagram
+## Job flow diagram
 
 ```
 Producer ──enqueue──▶ PostgreSQL ──NOTIFY──▶ EventRouter
@@ -21,14 +21,14 @@ Producer ──enqueue──▶ PostgreSQL ──NOTIFY──▶ EventRouter
 1. **Producer** inserts a job using `Queries.enqueue()`.
 2. A trigger emits a `table_changed_event` via **NOTIFY** on the configured channel.
 3. The **EventRouter** places the event in a `PGNoticeEventListener` queue.
-4. The **QueueManager** waits for events, fetches ready jobs with `FOR UPDATE SKIP LOCKED` (see [Row Locking & SKIP LOCKED](skip-locked.md) for a deep dive), and dispatches them to registered entrypoints.
+4. The **QueueManager** waits for events, fetches ready jobs with `FOR UPDATE SKIP LOCKED` (see [Row Locking & SKIP LOCKED](skip-locked.md) for the mechanics), and dispatches them to registered entrypoints.
 5. After execution, the **Consumer** updates job status back in PostgreSQL.
 
-Endpoint routing is handled by `EventRouter` which maps notification types to
-functions registered via `@pgq.entrypoint`. Notifications delivered through
-`LISTEN/NOTIFY` ensure consumers promptly react to new work.
+`EventRouter` maps notification types to the functions registered via
+`@pgq.entrypoint`. Because the notification arrives over `LISTEN/NOTIFY`, a
+consumer picks up new work without waiting for its next poll.
 
-## QueueManager Processing Loop
+## QueueManager processing loop
 
 ```
               ┌──────────────────┐
@@ -53,7 +53,7 @@ functions registered via `@pgq.entrypoint`. Notifications delivered through
               └──────────────┴──────────────────────────┘
 ```
 
-## Job Status Lifecycle
+## Job status lifecycle
 
 PgQueuer tracks each job's progress using a dedicated PostgreSQL ENUM type,
 `pgqueuer_status` by default:
@@ -85,7 +85,7 @@ The lifecycle of a job flows through these statuses:
 - **`deleted`**: Used when jobs are removed from the queue without running, such as during
   manual cleanup operations.
 
-### Status Transition Diagram
+### Status transition diagram
 
 ```
                   ┌────────┐

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,7 +1,7 @@
 # CLI Reference
 
-The `pgq` CLI provides a command-line interface for managing all aspects of PgQueuer.
-It can be invoked as `pgq` or `python3 -m pgqueuer`.
+The `pgq` CLI installs, inspects, and runs PgQueuer. Invoke it as `pgq` or
+`python3 -m pgqueuer`.
 
 ## Commands
 
@@ -275,7 +275,7 @@ pgq run my_module:my_factory --max-concurrent-tasks 5
 pgq run my_module:my_factory --mode drain
 ```
 
-#### Execution Modes
+#### Execution modes
 
 - **continuous** *(default)*: Keeps processing jobs indefinitely, waiting for new ones.
 - **drain**: Processes all available jobs and shuts down once the queue is empty.
@@ -284,10 +284,10 @@ Use **continuous** for long-running workers and **drain** for batch processing.
 
 ---
 
-## Durability Levels Explained
+## Durability levels
 
-Durability controls the logging behavior of PgQueuer tables, affecting performance and
-crash recovery.
+Durability controls whether PgQueuer tables are WAL-logged, which trades write speed
+against crash recovery.
 
 ### Volatile
 
@@ -310,12 +310,12 @@ crash recovery.
 
 ---
 
-## Factory Pattern (`run` command)
+## Factory pattern (`run` command)
 
 The `run` command uses a factory pattern. Your factory function creates and configures the
 manager instance; the CLI loads it, calls it, and runs the returned manager until shutdown.
 
-### Execution Flow
+### Execution flow
 
 ```
 pgq run my_module:factory
@@ -344,7 +344,7 @@ pgq run my_module:factory
       SHUTDOWN        (if --restart-on-failure)
 ```
 
-### Factory Contract
+### Factory contract
 
 The factory **must** return an `AsyncContextManager` (typically via `@asynccontextmanager`).
 Bare awaitables and sync context managers are **not** accepted; passing one raises
@@ -384,20 +384,20 @@ async def create_pgqueuer(args: list[str]):
     yield pgq
 ```
 
-### Key Points
+### Things worth knowing
 
-- **Factory runs on each restart**: With `--restart-on-failure`, the factory executes again
-  after failures, creating fresh connections and state.
-- **Async context manager is required**: Use `@asynccontextmanager` with `yield`.
-- **Extra args via `--`**: Arguments after `--` are passed as `list[str]` to the factory.
-  Factories that don't need args omit the parameter.
-- **Shutdown is graceful**: In-flight jobs complete before teardown runs.
+- With `--restart-on-failure`, the factory runs again after each failure, so every restart
+  gets fresh connections and state.
+- The factory must be an `@asynccontextmanager` that yields; nothing else is accepted.
+- Arguments after `--` reach the factory as `list[str]`. Factories that don't need them
+  omit the parameter.
+- Shutdown is graceful: in-flight jobs complete before teardown runs.
 
 See `examples/consumer.py` in the repository for a working example.
 
 ---
 
-## Global Options
+## Global options
 
 All commands accept the following connection options:
 

--- a/docs/reference/database-permissions.md
+++ b/docs/reference/database-permissions.md
@@ -3,7 +3,7 @@
 This page lists every PostgreSQL object PgQueuer creates, the privileges needed to install
 the schema, and the minimal runtime privileges for the application user.
 
-## Objects Created by `pgq install`
+## Objects created by `pgq install`
 
 | Object | Name | Type |
 |--------|------|------|
@@ -19,7 +19,7 @@ the schema, and the minimal runtime privileges for the application user.
 The trigger calls `pg_notify()` to emit a `table_changed_event` on the configured channel
 (`ch_pgqueuer` by default) whenever the queue table changes.
 
-## Installation Privileges
+## Installation privileges
 
 The database role that runs `pgq install` needs:
 
@@ -42,7 +42,7 @@ GRANT CREATE ON SCHEMA pgqueuer_schema TO pgqueuer_installer;
     grant minimal runtime privileges to the application role separately. The installer role
     does not need to be the role your application runs as.
 
-## Runtime Privileges
+## Runtime privileges
 
 The role your application uses at runtime needs significantly fewer permissions:
 
@@ -77,7 +77,7 @@ GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO pgqueuer_app;
     invoker. The application also needs to issue `LISTEN ch_pgqueuer`, which requires no
     special privilege beyond a database connection.
 
-## Recommended: Dedicated Schema
+## Recommended: dedicated schema
 
 For stronger isolation, install PgQueuer into its own schema:
 
@@ -104,7 +104,7 @@ privileges above). This separates PgQueuer objects from application tables and
 makes privilege management cleaner: you can grant or revoke schema-level access
 as a single operation.
 
-## Verifying Permissions
+## Verifying permissions
 
 Use `pgq verify` to confirm the schema is correctly installed:
 

--- a/docs/reference/database-setup.md
+++ b/docs/reference/database-setup.md
@@ -3,7 +3,7 @@
 PgQueuer requires initial setup in your PostgreSQL database: tables, triggers, and functions
 for job queuing and processing.
 
-## Table Structure
+## Table structure
 
 PgQueuer uses four primary tables:
 
@@ -64,7 +64,7 @@ pgq verify --expect absent
 
 The command exits with code `1` if any mismatches are detected.
 
-## Adjusting Durability
+## Adjusting durability
 
 PgQueuer tables are installed with **durable** settings by default. You can select a
 different durability level at install time:
@@ -81,7 +81,7 @@ pgq durability volatile
 
 See [CLI Reference](cli.md) for full details on `volatile`, `balanced`, and `durable` modes.
 
-## Autovacuum Optimization
+## Autovacuum optimization
 
 After installation, tune PostgreSQL autovacuum settings for PgQueuer tables:
 

--- a/docs/reference/drivers.md
+++ b/docs/reference/drivers.md
@@ -1,15 +1,8 @@
 # Drivers
 
-Drivers act as the bridge between PgQueuer and PostgreSQL, managing connections and
-abstracting database communication.
-
-## Purpose
-
-Drivers:
-
-- Manage database connections and enforce required configuration (e.g., autocommit).
-- Abstract the PostgreSQL-specific features that queue operations rely on.
-- Provide a consistent interface for executing queries.
+A driver wraps a PostgreSQL connection and gives PgQueuer one interface for running
+queries and receiving notifications, whichever underlying library you use. It also
+enforces the configuration queue operations depend on, autocommit in particular.
 
 ## Requirements
 
@@ -25,7 +18,7 @@ For any driver:
 3. **Default isolation level**: Connections should maintain the default PostgreSQL
    isolation level unless explicitly modified.
 
-## Driver Protocol
+## Driver protocol
 
 Every driver implements `pgqueuer.ports.driver.Driver`. Built-ins:
 `AsyncpgDriver`, `AsyncpgPoolDriver`, `PsycopgDriver`, `SyncPsycopgDriver`, and
@@ -58,7 +51,7 @@ async def notify(self, channel: str, payload: str) -> None:
     await self.execute("SELECT pg_notify($1, $2)", channel, payload)
 ```
 
-## Asynchronous Drivers
+## Asynchronous drivers
 
 ### `AsyncpgDriver`
 
@@ -96,7 +89,7 @@ driver = PsycopgDriver(conn)
     The `pgq` CLI handles this automatically. See the
     [psycopg async docs](https://www.psycopg.org/psycopg3/docs/advanced/async.html).
 
-## Synchronous Driver
+## Synchronous driver
 
 ### `SyncPsycopgDriver`
 
@@ -114,7 +107,7 @@ queries = SyncQueries(driver)
 queries.enqueue("fetch", b"payload")
 ```
 
-## Creating PgQueuer Instances with Classmethods
+## Creating PgQueuer instances with classmethods
 
 PgQueuer provides classmethods that handle driver instantiation automatically:
 
@@ -160,7 +153,7 @@ pgq = PgQueuer.from_psycopg_connection(connection)
 await pgq.run()
 ```
 
-## Classmethod Parameters
+## Classmethod parameters
 
 All classmethods accept:
 
@@ -170,13 +163,12 @@ All classmethods accept:
 | `channel` | No | Custom `Channel` configuration. Defaults to `Channel(DBSettings().channel)` |
 | `resources` | No | Mutable mapping for shared resources. Defaults to `{}` |
 
-## Best Practices
+## Recommendations
 
 - Prefer an async driver when your project already runs on asyncio.
 - Use the sync driver only to enqueue jobs from short-lived scripts or WSGI applications.
-- Reuse connections or pools; keep autocommit enabled.
-- Use the PgQueuer classmethods for simplified setup.
-- When using psycopg, always ensure autocommit is enabled before passing the connection.
+- Reuse connections or pools rather than opening one per enqueue.
+- With psycopg, set autocommit before you hand the connection to a driver.
 
 ## Troubleshooting
 

--- a/docs/reference/in-memory.md
+++ b/docs/reference/in-memory.md
@@ -1,7 +1,5 @@
 # In-Memory Adapter
 
-## Overview
-
 The in-memory adapter is a drop-in replacement for the PostgreSQL backend, so PgQueuer
 can run entirely without a database connection. Located in `pgqueuer.adapters.inmemory`, it
 provides `InMemoryDriver` and `InMemoryQueries` classes that satisfy the same
@@ -24,7 +22,7 @@ Or import the classes directly:
 from pgqueuer import InMemoryDriver, InMemoryQueries
 ```
 
-## Quick Start
+## Quick start
 
 ```python
 import asyncio
@@ -56,26 +54,23 @@ async def main():
 asyncio.run(main())
 ```
 
-## When to Use the In-Memory Adapter
+## When to use the in-memory adapter
 
-**Recommended for:**
+Reach for it when the queue only has to live as long as one process:
 
-- **Unit and integration tests**: no PostgreSQL instance or Docker container required
-- **CI/CD pipelines**: resource-constrained environments (GitHub Actions, lightweight containers)
-- **Local development**: prototype queue logic without infrastructure setup
-- **Short-lived batch containers**: process a fixed job set and discard (ETL, one-time cleanup)
-- **Proof-of-concept**: quickly demonstrate queue logic
+- Unit and integration tests, with no PostgreSQL instance or Docker container to start
+- CI pipelines on resource-constrained runners (GitHub Actions, lightweight containers)
+- Local development and prototyping, before you set up infrastructure
+- Short-lived batch containers that process a fixed job set and exit (ETL, one-time cleanup)
 
-**Not suitable for:**
+Avoid it when any of the following matter:
 
-- **Production workloads requiring durability**: any restart loses all queued and in-flight jobs
-- **Multi-process workers**: no visibility across processes
-- **Multi-node / distributed deployments**: no shared state between machines
-- **Long-running services**: process restarts lose data
-- **ACID transaction guarantees**: no rollback or atomic retry semantics
-- **Monitoring and observability**: no external store for post-exit inspection
+- Durability. A restart loses every queued and in-flight job, so nothing survives a crash.
+- More than one process or machine. Jobs are invisible outside the process that enqueued them.
+- Transactions. There is no rollback and no atomic retry.
+- Post-mortem inspection. Once the process exits, the job history is gone.
 
-## Limitations Reference
+## Limitations reference
 
 | Capability | PostgreSQL adapter | In-memory adapter |
 |---|---|---|
@@ -87,27 +82,27 @@ asyncio.run(main())
 | **Schema operations** | DDL executed | No-ops (always return True) |
 | **Performance** | Bounded by network I/O | CPU-bound; O(n) dequeue scan |
 
-## Implementation Notes
+## Implementation notes
 
 ### `driver.fetch()` and `driver.execute()`
 
 Both methods raise `NotImplementedError` by design. `InMemoryQueries` operates directly on
 in-memory dictionaries and never executes SQL.
 
-### Event Loop Yielding
+### Event loop yielding
 
 The `dequeue()` method includes an explicit `await asyncio.sleep(0)` to yield control to
 the event loop. This is critical: without it, `QueueManager.fetch_jobs` would starve signal
 handlers, timers, and concurrent jobs. The PostgreSQL adapter naturally yields during real
 I/O; the in-memory adapter must do so explicitly.
 
-### Schema Management
+### Schema management
 
 - `install()`, `upgrade()`: no-ops
 - `uninstall()`: clears all internal dictionaries, resetting queue state
 - Schema inspection methods always return `True`
 
-### Job State
+### Job state
 
 The adapter maintains job state using plain Python dictionaries:
 

--- a/docs/reference/ports-and-adapters.md
+++ b/docs/reference/ports-and-adapters.md
@@ -33,7 +33,7 @@ Migrate PgQueuer to a Ports & Adapters structure using Python `Protocol` classes
 definitions and dependency injection to wire adapters. The migration is incremental
 (strangler fig) and must not break the public API.
 
-### Constraint: Zero Unnecessary Breaking Changes
+### Constraint: zero unnecessary breaking changes
 
 The following imports must continue to work throughout all phases:
 
@@ -47,7 +47,7 @@ from pgqueuer import (
 The decorator APIs `.entrypoint()` and `.schedule()` must remain stable. When modules move
 to new paths, thin re-export shims preserve the old import locations.
 
-### Port Definitions
+### Port definitions
 
 Ports are `Protocol` classes living in `pgqueuer/ports/`. They capture what the core needs
 without specifying how.
@@ -101,7 +101,7 @@ class SchemaManagementPort(Protocol):
 The existing `Queries` class satisfies all four ports via structural subtyping. No
 inheritance or registration required.
 
-### Existing Ports (Already In Place)
+### Existing ports (already in place)
 
 - **`Driver`** (`pgqueuer.ports.driver`): database execution abstraction.
   Methods: `fetch`, `execute`, `add_listener`, `notify`. Adapters:
@@ -110,7 +110,7 @@ inheritance or registration required.
 - **`TracingProtocol`** (`pgqueuer.ports.tracing`): distributed tracing.
   Adapters: `LogfireTracing`, `SentryTracing`, `OpenTelemetryTracing`.
 
-### Dependency Injection Pattern
+### Dependency injection pattern
 
 `QueueManager` and `SchedulerManager` accept a `queries` argument (a `RepositoryPort`)
 as the first positional parameter. The underlying driver is accessed via
@@ -136,7 +136,7 @@ qm = QueueManager(Queries(driver))
 when a caller passes a `Driver` directly, so `PgQueuer(driver)` still works.
 `QueueManager` and `SchedulerManager` no longer build adapters themselves.
 
-### Target Directory Layout
+### Target directory layout
 
 ```
 pgqueuer/
@@ -193,7 +193,7 @@ removed; import from the canonical location under `pgqueuer.core.*`,
 `pgqueuer.adapters.*`, or `pgqueuer.ports.*` instead. See breaking change #11
 in the v1.0.0 release notes for the full mapping.
 
-### Migration Phases
+### Migration phases
 
 **Phase 0**: ~~Deprecate unused infrastructure fields in executor parameters.~~ Done; deprecated fields removed.
 
@@ -231,7 +231,7 @@ Phase 3 ──┘
 - Developers must learn the directory conventions and respect import boundaries.
 - Protocol definitions add surface area that must stay in sync with `Queries`.
 
-### Risks and Mitigations
+### Risks and mitigations
 
 | Risk | Mitigation |
 |------|-----------|


### PR DESCRIPTION
Say what a driver is instead of listing generic bullets, drop the bolded labels and duplicate entries from the in-memory suitability lists, and turn the CLI factory notes into sentences. Section headings below the page title move to sentence case.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
