### PR TITLE
docs: describe mechanisms directly in the guides

### DIFF
--- a/docs/guides/completion-tracking.md
+++ b/docs/guides/completion-tracking.md
@@ -10,7 +10,7 @@
 | `refresh_interval` | `timedelta \| None` | **5 s** | Safety-net poll in case a `NOTIFY` was lost. Pass `None` to disable polling and rely solely on notifications |
 | `debounce` | `timedelta` | **50 ms** | Coalesces bursts of `NOTIFY`s to reduce query load |
 
-## Basic Usage
+## Basic usage
 
 ```python
 from pgqueuer.core.completion import CompletionWatcher
@@ -23,7 +23,7 @@ async with CompletionWatcher(driver, queries=queries) as watcher:
     # status: "successful", "exception", "canceled", or "deleted"
 ```
 
-### Completion Watcher State Flow
+### Completion watcher state flow
 
 The watcher monitors a job's progression until it reaches a **terminal state**:
 
@@ -55,7 +55,7 @@ The watcher monitors a job's progression until it reaches a **terminal state**:
     only on `successful`, `exception`, `canceled`, or `deleted`. A held job stays
     unresolved until it is re-queued and reaches one of those states.
 
-## Tracking Many Jobs at Once
+## Tracking many jobs at once
 
 ```python
 from asyncio import gather
@@ -79,10 +79,9 @@ async with CompletionWatcher(driver, queries=queries) as w:
 
 Terminal states: `canceled`, `deleted`, `exception`, `successful`.
 
-## Helper Patterns
+## Helper patterns
 
-Below are two ready-to-use patterns you can copy into your own code for common
-completion-tracking scenarios.
+Two patterns to copy into your own code.
 
 ### Wait for all jobs
 
@@ -139,18 +138,18 @@ async def wait_for_first(
     return next(iter(done)).result()
 ```
 
-## Notification Reliability
+## Notification reliability
 
-To improve reliability without heavy polling:
+Two settings keep the watcher reliable without leaning on the refresh poll.
 
-1. **Listener health check**: Run with the `pgq run --shutdown-on-listener-failure` flag
-   (or pass `shutdown_on_listener_failure=True` to `QueueManager.run()`) so the manager stops
-   (and can be restarted by a supervisor) if the LISTEN channel becomes unhealthy.
+Run with `pgq run --shutdown-on-listener-failure` (or pass
+`shutdown_on_listener_failure=True` to `QueueManager.run()`) so the manager stops when the
+LISTEN channel goes unhealthy and a supervisor can restart it.
 
-2. **Minimize the refresh poll**: Set a long `refresh_interval` to rely primarily on
-   notifications when your channel is stable:
+Then, if the channel is stable, raise `refresh_interval` so notifications carry the traffic
+and the poll stays a fallback:
 
-    ```python
-    async with CompletionWatcher(driver, queries=Queries(driver), refresh_interval=timedelta(minutes=5)) as w:
-        status = await w.wait_for(job_id)
-    ```
+```python
+async with CompletionWatcher(driver, queries=Queries(driver), refresh_interval=timedelta(minutes=5)) as w:
+    status = await w.wait_for(job_id)
+```

--- a/docs/guides/concurrency-control.md
+++ b/docs/guides/concurrency-control.md
@@ -5,7 +5,7 @@ Concurrency limits are enforced **globally** at the database
 level via the dequeue SQL query, not per-worker. If you set `concurrency_limit=5`,
 at most 5 jobs run across your entire fleet.
 
-## Concurrency Limiting
+## Concurrency limiting
 
 Limit the number of jobs of a given type that run simultaneously:
 
@@ -18,7 +18,7 @@ async def process_data(job: Job) -> None:
 This is useful for protecting external services with connection pool limits or
 memory-intensive operations.
 
-## Serialized Processing
+## Serialized processing
 
 Ensure jobs of the same type are processed strictly one at a time:
 
@@ -31,7 +31,7 @@ async def process_shared_resource(job: Job) -> None:
 Setting `concurrency_limit=1` guarantees that only one job of this entrypoint runs
 at a time across all workers.
 
-## Global Concurrency Limit
+## Global concurrency limit
 
 You can also cap the total number of concurrently running tasks across **all** entrypoints
 at the worker level using the CLI flag:
@@ -42,7 +42,7 @@ pgq run myapp:main --max-concurrent-tasks 20
 
 This limits the total across all entrypoints regardless of individual entrypoint settings.
 
-## Combining Controls
+## Combining controls
 
 You can combine concurrency limits with other entrypoint options:
 
@@ -56,7 +56,7 @@ async def call_external_api(job: Job) -> None:
     pass
 ```
 
-## Configuring Timeouts
+## Configuring timeouts
 
 Two parameters on `pgq.run()` control job processing timing:
 

--- a/docs/guides/custom-executors.md
+++ b/docs/guides/custom-executors.md
@@ -1,20 +1,13 @@
 # Custom Executors
 
-Executors define how jobs are processed once dequeued. PgQueuer provides a default executor,
-but you can create custom executors to introduce specialized behavior such as advanced logging,
-conditional execution, or retry logic.
+Executors define how jobs are processed once dequeued. The default executor calls your
+handler and lets exceptions propagate. A custom executor sits in the same place but can
+wrap that call: log around it, dispatch on the payload, retry it, or refuse to run it.
 
-## What Are Executors?
+Because the executor is a class, that logic lives outside your handlers, which keeps
+handler bodies about the work itself.
 
-Custom executors let you:
-
-- **Implement custom logic**: Interact with external APIs, add specialized error handling, or
-  build complex workflows.
-- **Modularize job processing**: Keep execution logic separate from application code.
-- **Enhance flexibility**: Define concurrency limits, dynamic resource allocation, or multi-step
-  dispatch patterns.
-
-## Creating a Custom Executor
+## Creating a custom executor
 
 Subclass `AbstractEntrypointExecutor` and implement the `execute` method:
 
@@ -37,7 +30,7 @@ class NotificationExecutor(AbstractEntrypointExecutor):
         print(f"Sending SMS: {message}")
 ```
 
-## Registering a Custom Executor
+## Registering a custom executor
 
 Pass the executor class via `executor_factory`:
 
@@ -47,13 +40,13 @@ async def notification_task(job: Job) -> None:
     pass
 ```
 
-## Database Retry Executor
+## Database retry executor
 
 `DatabaseRetryEntrypointExecutor` converts unhandled exceptions into database-level retries
 via `RetryRequested`. The job is re-queued in the database so any worker can pick it up after
 the delay; retries survive worker restarts.
 
-### When to Use It
+### When to use it
 
 - Failures that may take minutes to resolve (e.g., downstream service outages)
 - Jobs that must survive worker restarts between retry attempts

--- a/docs/guides/deferred-execution.md
+++ b/docs/guides/deferred-execution.md
@@ -2,7 +2,7 @@
 
 The `execute_after` attribute controls when a job becomes eligible for processing.
 
-## How It Works
+## How it works
 
 `execute_after` specifies the **earliest** time a job can be picked for execution. If not
 provided, the job is eligible immediately (`NOW()`).
@@ -37,7 +37,7 @@ deferred jobs are never picked early.
     `execute_after` only accepts a `timedelta` offset from the current time (or `None` for
     immediate execution). Absolute `datetime` values are **not** supported.
 
-## Combining with Priority
+## Combining with priority
 
 Deferred jobs participate in the normal priority queue once their `execute_after` time passes:
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -3,7 +3,7 @@
 PgQueuer requires no message broker, Redis instance, or additional infrastructure, just
 PostgreSQL. This page covers how to run workers in production.
 
-## Single Worker Process
+## Single worker process
 
 The simplest deployment: one process, one `QueueManager`.
 
@@ -35,7 +35,7 @@ pgq run myapp:main
 This is sufficient for most workloads. A single `QueueManager` handles multiple entrypoints
 concurrently via asyncio.
 
-## Horizontal Scaling
+## Horizontal scaling
 
 Run multiple worker processes against the same PostgreSQL database. PgQueuer uses
 `FOR UPDATE SKIP LOCKED` in every dequeue query, so workers never claim the same job:
@@ -73,7 +73,7 @@ pgq run myapp:main &
 pgq run myapp:main
 ```
 
-## One Process per CPU Core
+## One process per CPU core
 
 For CPU-bound workloads, run one worker per core to avoid GIL contention in Python:
 
@@ -88,7 +88,7 @@ wait
 For IO-bound workloads (HTTP calls, database queries), a single asyncio process typically
 saturates a database connection before needing additional processes.
 
-## Process Supervision
+## Process supervision
 
 Use a supervisor to restart workers on crash.
 
@@ -146,7 +146,7 @@ LISTEN connection causes a clean restart rather than silent degradation:
   worker = "pgq run myapp:main --shutdown-on-listener-failure"
 ```
 
-## Graceful Shutdown
+## Graceful shutdown
 
 `pgq run` handles `SIGTERM` and `SIGINT`. On receiving a signal:
 
@@ -162,7 +162,7 @@ in-flight jobs finish provided the `terminationGracePeriodSeconds` is long enoug
     Set `terminationGracePeriodSeconds` to at least the 95th-percentile runtime of your
     longest job plus a 30-second buffer.
 
-## Schema Migrations on Deploy
+## Schema migrations on deploy
 
 Run `pgq upgrade` before deploying new application code. It is safe to run against a live
 database. Migrations are additive and non-destructive:
@@ -175,7 +175,7 @@ pgq upgrade          # apply schema changes
 
 `pgq upgrade` is idempotent: running it multiple times produces no side effects.
 
-## Environment Configuration
+## Environment configuration
 
 The database drivers read standard PostgreSQL environment variables:
 
@@ -204,7 +204,7 @@ PGQUEUER_SCHEMA=pgq pgq install
 PGQUEUER_SCHEMA=pgq pgq run my_app:main
 ```
 
-## Deployment Checklist
+## Deployment checklist
 
 - [ ] `pgq install` run once against the target database
 - [ ] `pgq autovac` applied after installation

--- a/docs/guides/docker-images.md
+++ b/docs/guides/docker-images.md
@@ -11,7 +11,7 @@ Registry on every release, tagged to match the PyPI version:
 
 Pin to a version tag in production; `latest` tracks the newest non-prerelease.
 
-## Web Dashboard
+## Web dashboard
 
 ```bash
 docker run -p 8080:8080 \
@@ -35,7 +35,7 @@ Without them the dashboard runs unauthenticated. It can cancel and requeue
 jobs, so never publish it without setting both. See
 [Web Dashboard → Authentication](../integrations/web-dashboard.md#authentication).
 
-## Prometheus Exporter
+## Prometheus exporter
 
 ```bash
 docker run -p 8000:8000 \

--- a/docs/guides/heartbeat.md
+++ b/docs/guides/heartbeat.md
@@ -3,18 +3,17 @@
 PgQueuer updates a heartbeat timestamp on every active job so that stalled or
 crashed workers can be detected.
 
-## How It Works
+## How it works
 
-While a job is in the `picked` state, the `QueueManager` periodically updates a `heartbeat`
-timestamp on the job record. This signals that the job is still actively being processed.
+While a job is in the `picked` state, the `QueueManager` refreshes a `heartbeat`
+timestamp on the job row at a configurable interval. A timestamp that stops moving is
+the signal that the worker holding the job died or hung.
 
-- **Periodic updates**: The heartbeat timestamp is refreshed at a configurable interval.
-- **Stall detection**: External monitoring can compare `heartbeat` against `NOW()` to
-  identify stalled or hung jobs.
-- **Resource management**: Unresponsive jobs do not hold locks indefinitely, and
-  external supervisors can detect and handle stuck workers.
+Anything with database access can act on that: PgQueuer itself re-picks jobs whose
+heartbeat is older than `heartbeat_timeout`, and your own monitoring can compare
+`heartbeat` against `NOW()` to alert on stuck workers.
 
-## Stall Detection Pattern
+## Stall detection pattern
 
 You can query for stalled jobs directly in PostgreSQL:
 
@@ -26,12 +25,13 @@ WHERE status = 'picked'
   AND heartbeat < NOW() - INTERVAL '5 minutes';
 ```
 
-## Heartbeat Timeout
+## Heartbeat timeout
 
 The `heartbeat_timeout` parameter on `pgq.run()` / `QueueManager.run()` sets the
 duration after which a picked job with a stale heartbeat becomes eligible for
 re-pickup by any available worker. Heartbeats are sent automatically at half
-this interval. This enables automatic recovery from crashed or stalled workers:
+this interval, so a crashed or stalled worker's jobs recover without operator
+action:
 
 ```python
 from datetime import timedelta

--- a/docs/guides/hold-failed-jobs.md
+++ b/docs/guides/hold-failed-jobs.md
@@ -10,7 +10,7 @@ job is updated to `status='failed'` and stays in the queue table with its payloa
 all metadata intact. The dequeue query skips `failed` jobs, so they won't be picked up by
 workers until explicitly re-queued.
 
-## How It Works
+## How it works
 
 1. A job handler raises an unhandled exception.
 2. PgQueuer checks the entrypoint's `on_failure` setting.
@@ -21,7 +21,7 @@ workers until explicitly re-queued.
 The hold operation flows through the same batched buffer as normal job completions; there is
 no performance penalty in the common (non-failure) path.
 
-## Use Cases
+## Use cases
 
 ### One-shot jobs with manual review
 
@@ -81,7 +81,7 @@ async def deliver_webhook(job: Job) -> None:
 Rate limits trigger an automatic database-level retry. Other HTTP errors (400, 500, etc.) raise
 an exception and the job is held for inspection.
 
-## Inspecting Failed Jobs
+## Inspecting failed jobs
 
 ### CLI
 
@@ -115,7 +115,7 @@ ORDER BY created DESC
 LIMIT 1;
 ```
 
-## Re-queuing Failed Jobs
+## Re-queuing failed jobs
 
 ### CLI
 
@@ -139,7 +139,7 @@ await queries.requeue_jobs([JobId(42), JobId(43)])
 - If `DatabaseRetryEntrypointExecutor` is configured, the job gets a full new set of retry
   attempts.
 
-## Behavior Summary
+## Behavior summary
 
 | Scenario | `on_failure="delete"` (default) | `on_failure="hold"` |
 |----------|--------------------------------|---------------------|

--- a/docs/guides/job-cancellation.md
+++ b/docs/guides/job-cancellation.md
@@ -3,7 +3,7 @@
 PgQueuer supports canceling queued or in-progress jobs programmatically via PostgreSQL's
 NOTIFY system. Cancellations are best-effort and may not halt a job already underway.
 
-## Enqueueing Jobs
+## Enqueueing jobs
 
 ```python
 from pgqueuer.queries import Queries
@@ -21,7 +21,7 @@ queries = SyncQueries(sync_db_driver)
 job_ids = queries.enqueue("task_entrypoint", b"Job data", priority=5)
 ```
 
-## Cancelling Jobs
+## Cancelling jobs
 
 ```python
 await queries.mark_job_as_cancelled(job_ids)
@@ -30,7 +30,7 @@ await queries.mark_job_as_cancelled(job_ids)
 `mark_job_as_cancelled` accepts a list of job IDs. Jobs that have already completed are
 unaffected.
 
-## Handling Cancellation in Job Code
+## Handling cancellation in job code
 
 Use the job's cancellation scope to stop processing when a cancel request arrives:
 
@@ -45,7 +45,7 @@ async def process_job(job: Job, ctx: Context) -> None:
         await perform_task(job.payload)
 ```
 
-## Job Status After Cancellation
+## Job status after cancellation
 
 Cancelled jobs transition to the `canceled` status and are logged in the statistics table.
 See [Architecture](../reference/architecture.md) for the full status lifecycle.

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -2,7 +2,7 @@
 
 This page covers the knobs available for tuning PgQueuer throughput and latency in production.
 
-## Batch Size
+## Batch size
 
 `batch_size` controls how many jobs are fetched from the database in a single `FOR UPDATE SKIP LOCKED` query. Per the PostgreSQL manual, the `LIMIT` this maps to also bounds how many rows the statement locks per round-trip; see [Row Locking & SKIP LOCKED](../reference/skip-locked.md) for the mechanics.
 
@@ -22,7 +22,7 @@ await pgq.run(batch_size=25, dequeue_timeout=timedelta(seconds=10))
 - Decrease it when jobs are long-running and you want finer concurrency control.
 - `max_concurrent_tasks` must be at least `2 × batch_size`; PgQueuer enforces this.
 
-## Concurrency Limits
+## Concurrency limits
 
 Limit concurrent execution globally or per-entrypoint:
 
@@ -41,7 +41,7 @@ async def resize_image(job: Job) -> None:
 share a scarce external resource (e.g., an API with rate limits). `max_concurrent_tasks`, by
 contrast, is a per-process safety ceiling on total asyncio tasks.
 
-## Connection Pooling
+## Connection pooling
 
 For high-throughput deployments, use a connection pool driver instead of a single connection:
 
@@ -60,7 +60,7 @@ pgq = PgQueuer(driver)
 - Start with `max_size = 2 × expected_concurrent_jobs` and adjust based on `pg_stat_activity`.
 - Avoid pools larger than your PostgreSQL `max_connections` allows.
 
-## Durability vs. Throughput
+## Durability vs. throughput
 
 Choose the durability level that matches your risk tolerance:
 
@@ -81,7 +81,7 @@ pgq durability balanced
     Use only for jobs that are safe to drop and re-enqueue (e.g., cache-warming, fire-and-forget
     analytics).
 
-## Autovacuum Tuning
+## Autovacuum tuning
 
 The `pgqueuer` table is high-churn: rows are inserted and then deleted rapidly. Without tuned
 autovacuum, dead tuple bloat accumulates and slows down index scans.
@@ -110,7 +110,7 @@ Revert to system defaults:
 pgq autovac --rollback
 ```
 
-## NOTIFY Channel and Polling Fallback
+## NOTIFY channel and polling fallback
 
 PgQueuer uses `LISTEN/NOTIFY` for low-latency job pickup. A trigger fires on every insert
 into `pgqueuer` and sends a notification on the `ch_pgqueuer` channel.
@@ -149,7 +149,7 @@ These partial indexes are maintained by `pgq install` and `pgq upgrade`. Do not 
 (`pgq upgrade` additionally adds a `heartbeat`-based picked index on databases created by
 older versions.)
 
-## Quick-Reference Checklist
+## Quick-reference checklist
 
 - [ ] Run `pgq autovac` after installation
 - [ ] Choose a `durability` level appropriate for your crash recovery requirements

--- a/docs/guides/reliability.md
+++ b/docs/guides/reliability.md
@@ -3,7 +3,7 @@
 This page explains how PgQueuer handles failures, ensures jobs are not lost, supports
 idempotent enqueuing, and provides an audit trail of every completed job.
 
-## Failure Handling
+## Failure handling
 
 When a job raises an unhandled exception, PgQueuer:
 
@@ -26,7 +26,7 @@ ORDER BY created DESC
 LIMIT 20;
 ```
 
-## Retry Strategies
+## Retry strategies
 
 PgQueuer provides three complementary retry mechanisms.
 
@@ -155,7 +155,7 @@ enqueued and every later occurrence is treated as a conflict. Under `on_conflict
 later positions come back as `None`; under the default they fail the call. Order your inputs
 so the payload you want kept comes first.
 
-## Poison Jobs
+## Poison jobs
 
 A "poison job" is one that consistently causes worker crashes or hangs without updating its
 heartbeat. PgQueuer does not include a built-in dead-letter queue, but you can detect and
@@ -174,7 +174,7 @@ ORDER BY heartbeat ASC;
 **Recommended pattern:** route these to a separate monitoring alert or move them to a
 dedicated "quarantine" entrypoint by updating their entrypoint column and re-queuing.
 
-## Audit Trail
+## Audit trail
 
 Every job that leaves the active queue is written to `pgqueuer_log`:
 
@@ -193,7 +193,7 @@ or use `pgq dashboard` from the CLI.
     PgQueuer does not automatically prune `pgqueuer_log`. Add a periodic `DELETE` job or
     PostgreSQL table partition policy to manage log growth in high-throughput systems.
 
-## Statistics Aggregation
+## Statistics aggregation
 
 Rows in `pgqueuer_log` are rolled up into per-second counts in `pgqueuer_statistics`
 (grouped by entrypoint, priority, and status). `QueueManager` runs this aggregation on a

--- a/docs/guides/retry.md
+++ b/docs/guides/retry.md
@@ -5,7 +5,7 @@ job stays in the queue table and is re-queued for another attempt. The job row i
 in-place (not deleted and re-inserted), so the `id`, `payload`, `headers`, and all metadata
 are preserved across retries.
 
-## How It Works
+## How it works
 
 1. Your handler raises `RetryRequested` with an optional delay and reason.
 2. PgQueuer catches the exception and atomically:
@@ -20,7 +20,7 @@ Because the job row is **updated** (not deleted), the same `job.id` is stable ac
 retry attempts. This makes it straightforward to trace the full retry graph by querying the
 log table.
 
-## Basic Usage
+## Basic usage
 
 Raise `RetryRequested` from your handler when you detect a transient failure:
 
@@ -49,7 +49,7 @@ async def call_api(job: Job) -> None:
 | `delay` | `timedelta` | `timedelta(0)` | Time to wait before the next attempt |
 | `reason` | `str \| None` | `None` | Human-readable explanation (stored in the log) |
 
-## Reading the Attempt Counter
+## Reading the attempt counter
 
 The `job.attempts` field tells you how many previous attempts have been made. On the first
 execution it is `0`, after one retry it is `1`, and so on:
@@ -70,7 +70,7 @@ async def resilient_task(job: Job) -> None:
         )
 ```
 
-## Automatic Retry with DatabaseRetryEntrypointExecutor
+## Automatic retry with DatabaseRetryEntrypointExecutor
 
 For cases where you want **any** unhandled exception to trigger a retry (not just explicit
 `RetryRequested` raises), use `DatabaseRetryEntrypointExecutor`. It wraps your handler and
@@ -112,7 +112,7 @@ the executor only converts non-retry exceptions.
 | `max_delay` | `timedelta` | `5m` | Cap on exponential backoff |
 | `backoff_multiplier` | `float` | `2.0` | Multiplier applied to delay after each attempt |
 
-### Backoff Schedule Example
+### Backoff schedule example
 
 With `initial_delay=1s`, `backoff_multiplier=2.0`, `max_delay=60s`:
 
@@ -130,7 +130,7 @@ The table shows the delay *formula* independent of `max_attempts`. With the defa
 `max_attempts=5`, only attempts 0-4 are retried (delays 1s-16s); the 5th failure is terminal,
 so the 32s/60s rows never apply unless you raise `max_attempts`.
 
-## Retry vs. Heartbeat Recovery
+## Retry vs. heartbeat recovery
 
 PgQueuer has two complementary retry mechanisms:
 
@@ -172,7 +172,7 @@ WHERE job_id = 42
 ORDER BY created;
 ```
 
-## Behavior Summary
+## Behavior summary
 
 | Scenario | What happens |
 |----------|-------------|

--- a/docs/guides/scheduling.md
+++ b/docs/guides/scheduling.md
@@ -3,7 +3,7 @@
 PgQueuer includes a built-in scheduler for managing recurring tasks using cron-like expressions.
 No separate process (like `celery-beat`) is required.
 
-## Basic Usage
+## Basic usage
 
 ```python
 from pgqueuer.models import Schedule
@@ -21,14 +21,14 @@ async def heartbeat(schedule: Schedule) -> None:
     await send_heartbeat()
 ```
 
-## How It Works
+## How it works
 
-- **Registration**: Define tasks using the `@schedule` decorator with a name and a cron expression.
-- **Execution**: The scheduler runs tasks at defined intervals and tracks execution state.
-- **Database Integration**: Schedules are stored in PostgreSQL and survive process
-  restarts.
+The `@schedule` decorator registers a name and a cron expression as a row in
+`pgqueuer_schedules`. The scheduler polls that table, runs the tasks whose expressions
+are due, and records the run. Because the state lives in PostgreSQL, schedules survive
+process restarts and only one worker runs each due task.
 
-### Scheduler Flow Diagram
+### Scheduler flow diagram
 
 ```
 @pgq.schedule ──▶ Schedule in DB ──▶ Poll loop ──cron ready──▶ Execute task
@@ -36,7 +36,7 @@ async def heartbeat(schedule: Schedule) -> None:
                                         └──────────────────────────┘
 ```
 
-## Cron Expression Format
+## Cron expression format
 
 PgQueuer supports both standard 5-field cron expressions and 6-field expressions with seconds
 in the final position.
@@ -94,7 +94,7 @@ Examples:
 Use trailing seconds, not leading seconds. For example, `*/3 * * * * *` is **not** "every 3
 seconds"; use `* * * * * */3` instead.
 
-## Accessing Shared Resources
+## Accessing shared resources
 
 Scheduled tasks can access shared resources (HTTP clients, database pools, etc.) by annotating a
 parameter as `ScheduleContext`. PgQueuer auto-detects it and injects the context, whose
@@ -111,7 +111,7 @@ async def sync_data(schedule: Schedule, ctx: ScheduleContext) -> None:
 
 See [Shared Resources](shared-resources.md) for full details.
 
-## Cleaning Up Old Schedules
+## Cleaning up old schedules
 
 When `clean_old=True`, PgQueuer deletes any **existing** database schedules whose entrypoint
 matches this decorator's entrypoint before re-registering it. This is useful when you change
@@ -125,7 +125,7 @@ async def fetch_db(schedule: Schedule) -> None:
 
 By default, `clean_old=False`: old schedules are retained.
 
-## Managing Schedules via CLI
+## Managing schedules via CLI
 
 List all schedules:
 
@@ -139,7 +139,7 @@ Remove a schedule by name:
 pgq schedules --remove fetch_db
 ```
 
-## Example: Full Setup with Scheduling
+## Example: full setup with scheduling
 
 ```python
 from contextlib import asynccontextmanager

--- a/docs/guides/shared-resources.md
+++ b/docs/guides/shared-resources.md
@@ -1,18 +1,14 @@
 # Shared Resources (`Context.resources`)
 
-PgQueuer lets you provide a single shared resources container that is injected into every job
-execution context. This makes it easy to initialize heavyweight or shared components (database
-pools, HTTP clients, caches, ML models, etc.) once at process startup and reuse them across
-all jobs.
+PgQueuer injects a single shared resources container into every job execution context.
+Create the expensive things once at process startup (database pools, HTTP clients, caches,
+ML models) and every job reuses them.
 
-## Why Use Shared Resources?
+That saves the per-job cost of rebuilding an HTTP session pool or reloading model weights,
+keeps the lifecycle in one place (created at startup, closed at shutdown), and gives jobs a
+way to share mutable state such as in-memory counters or feature flags.
 
-- Avoid re-initializing expensive objects per job (e.g. HTTP session pools, model weights)
-- Centralize lifecycle (create at startup, optionally close at shutdown)
-- Enable coordinated state (e.g. in‑memory counters, feature flags)
-- Provide a structured place for integrations (tracing, metrics, external APIs)
-
-## Providing Resources
+## Providing resources
 
 You pass a mutable mapping when constructing `PgQueuer` (or `QueueManager` directly):
 
@@ -50,7 +46,7 @@ async def build_pgqueuer():
 Internally this mapping is passed into each `Context` as `context.resources`. All jobs receive
 the **same object** (it is not copied), so mutations are visible across jobs.
 
-## Access Inside Custom Executors
+## Access inside custom executors
 
 If you implement a custom executor (`AbstractEntrypointExecutor`), the `execute(self, job, context)`
 method receives the `Context`:
@@ -67,7 +63,7 @@ class LoggingExecutor(AbstractEntrypointExecutor):
         # Call wrapped function (if delegating) or implement logic directly
 ```
 
-## Mutating Resources
+## Mutating resources
 
 Because `resources` is a shared mutable mapping:
 
@@ -79,7 +75,7 @@ context.resources["metrics"]["processed"] += 1
 If you need stricter control (immutability, lifecycle hooks), you can replace the mapping with
 a custom registry class; the public contract is simply "object with mapping semantics."
 
-## Enabling Context Injection
+## Enabling context injection
 
 Context injection is **auto-detected from the handler signature**. Annotate a parameter as
 `Context` and PgQueuer passes the runtime `Context`:
@@ -110,7 +106,7 @@ async def forced(job: Job, ctx: Context) -> None:
     ...
 ```
 
-## Scheduled Tasks
+## Scheduled tasks
 
 Scheduled tasks follow the same rule: annotate a parameter as `ScheduleContext` and it is
 injected automatically.
@@ -132,7 +128,7 @@ async def simple_task(schedule: Schedule) -> None:
     await perform_task()
 ```
 
-## Testing With Resources
+## Testing with resources
 
 ```python
 from pgqueuer.queries import Queries


### PR DESCRIPTION
The "How It Works" sections listed bolded labels that mostly restated their own heading; they now explain the mechanism instead. Same for the shared-resources rationale, the heartbeat bullets, and the completion-watcher reliability notes, whose code block was also indented into a literal block. Section headings below the page title move to sentence case.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
