### PR TITLE
feat(django): add django.tasks backend and worker

### DIFF
--- a/examples/django_tracer.py
+++ b/examples/django_tracer.py
@@ -1,0 +1,236 @@
+"""Tracer: a synchronous Django task, enqueued transactionally, run by pgqueuer.
+
+Proves five things in one pass:
+
+1. A plain ``def`` handler runs inside pgqueuer's async worker.
+2. ``.enqueue()`` joins the caller's ``transaction.atomic()``: the row is visible
+   inside the block and gone after a rollback.
+3. The worker runs on its own native psycopg connection, separate from Django's.
+4. The handler reads the Django ORM without ``SynchronousOnlyOperation``.
+5. The return value is readable afterwards through ``get_result()``.
+
+Not proven here: ``LISTEN/NOTIFY`` dispatch latency. ``drain`` mode picks up
+already-queued jobs with its first dequeue, so it exercises the connection split
+but not notification-driven wake-up. That needs a long-running worker and a
+timing assertion.
+
+Result storage is faked: the return value goes to a table this example creates
+rather than to a column on the job row. Everything else is the real path.
+
+Because ``@task`` instantiates the backend at decoration time, Django has to be
+configured while this module is still importing — hence ``configure()`` running
+at module scope and the ``# noqa: E402`` imports below it. That ordering is
+inherent to single-file Django scripts.
+
+Run against a local Postgres::
+
+    PGHOST=localhost PGDATABASE=pgqdb PGUSER=pgquser PGPASSWORD=pgqpw \
+        uv run python examples/django_tracer.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import django
+import psycopg
+from django.conf import settings
+
+RESULT_TABLE = "django_tracer_result"
+
+
+def configure() -> None:
+    """Configure Django from PG* environment variables. Idempotent."""
+    if settings.configured:
+        return
+    settings.configure(
+        DEBUG=False,
+        SECRET_KEY="tracer-only-not-a-secret",
+        USE_TZ=True,
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "pgqueuer.adapters.django",
+        ],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.postgresql",
+                "NAME": os.environ.get("PGDATABASE", "postgres"),
+                "USER": os.environ.get("PGUSER", "postgres"),
+                "PASSWORD": os.environ.get("PGPASSWORD", ""),
+                "HOST": os.environ.get("PGHOST", "localhost"),
+                "PORT": os.environ.get("PGPORT", "5432"),
+            }
+        },
+        TASKS={"default": {"BACKEND": f"{__name__}.TracerBackend", "QUEUES": []}},
+    )
+    django.setup()
+
+
+configure()
+
+from django.db import connections, transaction  # noqa: E402
+from django.tasks import task  # noqa: E402
+from django.tasks.base import TaskResult, TaskResultStatus  # noqa: E402
+from django.tasks.exceptions import TaskResultDoesNotExist  # noqa: E402
+from django.utils import timezone  # noqa: E402
+
+from pgqueuer.adapters.django.backend import PgqueuerBackend, entrypoint_name  # noqa: E402
+from pgqueuer.adapters.django.discovery import discover_tasks  # noqa: E402
+from pgqueuer.adapters.django.driver import worker_connection_params  # noqa: E402
+from pgqueuer.adapters.django.worker import run_worker  # noqa: E402
+from pgqueuer.adapters.drivers.psycopg import PsycopgDriver  # noqa: E402
+from pgqueuer.adapters.persistence.queries import Queries  # noqa: E402
+from pgqueuer.domain import types  # noqa: E402
+
+# --------------------------------------------------------------------------
+# Result storage, faked in the example. In a real integration this is a JSONB
+# column on the job row and this subclass disappears.
+# --------------------------------------------------------------------------
+
+
+class TracerBackend(PgqueuerBackend):
+    """PgqueuerBackend plus a result table this example owns."""
+
+    supports_get_result = True
+
+    def pre_enqueue(self, task_result: TaskResult) -> None:
+        with connections["default"].cursor() as cursor:
+            cursor.execute(
+                f'INSERT INTO "{RESULT_TABLE}" (result_id, entrypoint, status) VALUES (%s, %s, %s)',
+                [task_result.id, entrypoint_name(task_result.task), "READY"],
+            )
+
+    def get_result(self, result_id: str) -> TaskResult:
+        with connections["default"].cursor() as cursor:
+            cursor.execute(
+                f'SELECT entrypoint, status, return_value FROM "{RESULT_TABLE}" '
+                "WHERE result_id = %s",
+                [result_id],
+            )
+            row = cursor.fetchone()
+        if row is None:
+            raise TaskResultDoesNotExist(result_id)
+
+        entrypoint, status, return_value = row
+        # Django's psycopg backend registers no jsonb loader for raw cursors --
+        # it handles JSON at the field level -- so jsonb arrives as text here.
+        if return_value is not None:
+            return_value = json.loads(return_value)
+        result = TaskResult(
+            task=discover_tasks([__name__])[entrypoint],
+            id=result_id,
+            status=TaskResultStatus(status),
+            enqueued_at=timezone.now(),
+            started_at=None,
+            last_attempted_at=None,
+            finished_at=None,
+            args=[],
+            kwargs={},
+            backend=self.alias,
+            errors=[],
+            worker_ids=[],
+        )
+        object.__setattr__(result, "_return_value", return_value)
+        return result
+
+
+# --------------------------------------------------------------------------
+# The task. Module-level and synchronous, exactly as a Django user writes it:
+# no async, and a plain ORM query in the body.
+# --------------------------------------------------------------------------
+
+
+@task()
+def count_content_types() -> int:
+    """Return the number of ContentType rows, read through the sync ORM."""
+    from django.contrib.contenttypes.models import ContentType
+
+    return ContentType.objects.count()
+
+
+# --------------------------------------------------------------------------
+# Setup helpers
+# --------------------------------------------------------------------------
+
+
+def create_result_table() -> None:
+    with connections["default"].cursor() as cursor:
+        cursor.execute(
+            f"""CREATE TABLE IF NOT EXISTS "{RESULT_TABLE}" (
+                   result_id    text PRIMARY KEY,
+                   entrypoint   text NOT NULL,
+                   status       text NOT NULL,
+                   return_value jsonb
+               )"""
+        )
+
+
+async def install_schema() -> None:
+    """Install the pgqueuer schema, tolerating an already-installed one."""
+    params = worker_connection_params()
+    connection = await psycopg.AsyncConnection.connect(**params, autocommit=True)
+    try:
+        await Queries(PsycopgDriver(connection)).install()
+    except psycopg.errors.DuplicateObject:
+        pass
+    finally:
+        await connection.close()
+
+
+def queued_count() -> int:
+    with connections["default"].cursor() as cursor:
+        cursor.execute("SELECT count(*) FROM pgqueuer")
+        row = cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
+def drain() -> None:
+    """Run a worker until the queue is empty, then stop."""
+    asyncio.run(
+        run_worker(
+            task_modules=[__name__],
+            result_table=RESULT_TABLE,
+            mode=types.QueueExecutionMode.drain,
+        )
+    )
+
+
+def main() -> None:
+    from django.core.management import call_command
+
+    asyncio.run(install_schema())
+    call_command("migrate", "contenttypes", verbosity=0)
+    create_result_table()
+
+    print(f"queued at start           : {queued_count()}")
+
+    # --- proof 2a: the job is visible inside the txn, and rolls back with it
+    try:
+        with transaction.atomic():
+            count_content_types.enqueue()
+            # Same connection, still inside the transaction: the row is there.
+            print(f"queued inside txn         : {queued_count()}   <- expect 1")
+            raise RuntimeError("deliberate rollback")
+    except RuntimeError:
+        pass
+    print(f"queued after rollback     : {queued_count()}   <- expect 0")
+
+    # --- proof 2b: commit keeps it ---------------------------------------
+    with transaction.atomic():
+        result = count_content_types.enqueue()
+    print(f"queued after commit       : {queued_count()}   <- expect 1")
+
+    # --- proofs 1, 3, 4: the worker runs the sync handler ------------------
+    drain()
+    print(f"queued after worker drain : {queued_count()}   <- expect 0")
+
+    # --- proof 5: the return value came back ------------------------------
+    refreshed = count_content_types.get_result(result.id)
+    print(f"result status             : {refreshed.status}")
+    print(f"result return_value       : {refreshed.return_value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pgqueuer/adapters/django/__init__.py
+++ b/pgqueuer/adapters/django/__init__.py
@@ -1,0 +1,25 @@
+"""Django integration: a ``django.tasks`` backend and a worker command.
+
+Add the app to ``INSTALLED_APPS`` and point ``TASKS`` at the backend::
+
+    INSTALLED_APPS = [..., "pgqueuer.adapters.django"]
+    TASKS = {"default": {"BACKEND": "pgqueuer.adapters.django.backend.PgqueuerBackend"}}
+
+Install the queue schema with ``pgq install``, then run ``manage.py pgqworker``.
+"""
+
+from __future__ import annotations
+
+from pgqueuer.adapters.django.backend import PgqueuerBackend, entrypoint_name
+from pgqueuer.adapters.django.driver import DjangoDriver, worker_connection_params
+from pgqueuer.adapters.django.executors import build_entrypoint
+
+default_app_config = "pgqueuer.adapters.django.apps.PgqueuerConfig"
+
+__all__ = [
+    "DjangoDriver",
+    "PgqueuerBackend",
+    "build_entrypoint",
+    "entrypoint_name",
+    "worker_connection_params",
+]

--- a/pgqueuer/adapters/django/apps.py
+++ b/pgqueuer/adapters/django/apps.py
@@ -1,0 +1,18 @@
+"""Django application configuration for the pgqueuer adapter."""
+
+from __future__ import annotations
+
+from django.apps import AppConfig
+
+
+class PgqueuerConfig(AppConfig):
+    """Registers the adapter so ``manage.py pgqworker`` is discoverable.
+
+    ``label`` is a permanent compatibility contract for a reusable app and must
+    not change.
+    """
+
+    name = "pgqueuer.adapters.django"
+    label = "pgqueuer"
+    verbose_name = "PgQueuer"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/pgqueuer/adapters/django/backend.py
+++ b/pgqueuer/adapters/django/backend.py
@@ -1,0 +1,125 @@
+"""A ``django.tasks`` backend that enqueues into pgqueuer.
+
+``django.tasks`` (Django 6.0+) defines the task API but ships no worker; Django's
+own documentation delegates execution to the ecosystem. This backend implements
+the enqueue half against pgqueuer; ``manage.py pgqworker`` runs the other half.
+
+Enqueue goes through :class:`~pgqueuer.adapters.django.driver.DjangoDriver`, i.e.
+Django's own connection, so a job joins the caller's ``transaction.atomic()``
+block and disappears with it on rollback.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from typing import Any
+
+from django.tasks.backends.base import BaseTaskBackend
+from django.tasks.base import Task, TaskResult, TaskResultStatus
+from django.tasks.signals import task_enqueued
+from django.utils import timezone
+from django.utils.crypto import get_random_string
+
+from pgqueuer.adapters.django.driver import DjangoDriver
+from pgqueuer.adapters.persistence.queries import SyncQueries
+
+# django.tasks documents result ids as strings shorter than 64 characters.
+RESULT_ID_LENGTH = 32
+
+
+def entrypoint_name(task: Task) -> str:
+    """Return the pgqueuer entrypoint for *task*.
+
+    Prefixing with the queue name lets a worker select queues by prefix, while
+    one entrypoint per task gives per-task concurrency limits and per-task
+    dashboard statistics without extra machinery.
+    """
+    return f"{task.queue_name}:{task.module_path}"
+
+
+class PgqueuerBackend(BaseTaskBackend):
+    """Enqueue ``django.tasks`` tasks into pgqueuer.
+
+    Recognised ``OPTIONS``:
+
+    ``DATABASE_ALIAS``
+        Django database alias to enqueue on. Defaults to ``"default"``.
+
+    Usage example::
+
+        TASKS = {
+            "default": {
+                "BACKEND": "pgqueuer.adapters.django.backend.PgqueuerBackend",
+                "OPTIONS": {"DATABASE_ALIAS": "default"},
+            }
+        }
+    """
+
+    supports_defer = True
+    supports_priority = True
+
+    # The worker calls handlers through a thread; coroutine handlers would need
+    # a different execution path, so they are rejected up front rather than
+    # failing at dispatch.
+    supports_async_task = False
+
+    # Result storage is not implemented yet; see the tracer example for a
+    # subclass that adds it.
+    supports_get_result = False
+
+    def __init__(self, alias: str, params: dict) -> None:
+        super().__init__(alias, params)
+        self.database_alias = self.options.get("DATABASE_ALIAS", "default")
+
+    def enqueue(
+        self,
+        task: Task,
+        args: list[Any],
+        kwargs: dict[str, Any],
+    ) -> TaskResult:
+        self.validate_task(task)
+
+        task_result = TaskResult(
+            task=task,
+            id=get_random_string(RESULT_ID_LENGTH),
+            status=TaskResultStatus.READY,
+            enqueued_at=timezone.now(),
+            started_at=None,
+            last_attempted_at=None,
+            finished_at=None,
+            args=args,
+            kwargs=kwargs,
+            backend=self.alias,
+            errors=[],
+            worker_ids=[],
+        )
+
+        # Read args/kwargs back off the result: TaskResult.__post_init__ has
+        # normalised them, which is the serialisation the built-in backends use.
+        payload = json.dumps(
+            {
+                "result_id": task_result.id,
+                "args": task_result.args,
+                "kwargs": task_result.kwargs,
+            }
+        ).encode()
+
+        self.pre_enqueue(task_result)
+        SyncQueries(DjangoDriver(self.database_alias)).enqueue(
+            entrypoint_name(task),
+            payload,
+            task.priority,
+            execute_after=self.execute_after(task),
+        )
+        task_enqueued.send(type(self), task_result=task_result)
+        return task_result
+
+    def pre_enqueue(self, task_result: TaskResult) -> None:
+        """Hook for subclasses needing to persist state before the insert."""
+
+    def execute_after(self, task: Task) -> timedelta | None:
+        """Translate ``run_after`` into pgqueuer's relative delay."""
+        if task.run_after is None:
+            return None
+        return task.run_after - timezone.now()

--- a/pgqueuer/adapters/django/discovery.py
+++ b/pgqueuer/adapters/django/discovery.py
@@ -1,0 +1,46 @@
+"""Locate declared ``django.tasks`` tasks.
+
+``django.tasks`` keeps no registry of declared tasks — the decorator returns a
+:class:`~django.tasks.base.Task` and nothing records it. A worker therefore has
+to import the modules that declare tasks and inspect their contents.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Iterator
+
+from django.apps import apps
+from django.tasks.base import Task
+
+from pgqueuer.adapters.django.backend import entrypoint_name
+
+
+def tasks_in_module(module_path: str) -> Iterator[Task]:
+    """Yield every :class:`Task` declared in the module at *module_path*."""
+    module = importlib.import_module(module_path)
+    for value in vars(module).values():
+        if isinstance(value, Task):
+            yield value
+
+
+def default_task_modules() -> Iterator[str]:
+    """Yield the ``<app>.tasks`` module path of every installed app that has one."""
+    for config in apps.get_app_configs():
+        candidate = f"{config.name}.tasks"
+        try:
+            importlib.import_module(candidate)
+        except ModuleNotFoundError:
+            continue
+        yield candidate
+
+
+def discover_tasks(module_paths: list[str] | None = None) -> dict[str, Task]:
+    """Return tasks keyed by :func:`~pgqueuer.adapters.django.backend.entrypoint_name`.
+
+    With *module_paths* omitted, every installed app's ``tasks`` module is
+    scanned. Duplicate keys collapse, which is harmless: the same task imported
+    from two modules is still the same task.
+    """
+    paths = list(default_task_modules()) if module_paths is None else module_paths
+    return {entrypoint_name(task): task for path in paths for task in tasks_in_module(path)}

--- a/pgqueuer/adapters/django/driver.py
+++ b/pgqueuer/adapters/django/driver.py
@@ -1,0 +1,79 @@
+"""Django-backed drivers and connection-parameter derivation.
+
+Django integration needs two distinct connections:
+
+* **Enqueue** borrows Django's own connection, so inserts join the caller's
+  ``transaction.atomic()`` block.
+* **Worker** needs a native connection, because Django's connection cannot hold a
+  long-lived ``LISTEN`` (Django has no async database layer).
+
+:class:`DjangoDriver` covers the first; :func:`worker_connection_params` derives
+the parameters for the second from Django's own configuration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+from django.db import connections
+from psycopg.rows import dict_row
+
+from pgqueuer.ports.driver import SyncDriver
+
+# Keys Django's psycopg backend adds that psycopg.connect() itself rejects.
+_UNSUPPORTED_CONNECT_KEYS = ("cursor_factory", "context")
+
+
+def worker_connection_params(alias: str = "default") -> dict[str, Any]:
+    """Return ``psycopg.connect()`` kwargs for *alias*, derived from Django.
+
+    Asking Django's backend rather than parsing ``settings.DATABASES`` inherits
+    ``NAME`` -> ``dbname`` mapping, ``OPTIONS`` passthrough and — importantly for
+    tests — Django's test-database name substitution.
+
+    Usage example::
+
+        params = worker_connection_params()
+        connection = await psycopg.AsyncConnection.connect(**params, autocommit=True)
+    """
+    params = dict(connections[alias].get_connection_params())
+    for key in _UNSUPPORTED_CONNECT_KEYS:
+        params.pop(key, None)
+    return params
+
+
+class DjangoDriver(SyncDriver):
+    """Synchronous driver executing on Django's connection for *alias*.
+
+    The connection is looked up per call rather than cached, so the driver
+    follows Django's thread-local wrapper across reconnects. Unlike
+    :class:`~pgqueuer.adapters.drivers.psycopg.SyncPsycopgDriver` it does not
+    require autocommit, which is what allows enqueueing inside
+    ``transaction.atomic()``.
+
+    Usage example::
+
+        queries = SyncQueries(DjangoDriver())
+        with transaction.atomic():
+            order.save()
+            queries.enqueue("send-invoice", payload)
+    """
+
+    def __init__(self, alias: str = "default") -> None:
+        self.alias = alias
+
+    @property
+    def connection(self) -> psycopg.Connection:
+        wrapper = connections[self.alias]
+        wrapper.ensure_connection()
+        return wrapper.connection
+
+    def fetch(
+        self,
+        query: str,
+        *args: Any,
+    ) -> list[dict]:
+        cursor = psycopg.RawCursor(self.connection, row_factory=dict_row)
+        cursor.execute(query, args or None)
+        return cursor.fetchall()

--- a/pgqueuer/adapters/django/executors.py
+++ b/pgqueuer/adapters/django/executors.py
@@ -1,0 +1,80 @@
+"""Bridge a Django task function into a pgqueuer entrypoint.
+
+A ``django.tasks`` task function is an ordinary synchronous callable, while
+pgqueuer entrypoints are coroutines. :func:`build_entrypoint` wraps the former
+into the latter via :func:`asgiref.sync.sync_to_async`, which keeps the
+``Entrypoint`` type honest and means the stock
+:class:`~pgqueuer.core.executors.EntrypointExecutor` can run it unchanged.
+
+Threading policy lives here because it is a Django concern:
+
+``thread_sensitive=True`` (the default) runs every handler on one shared thread,
+because database adapters require access from the thread that created them. Jobs
+therefore **serialize**, and throughput scales with worker processes rather than
+with ``concurrency_limit``.
+
+``thread_sensitive=False`` runs handlers concurrently, but each call gets a fresh
+thread, hence a fresh Django connection wrapper and a fresh Postgres session.
+Those sessions leak unless closed, so the wrapper always calls
+``connections.close_all()`` on the way out.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from asgiref.sync import sync_to_async
+from django.db import connections
+
+from pgqueuer.core.executors import AsyncEntrypoint
+from pgqueuer.domain import models
+
+
+def build_entrypoint(
+    func: Callable[..., Any],
+    *,
+    thread_sensitive: bool = True,
+    result_table: str | None = None,
+) -> AsyncEntrypoint:
+    """Wrap the synchronous Django task *func* as an async pgqueuer entrypoint.
+
+    The job payload carries ``args``, ``kwargs`` and ``result_id`` as written by
+    :meth:`~pgqueuer.adapters.django.backend.PgqueuerBackend.enqueue`.
+
+    When *result_table* is set, the return value is recorded there keyed by
+    ``result_id``. This is a stand-in for real result storage and is expected to
+    be replaced by a JSONB column on the job row.
+    """
+
+    def call(job: models.Job) -> None:
+        payload = json.loads(job.payload) if job.payload else {}
+        args = payload.get("args", [])
+        kwargs = payload.get("kwargs", {})
+        try:
+            return_value = func(*args, **kwargs)
+            if result_table is not None:
+                record_result(result_table, payload.get("result_id"), return_value)
+        finally:
+            # Only needed when each job got its own thread, and therefore its own
+            # connection wrapper, which would otherwise leak a Postgres session.
+            # Under thread_sensitive=True one thread is reused, so closing here
+            # would just churn the connection on every job.
+            if not thread_sensitive:
+                connections.close_all()
+
+    async def entrypoint(job: models.Job) -> None:
+        await sync_to_async(call, thread_sensitive=thread_sensitive)(job)
+
+    return entrypoint
+
+
+def record_result(table: str, result_id: str | None, return_value: Any) -> None:
+    """Store *return_value* against *result_id*. Table name is caller-controlled."""
+    if result_id is None:
+        return
+    with connections["default"].cursor() as cursor:
+        cursor.execute(
+            f'UPDATE "{table}" SET status = %s, return_value = %s WHERE result_id = %s',
+            ["SUCCESSFUL", json.dumps(return_value), result_id],
+        )

--- a/pgqueuer/adapters/django/management/__init__.py
+++ b/pgqueuer/adapters/django/management/__init__.py
@@ -1,0 +1,1 @@
+"""Django management command package."""

--- a/pgqueuer/adapters/django/management/commands/__init__.py
+++ b/pgqueuer/adapters/django/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""PgQueuer management commands."""

--- a/pgqueuer/adapters/django/management/commands/pgqworker.py
+++ b/pgqueuer/adapters/django/management/commands/pgqworker.py
@@ -1,0 +1,66 @@
+"""``manage.py pgqworker`` — run a pgqueuer worker for this Django project."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from typing import Any
+
+from asgiref.sync import async_to_sync
+from django.core.management.base import BaseCommand
+from django.db import connections
+
+from pgqueuer.adapters.django.worker import run_worker
+
+
+class Command(BaseCommand):
+    help = "Run a PgQueuer worker for the tasks declared in this project."
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--database",
+            default="default",
+            help="Django database alias to derive the worker connection from.",
+        )
+        parser.add_argument(
+            "--tasks-module",
+            action="append",
+            dest="task_modules",
+            help="Module declaring tasks. Repeatable. Defaults to every app's 'tasks' module.",
+        )
+        parser.add_argument(
+            "--queue-name",
+            action="append",
+            dest="queue_names",
+            help="Only serve tasks on this queue. Repeatable. Defaults to all queues.",
+        )
+        parser.add_argument(
+            "--concurrency",
+            type=int,
+            default=0,
+            help="Per-entrypoint concurrency limit; 0 means unlimited.",
+        )
+        parser.add_argument(
+            "--no-thread-sensitive",
+            action="store_false",
+            dest="thread_sensitive",
+            help=(
+                "Run handlers on independent threads instead of one shared thread. "
+                "Faster, but each handler gets its own database connection."
+            ),
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        # async_to_sync rather than asyncio.run: it is what enables
+        # sync_to_async's thread_sensitive mode below it.
+        try:
+            async_to_sync(run_worker)(
+                alias=options["database"],
+                task_modules=options["task_modules"],
+                queue_names=options["queue_names"],
+                concurrency_limit=options["concurrency"],
+                thread_sensitive=options["thread_sensitive"],
+            )
+        finally:
+            # Sync context: close_all() is @async_unsafe and cannot run inside
+            # the loop.
+            connections.close_all()

--- a/pgqueuer/adapters/django/worker.py
+++ b/pgqueuer/adapters/django/worker.py
@@ -1,0 +1,69 @@
+"""Run a pgqueuer worker over the tasks declared in a Django project.
+
+The worker deliberately does **not** use Django's connection: Django has no
+async database layer, so its connection cannot hold the long-lived ``LISTEN``
+that pgqueuer's dispatch depends on. It opens its own connection instead, using
+parameters derived from Django's configuration.
+
+Connection cleanup is deliberately *not* done here: ``connections.close_all()``
+is decorated ``@async_unsafe`` and raises ``SynchronousOnlyOperation`` when
+called from a coroutine. Callers close from sync context after the loop exits —
+see the ``pgqworker`` management command.
+"""
+
+from __future__ import annotations
+
+import psycopg
+
+from pgqueuer.adapters.django.discovery import discover_tasks
+from pgqueuer.adapters.django.driver import worker_connection_params
+from pgqueuer.adapters.django.executors import build_entrypoint
+from pgqueuer.adapters.drivers.psycopg import PsycopgDriver
+from pgqueuer.adapters.persistence.queries import Queries
+from pgqueuer.core.executors import EntrypointExecutor, EntrypointExecutorParameters
+from pgqueuer.core.qm import QueueManager
+from pgqueuer.domain import types
+
+
+async def run_worker(
+    *,
+    alias: str = "default",
+    task_modules: list[str] | None = None,
+    queue_names: list[str] | None = None,
+    concurrency_limit: int = 0,
+    thread_sensitive: bool = True,
+    result_table: str | None = None,
+    mode: types.QueueExecutionMode = types.QueueExecutionMode.continuous,
+) -> None:
+    """Register every discovered task as an entrypoint and process jobs.
+
+    *queue_names* filters discovered tasks by queue; omit it to take all of them.
+    *mode* accepts ``drain`` to exit once the queue is empty, which is what tests
+    want.
+    """
+    tasks = discover_tasks(task_modules)
+    if queue_names is not None:
+        allowed = set(queue_names)
+        tasks = {name: task for name, task in tasks.items() if task.queue_name in allowed}
+
+    params = worker_connection_params(alias)
+    connection = await psycopg.AsyncConnection.connect(**params, autocommit=True)
+    try:
+        manager = QueueManager(Queries(PsycopgDriver(connection)))
+        for entrypoint, task in tasks.items():
+            manager.register_executor(
+                entrypoint,
+                EntrypointExecutor(
+                    EntrypointExecutorParameters(
+                        concurrency_limit=concurrency_limit,
+                        func=build_entrypoint(
+                            task.func,
+                            thread_sensitive=thread_sensitive,
+                            result_table=result_table,
+                        ),
+                    )
+                ),
+            )
+        await manager.run(mode=mode)
+    finally:
+        await connection.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,13 @@ docs = [
 dev = [
     "async-timeout>=5.0.1",
 ]
+# Not part of `dev`, and deliberately not an extra: Django 6.1 requires Python
+# 3.12+, while the CI matrix covers 3.10-3.14 and installs every extra. Keeping
+# it in its own group leaves existing jobs untouched.
+#     uv sync --all-extras --group django --frozen
+django = [
+    "django>=6.1; python_version >= '3.12'",
+]
 
 [tool.ruff]
 line-length = 100

--- a/test/django_support.py
+++ b/test/django_support.py
@@ -1,0 +1,94 @@
+"""Shared Django bootstrap for the adapter tests.
+
+Django settings are process-global and ``settings.configure()`` may only run
+once, so every Django-touching test module goes through :func:`configure_django`
+rather than configuring its own. Per-test database changes go through
+:func:`use_databases`, which works around the fact that plain
+``override_settings(DATABASES=...)`` is silently ineffective.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+PLACEHOLDER_DATABASES: dict[str, dict[str, Any]] = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "placeholder",
+        "USER": "placeholder",
+        "HOST": "localhost",
+        "PORT": "5432",
+    }
+}
+
+
+def configure_django() -> None:
+    """Configure and initialise Django once per process. Opens no connection."""
+    import django
+    from django.conf import settings
+
+    if settings.configured:
+        return
+
+    settings.configure(
+        DEBUG=False,
+        SECRET_KEY="test-only-not-a-secret",
+        USE_TZ=True,
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "pgqueuer.adapters.django",
+        ],
+        DATABASES=PLACEHOLDER_DATABASES,
+        TASKS={
+            "default": {
+                "BACKEND": "pgqueuer.adapters.django.backend.PgqueuerBackend",
+                "QUEUES": [],
+            }
+        },
+    )
+    django.setup()
+
+
+def reset_connection_handler() -> None:
+    """Force Django to rebuild connections from the current DATABASES setting.
+
+    ``override_settings(DATABASES=...)`` on its own does nothing once anything
+    has touched ``connections``: the handler caches the setting both in a
+    ``cached_property`` and in ``_settings``, and ``setting_changed`` invalidates
+    neither. That is what Django's "can lead to unexpected behavior" warning
+    means in practice. Django's own test runner sidesteps it by building test
+    databases before any connection exists.
+
+    Existing connections are *discarded, not closed*: ``close()`` is
+    ``@async_unsafe`` and raises if called inside a coroutine. Closing is the
+    caller's job, from sync context.
+    """
+    from django.db import connections
+
+    for alias in list(connections):
+        with contextlib.suppress(AttributeError):
+            del connections[alias]
+    connections._settings = None
+    connections.__dict__.pop("settings", None)
+
+
+@contextmanager
+def use_databases(
+    databases: dict[str, dict[str, Any]],
+    **other_settings: Any,
+) -> Iterator[None]:
+    """Point Django at *databases* for the duration of the block.
+
+    Resets the connection handler on both entry and exit, so tests are
+    independent of each other's ordering.
+    """
+    from django.test.utils import override_settings
+
+    with override_settings(DATABASES=databases, **other_settings):
+        reset_connection_handler()
+        try:
+            yield
+        finally:
+            reset_connection_handler()

--- a/test/integration/test_django_tracer.py
+++ b/test/integration/test_django_tracer.py
@@ -1,0 +1,122 @@
+"""End-to-end test for examples/django_tracer.py.
+
+Drives the whole path: a sync task enqueued inside ``transaction.atomic()``, a
+pgqueuer worker on its own native connection, and the return value read back.
+
+Django's ORM is sync-only, so every Django call here goes through
+``asyncio.to_thread``; the worker itself is awaited directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+
+pytest.importorskip("django")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from test.django_support import configure_django, use_databases  # noqa: E402
+
+configure_django()
+
+from pgqueuer.domain import types  # noqa: E402
+
+pytestmark = pytest.mark.timeout(90)
+
+
+def django_databases(dsn: str) -> dict[str, dict[str, Any]]:
+    parsed = urlparse(dsn)
+    return {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": parsed.path.lstrip("/"),
+            "USER": parsed.username or "",
+            "PASSWORD": parsed.password or "",
+            "HOST": parsed.hostname or "",
+            "PORT": str(parsed.port or 5432),
+            "OPTIONS": {},
+            "CONN_MAX_AGE": 0,
+            "TIME_ZONE": None,
+            "CONN_HEALTH_CHECKS": False,
+            "AUTOCOMMIT": True,
+            "ATOMIC_REQUESTS": False,
+        }
+    }
+
+
+async def test_sync_task_enqueued_transactionally_and_run_by_worker(dsn: str) -> None:
+    from django.core.management import call_command
+    from django.db import connections, transaction
+    from django.tasks.base import TaskResultStatus
+
+    from examples import django_tracer as tracer
+
+    databases = django_databases(dsn)
+    tasks = {
+        "default": {
+            "BACKEND": f"{tracer.__name__}.TracerBackend",
+            "QUEUES": [],
+        }
+    }
+
+    def setup() -> None:
+        # The dsn fixture already installed the pgqueuer schema; contenttypes
+        # and the example's result table are ours to create.
+        call_command("migrate", "contenttypes", verbosity=0)
+        tracer.create_result_table()
+
+    def enqueue_and_roll_back() -> tuple[int, int]:
+        """Return the queue depth seen inside the transaction, then after rollback."""
+        inside = 0
+        try:
+            with transaction.atomic():
+                tracer.count_content_types.enqueue()
+                inside = tracer.queued_count()
+                raise RuntimeError("deliberate rollback")
+        except RuntimeError:
+            pass
+        return inside, tracer.queued_count()
+
+    def enqueue_and_commit() -> tuple[str, int]:
+        with transaction.atomic():
+            result = tracer.count_content_types.enqueue()
+        return result.id, tracer.queued_count()
+
+    def read_result(result_id: str) -> tuple[Any, Any]:
+        refreshed = tracer.count_content_types.get_result(result_id)
+        return refreshed.status, refreshed.return_value
+
+    with use_databases(databases, TASKS=tasks):
+        try:
+            await asyncio.to_thread(setup)
+
+            # Transactional enqueue: visible inside the block, gone after rollback.
+            inside, after_rollback = await asyncio.to_thread(enqueue_and_roll_back)
+            assert inside == 1
+            assert after_rollback == 0
+
+            result_id, after_commit = await asyncio.to_thread(enqueue_and_commit)
+            assert after_commit == 1
+
+            # The worker opens its own native connection; drain exits when empty.
+            await tracer.run_worker(
+                task_modules=[tracer.__name__],
+                result_table=tracer.RESULT_TABLE,
+                mode=types.QueueExecutionMode.drain,
+            )
+            assert await asyncio.to_thread(tracer.queued_count) == 0
+
+            status, return_value = await asyncio.to_thread(read_result, result_id)
+            assert status == TaskResultStatus.SUCCESSFUL
+            # One ContentType row exists per model in INSTALLED_APPS; the point
+            # is that the sync ORM read worked at all, not the exact count.
+            assert isinstance(return_value, int)
+            assert return_value >= 1
+        finally:
+            await asyncio.to_thread(connections.close_all)

--- a/test/test_django_adapter.py
+++ b/test/test_django_adapter.py
@@ -1,0 +1,117 @@
+"""Unit tests for the Django adapter. No Postgres, no real Django project.
+
+Covers parameter derivation, entrypoint naming, task discovery and the
+sync-to-async wrapper. Django is configured but never connects.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+pytest.importorskip("django")
+
+from test.django_support import configure_django, use_databases  # noqa: E402
+
+configure_django()
+
+from django.tasks import task  # noqa: E402
+
+from pgqueuer.adapters.django.backend import entrypoint_name  # noqa: E402
+from pgqueuer.adapters.django.discovery import discover_tasks, tasks_in_module  # noqa: E402
+from pgqueuer.adapters.django.driver import worker_connection_params  # noqa: E402
+from pgqueuer.adapters.django.executors import build_entrypoint  # noqa: E402
+from pgqueuer.domain import models  # noqa: E402
+
+
+@task()
+def sample_task(value: int, offset: int = 0) -> int:
+    """A plain sync task, declared at module level as django.tasks requires."""
+    return value + offset
+
+
+def make_job(payload: dict[str, Any] | None) -> models.Job:
+    now = models.utc_now()
+    return models.Job(
+        id=models.JobId(1),
+        priority=0,
+        created=now,
+        updated=now,
+        heartbeat=now,
+        execute_after=now,
+        status="picked",
+        entrypoint="queue:sample",
+        payload=None if payload is None else json.dumps(payload).encode(),
+        queue_manager_id=None,
+        headers=None,
+    )
+
+
+def test_worker_connection_params_are_psycopg_ready() -> None:
+    databases = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": "derived_db",
+            "USER": "someone",
+            "HOST": "localhost",
+            "PORT": "5432",
+            "OPTIONS": {"connect_timeout": 3},
+        }
+    }
+    with use_databases(databases):
+        params = worker_connection_params()
+
+    # Django's NAME becomes psycopg's dbname, and OPTIONS pass through.
+    assert params["dbname"] == "derived_db"
+    assert params["connect_timeout"] == 3
+    # Keys psycopg.connect() itself rejects must be gone.
+    assert "cursor_factory" not in params
+    assert "context" not in params
+
+
+def test_entrypoint_name_is_queue_prefixed() -> None:
+    assert entrypoint_name(sample_task) == f"default:{__name__}.sample_task"
+
+
+def test_tasks_in_module_finds_declared_tasks() -> None:
+    assert sample_task in list(tasks_in_module(__name__))
+
+
+def test_discover_tasks_keys_by_entrypoint_name() -> None:
+    discovered = discover_tasks([__name__])
+    assert discovered[f"default:{__name__}.sample_task"] is sample_task
+
+
+async def test_build_entrypoint_runs_a_sync_callable() -> None:
+    seen: list[int] = []
+
+    def handler(value: int, offset: int = 0) -> None:
+        seen.append(value + offset)
+
+    entrypoint = build_entrypoint(handler)
+    await entrypoint(make_job({"args": [40], "kwargs": {"offset": 2}}))
+
+    assert seen == [42]
+
+
+async def test_build_entrypoint_tolerates_an_empty_payload() -> None:
+    calls: list[int] = []
+
+    def handler() -> None:
+        calls.append(1)
+
+    entrypoint = build_entrypoint(handler)
+    await entrypoint(make_job(None))
+
+    assert calls == [1]
+
+
+async def test_build_entrypoint_propagates_handler_errors() -> None:
+    def handler() -> None:
+        raise ValueError("handler blew up")
+
+    entrypoint = build_entrypoint(handler)
+    with pytest.raises(ValueError, match="handler blew up"):
+        await entrypoint(make_job({"args": [], "kwargs": {}}))

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
@@ -28,6 +29,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
 ]
 
 [[package]]
@@ -544,6 +554,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/6d/73557ed0ef7d73d04d9aba745d2c8e95218213687ee5e76b7d236a5030fc/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b", size = 4217595, upload-time = "2026-03-25T23:34:44.205Z" },
     { url = "https://files.pythonhosted.org/packages/9e/c5/e1594c4eec66a567c3ac4400008108a415808be2ce13dcb9a9045c92f1a0/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a", size = 4380912, upload-time = "2026-03-25T23:34:46.328Z" },
     { url = "https://files.pythonhosted.org/packages/1a/89/843b53614b47f97fe1abc13f9a86efa5ec9e275292c457af1d4a60dc80e0/cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e", size = 3409955, upload-time = "2026-03-25T23:34:48.465Z" },
+]
+
+[[package]]
+name = "django"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]
@@ -1430,6 +1454,9 @@ web = [
 dev = [
     { name = "async-timeout" },
 ]
+django = [
+    { name = "django", marker = "python_full_version >= '3.12'" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1492,6 +1519,7 @@ provides-extras = ["asyncpg", "psycopg", "logfire", "sentry", "opentelemetry", "
 
 [package.metadata.requires-dev]
 dev = [{ name = "async-timeout", specifier = ">=5.0.1" }]
+django = [{ name = "django", marker = "python_full_version >= '3.12'", specifier = ">=6.1" }]
 
 [[package]]
 name = "platformdirs"
@@ -2190,6 +2218,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Django 6.0 shipped django.tasks with no worker, and Django's own docs delegate execution to the ecosystem. This adds the enqueue half as a BaseTaskBackend implementation plus a `manage.py pgqworker` command for the execution half.

Enqueue borrows Django's own connection, so a job joins the caller's transaction.atomic() and disappears with it on rollback. The worker opens a separate native psycopg connection, because Django has no async database layer and its connection therefore cannot hold LISTEN.

Requires no changes under pgqueuer/core/. A Django task function is synchronous, so the adapter wraps it in an async closure via asgiref.sync_to_async; is_async_callable then accepts it and the stock EntrypointExecutor runs it unchanged.

Threading policy is deliberate. thread_sensitive=True is the default because database adapters require access from their creating thread; jobs therefore serialize and throughput scales with worker processes rather than concurrency_limit. Under thread_sensitive=False each job gets its own thread and connection, so connections are closed after every job to avoid leaking sessions.

Django is declared as a dependency group rather than an extra: it needs Python 3.12+, while CI installs every extra across 3.10-3.14. Existing jobs are unaffected and the new tests skip when Django is absent.

examples/django_tracer.py is an end-to-end walkthrough. Its result storage is a stand-in for a real result column and is not a supported API.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
