### PR TITLE
docs: rework celery comparison for balance and traceability

### DIFF
--- a/docs/comparisons/celery-comparison.md
+++ b/docs/comparisons/celery-comparison.md
@@ -1,24 +1,79 @@
 # PgQueuer vs Celery
 
-Celery and PgQueuer solve the same core problem (reliable background job processing)
-with different trade-offs. This page compares them side by side so you can pick the
-right tool for your situation.
+Celery is the most established task queue in the Python ecosystem:
+[BSD-licensed](https://pypi.org/project/celery/), actively maintained
+([5.6.3 released 2026-03-26](https://github.com/celery/celery/releases)), with a
+broker-based architecture that scales beyond what
+any single-database queue can do. PgQueuer solves the same core problem, reliable
+background job processing, with a smaller footprint: PostgreSQL is the only moving
+part.
 
-## Feature Comparison
+Facts about Celery were checked on 2026-08-20 against
+[docs.celeryq.dev](https://docs.celeryq.dev/en/stable/) and Celery 5.6.3.
+
+## Architecture at a glance
+
+| | Celery | PgQueuer |
+|---|--------|----------|
+| Message transport | RabbitMQ, Redis, SQS (stable); Kafka, Zookeeper, GC Pub/Sub (experimental)[^brokers] | PostgreSQL (`LISTEN/NOTIFY` + `FOR UPDATE SKIP LOCKED`) |
+| Result storage | 17 supported backends (Redis, RPC, SQLAlchemy, DynamoDB, S3, ...)[^backends] | PostgreSQL (`pgqueuer_log` table) |
+| Processes to run | Worker + broker + result backend + optional `beat` | Worker + PostgreSQL |
+| Concurrency model | prefork, eventlet, gevent, threads, solo[^concurrency] | asyncio |
+| Recurring tasks | Separate `celery beat` process | Built-in `@pgq.schedule` decorator |
+| Workflow primitives | Chains, chords, groups, map, chunks ([canvas](https://docs.celeryq.dev/en/stable/userguide/canvas.html)) | None; single jobs only |
+| Multi-language | Protocol designed for it (message `lang` header)[^protocol] | Python only |
+| Monitoring | [Flower](https://docs.celeryq.dev/en/stable/userguide/monitoring.html) web UI, `celery events`, inspect commands | `pgq dashboard`, [web dashboard](../integrations/web-dashboard.md), [Prometheus](../integrations/prometheus.md), SQL |
+
+[^brokers]: [Broker overview](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html).
+[^backends]: [Introduction, "What do I need?"](https://docs.celeryq.dev/en/stable/getting-started/introduction.html).
+[^concurrency]: [Introduction, features list](https://docs.celeryq.dev/en/stable/getting-started/introduction.html). Native asyncio task support is not shipped; it is an open design discussion targeted at Celery 6.0 ([#3884](https://github.com/celery/celery/issues/3884), [#7874](https://github.com/celery/celery/issues/7874)).
+[^protocol]: [Message protocol v2](https://docs.celeryq.dev/en/stable/internals/protocol.html): "Worker may redirect the message to a worker that supports the language."
+
+## Delivery semantics
+
+This is the most consequential difference, and it cuts both ways.
+
+**Celery acknowledges early by default.** The worker acks a task *before* executing
+it, "so that a task invocation that already started is never executed again"
+([docs](https://docs.celeryq.dev/en/stable/userguide/tasks.html)). If the worker
+crashes mid-task, the task is gone. Opting into
+[`acks_late`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-acks-late)
+plus `task_reject_on_worker_lost` gives redelivery, with the documented requirement
+that tasks be idempotent. On Redis, redelivery is governed by a
+[visibility timeout](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html)
+(default 1 hour), and the docs warn that ETA/countdown tasks exceeding it "will be
+executed again, and again in a loop."
+
+**PgQueuer is at-least-once by design.** A picked job holds a row-level lock and
+refreshes a heartbeat; if the worker dies, the job becomes eligible for re-pickup
+after `heartbeat_timeout` and any worker resumes it (see
+[Reliability Model](../guides/reliability.md)). The same idempotency requirement
+applies: a recovered job runs again from the start.
+
+If your tasks must never run twice, Celery's early-ack default is the safer behavior.
+If your tasks must never be lost, PgQueuer gives you that without configuration.
+
+## Feature comparison
 
 | Feature | Celery | PgQueuer |
-|---------|--------|---------|
-| Message broker | Redis, RabbitMQ, SQS, etc. | PostgreSQL |
-| Recurring tasks | Separate `celery-beat` process | Built-in `@pgq.schedule` decorator |
-| Architecture | App + broker + optional beat | App + PostgreSQL |
-| Job delivery | Broker-dependent | Real-time via `LISTEN/NOTIFY` |
-| Transactional enqueue | Separate from app data | Same PostgreSQL transaction |
-| Async model | Sync-first with async support | Built on asyncio |
-| Complex workflows | Chains, chords, groups, canvas | Basic job queue |
+|---------|--------|----------|
+| Transactional enqueue with app data | No; the broker is separate from your database | Yes; same PostgreSQL transaction |
+| Retries | [`autoretry_for`, exponential backoff, `max_retries`](https://docs.celeryq.dev/en/stable/userguide/tasks.html) | [`RetryRequested`, `DatabaseRetryEntrypointExecutor` with backoff](../guides/retry.md) |
+| Rate limiting | Per-task, changeable at runtime | No built-in rate limiter |
+| Concurrency limits | Worker pool size, [autoscaling](https://docs.celeryq.dev/en/stable/userguide/workers.html) | [Per-entrypoint, enforced globally in SQL](../guides/concurrency-control.md) |
+| Task routing | [Glob/regex routes, AMQP exchanges](https://docs.celeryq.dev/en/stable/userguide/routing.html) | Entrypoint name only |
+| Priorities | Native on RabbitMQ; limited on Redis[^prio] | Native integer priority column |
+| Deduplication | Not built in | [`dedupe_key` unique constraint](../guides/reliability.md#idempotency) |
+| Scheduled/recurring | `beat`, a separate single-instance process[^beat] | [Built-in, DB-backed, any worker](../guides/scheduling.md) |
+| Job completion tracking | `AsyncResult.get()` via result backend | [`CompletionWatcher` via `LISTEN/NOTIFY`](../guides/completion-tracking.md) |
 
-## Example: Running a Worker
+[^prio]: [Routing guide](https://docs.celeryq.dev/en/stable/userguide/routing.html): Redis priorities "will never be as good as priorities implemented at the broker server level."
+[^beat]: [Periodic tasks](https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html): "You have to ensure only a single scheduler is running for a schedule at a time, otherwise you'd end up with duplicate tasks." Embedding beat in a worker with `-B` is documented as not recommended for production.
 
-**Celery** needs a broker and a separate worker process:
+## Example: running a worker
+
+**Celery** needs a broker and a separate worker process (adapted from
+[First steps with Celery](https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html)):
 
 ```python
 # celery_app.py
@@ -35,7 +90,8 @@ def add(x, y):
 celery -A celery_app worker -l info
 ```
 
-**PgQueuer** connects directly to PostgreSQL:
+**PgQueuer** connects directly to PostgreSQL (see the
+[Quick Start](../getting-started/quickstart.md)):
 
 ```python
 # pgqueuer_app.py
@@ -64,9 +120,10 @@ async def create_pgq():
 pgq run pgqueuer_app:create_pgq
 ```
 
-## Example: Enqueuing a Task
+## Example: enqueuing a task
 
-**Celery** uses `delay()`:
+**Celery** uses `delay()`
+([First steps, "Calling the task"](https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html)):
 
 ```python
 from celery_app import add
@@ -74,7 +131,8 @@ result = add.delay(2, 3)
 print(result.id)
 ```
 
-**PgQueuer** enqueues directly into PostgreSQL:
+**PgQueuer** enqueues directly into PostgreSQL (see the
+[Quick Start](../getting-started/quickstart.md)):
 
 ```python
 import asyncpg
@@ -88,9 +146,10 @@ async def main() -> None:
     print(job_ids)
 ```
 
-## Example: Scheduling a Recurring Task
+## Example: scheduling a recurring task
 
-**Celery** requires the `celery-beat` service:
+**Celery** uses the `beat` scheduler (adapted from
+[Periodic tasks](https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html)):
 
 ```python
 from celery import Celery
@@ -114,7 +173,9 @@ app.conf.beat_schedule = {
 celery -A celery_scheduled worker -B -l info
 ```
 
-**PgQueuer** has the scheduler built in:
+**PgQueuer** has the scheduler built in. State lives in PostgreSQL, so any worker
+can run due tasks and schedules survive restarts (see
+[Scheduling](../guides/scheduling.md)):
 
 ```python
 import asyncpg
@@ -140,16 +201,18 @@ async def create_pgq():
 pgq run pgqueuer_scheduled:create_pgq
 ```
 
-## Example: Waiting for Job Completion
+## Example: waiting for job completion
 
-**Celery** provides `AsyncResult.get()`:
+**Celery** provides `AsyncResult.get()`, which requires a configured result backend
+([First steps, "Keeping results"](https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html)):
 
 ```python
 result = add.delay(2, 3)
 print(result.get())
 ```
 
-**PgQueuer** uses `CompletionWatcher`, which streams status updates via `LISTEN/NOTIFY`:
+**PgQueuer** uses `CompletionWatcher`, which streams status updates via
+`LISTEN/NOTIFY` (see [Completion Tracking](../guides/completion-tracking.md)):
 
 ```python
 import asyncpg
@@ -170,21 +233,31 @@ async def wait_for_job() -> None:
         print(status)
 ```
 
-## When PgQueuer Is a Good Fit
+## When Celery is the better choice
 
-- You're already using PostgreSQL and want to avoid an extra broker service
-- You value stack simplicity and reduced operational overhead
-- You need lightweight recurring jobs without running `celery-beat`
-- Your workload fits within PostgreSQL's throughput characteristics
-- You want transactional enqueuing (enqueue a job in the same transaction as your app data)
+- Canvas primitives (chains, chords, groups) let you compose multi-step pipelines
+  declaratively. PgQueuer has nothing comparable.
+- A dedicated broker like RabbitMQ absorbs message volume that would otherwise
+  contend with your application's OLTP load on a shared PostgreSQL.
+- Flower's web UI and remote worker control (autoscaling, runtime rate-limit
+  changes, revocation, broadcast commands) have years of production use behind them.
+- Celery's prefork model fits classic Django/Flask apps without requiring asyncio.
+  PgQueuer's handlers must be `async def`.
+- The message protocol carries a language header and has implementations outside
+  Python, so it can serve polyglot systems.
+- The ecosystem is much larger: integrations, documentation, answers, and hiring
+  familiarity.
 
-## When Celery May Be Better
+## When PgQueuer is the better choice
 
-Celery is a mature project with a long history. It may be the better choice when:
+- You already run PostgreSQL and want no additional infrastructure to provision,
+  monitor, secure, and keep available.
+- Committing a job atomically with your application data removes a class of
+  dual-write bugs. With a separate broker this requires an outbox pattern.
+- Handlers are plain coroutines, so asyncio codebases need no pool bridging.
+- Recurring jobs need no separate scheduler process and have no single-instance
+  constraint, since schedule state lives in the database.
+- Crash recovery via heartbeat re-pickup is the default, not an `acks_late` plus
+  visibility-timeout configuration exercise.
 
-- You need complex multi-step workflows (chains, chords, groups)
-- You require canvas primitives for task composition
-- Your system spans multiple languages or needs a non-Python broker
-- You need very high throughput beyond what a single PostgreSQL instance can deliver
-
-For more details on PgQueuer's throughput characteristics, see [Benchmarks](benchmarks.md).
+For throughput numbers, see [Benchmarks](benchmarks.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,9 +179,9 @@ That is the whole setup: PostgreSQL and your application code.
 | Recurring tasks | Built-in `@schedule` decorator | Separate `celery-beat` process |
 | Complex workflows | Basic job queue | Chains, chords, groups, canvas |
 
-Celery is a mature, battle-tested project that excels at complex multi-step workflows,
-canvas primitives, and multi-broker topologies. PgQueuer is a good fit when your jobs
-are backed by PostgreSQL and you want a simpler operational footprint.
+Celery is a mature project with strong support for multi-step workflows, canvas
+primitives, and multi-broker topologies. PgQueuer is a good fit when your jobs are
+backed by PostgreSQL and you want a simpler operational footprint.
 
 [Detailed Comparison](comparisons/celery-comparison.md){ .md-button }
 


### PR DESCRIPTION
Credit Celery's strengths (canvas, Flower, acks-late semantics, multi-language protocol, ecosystem) instead of one-sided framing. Every Celery claim and code example now links to a tier-1 source (docs.celeryq.dev, GitHub, PyPI), checked 2026-08-20 against 5.6.3. Also soften the home-page comparison teaser.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
