### PR TITLE
docs: explain when PgQueuer fits (#749)

### DIFF
--- a/docs/comparisons/celery-comparison.md
+++ b/docs/comparisons/celery-comparison.md
@@ -170,21 +170,13 @@ async def wait_for_job() -> None:
         print(status)
 ```
 
-## When PgQueuer Is a Good Fit
+## Choosing Between Them
 
-- You're already using PostgreSQL and want to avoid an extra broker service
-- You value stack simplicity and reduced operational overhead
-- You need lightweight recurring jobs without running `celery-beat`
-- Your workload fits within PostgreSQL's throughput characteristics
-- You want transactional enqueuing (enqueue a job in the same transaction as your app data)
+Celery is a mature project with a long history. Its advantages over PgQueuer are
+canvas primitives for task composition, brokers that are not tied to one language,
+and throughput beyond a single PostgreSQL instance. PgQueuer's advantages are the
+ones visible in the examples above: no broker, no beat process, and enqueuing inside
+the transaction that writes your application data.
 
-## When Celery May Be Better
-
-Celery is a mature project with a long history. It may be the better choice when:
-
-- You need complex multi-step workflows (chains, chords, groups)
-- You require canvas primitives for task composition
-- Your system spans multiple languages or needs a non-Python broker
-- You need very high throughput beyond what a single PostgreSQL instance can deliver
-
-For more details on PgQueuer's throughput characteristics, see [Benchmarks](benchmarks.md).
+[When to use PgQueuer](../getting-started/when-to-use.md) works through the fit
+question in full, and [Benchmarks](benchmarks.md) covers throughput.

--- a/docs/getting-started/when-to-use.md
+++ b/docs/getting-started/when-to-use.md
@@ -1,107 +1,40 @@
 # When to use PgQueuer
 
-PgQueuer is a good fit when your application already uses PostgreSQL and needs
-background work without another broker service. It is an async-first job queue,
-not a general workflow engine.
+PgQueuer is an async Python job queue that keeps jobs in the PostgreSQL database
+you already run. This page covers where that design stops being a good idea.
 
-## Good fits
+## A good fit
 
-### Your application already depends on PostgreSQL
+The case for it is short: if the application already runs PostgreSQL, the queue
+can share the database's backups, monitoring, and access rules, and a producer can
+enqueue a job in the same transaction that writes the row the job is about.
+[Why PostgreSQL?](../index.md#why-postgresql) makes that argument in full, and
+[PgQueuer vs Celery](../comparisons/celery-comparison.md) puts it next to the
+usual alternative.
 
-Jobs, schedules, and execution logs live in PostgreSQL. You do not need Redis or
-RabbitMQ alongside it. Workers use `LISTEN/NOTIFY` for prompt wakeups and
-`FOR UPDATE SKIP LOCKED` to claim jobs safely.
+Two requirements are worth checking before you go further. Handlers run as
+`async def` in a Python worker process, and a job can run more than once, because
+a worker that dies mid-job leaves its job to be retried.
 
-This design is useful when the queue should follow the same backup, access, and
-monitoring practices as the rest of your application database.
+## Use a different design when
 
-### A database change and its job must commit together
+No configuration flag removes the limits below. They follow from the design.
 
-PgQueuer accepts connections created by your application. A producer can enqueue
-a job inside the transaction that updates application data, so both changes commit
-or roll back together.
+| Requirement | Where PgQueuer stops |
+|-------------|----------------------|
+| Native synchronous handlers | Handlers must be `async def`. Sync code can enqueue through psycopg, and blocking calls can go through `asyncio.to_thread()`, but the worker is asyncio |
+| Chains, groups, chords, or DAGs | PgQueuer processes independent jobs; it does not persist dependencies between them. Application code can enqueue follow-up work, but nothing resumes a half-finished graph after a crash |
+| Reading a job's return value | Nothing stores what a handler returns. `CompletionWatcher` reports the final status, so results have to go somewhere the caller can read them |
+| Passing typed arguments | Payloads are `bytes`. Encoding and decoding are application code, with no argument signature to validate against |
+| Workers in several languages | The queue tables are readable by any PostgreSQL client, but worker registration, retries, cancellation, and tracing are Python APIs |
+| Queue traffic isolated from the primary database | Claims, heartbeats, and logs all consume PostgreSQL resources on the same instance as your application queries |
+| Hard isolation for CPU-heavy or untrusted tasks | Handlers run in the worker process. There is no built-in process pool, so a runaway job affects everything sharing that worker |
 
-### Your handlers are asynchronous
-
-Entrypoint handlers use `async def`, which suits jobs that spend most of their
-time on database, HTTP, or other network I/O. Synchronous applications can still
-enqueue jobs through `SyncPsycopgDriver`, but workers and handlers remain
-asynchronous. See [Drivers](../reference/drivers.md).
-
-### You need queue controls without a separate scheduler
-
-PgQueuer includes:
-
-- priority and delayed execution
-- cron schedules with minute or second precision
-- database-wide concurrency limits per entrypoint
-- deduplication for queued and running jobs
-- cancellation and completion notifications
-- durable retries and manual re-queueing
-- heartbeat-based recovery after a worker crash
-
-The [Core Concepts](core-concepts.md) and [Reliability Model](../guides/reliability.md)
-describe how these controls interact.
-
-### Operators need to inspect the queue
-
-PgQueuer exposes queue state through PostgreSQL tables, CLI commands, Prometheus
-metrics, distributed tracing, and an optional web dashboard. The in-memory adapter
-provides the same queue API for tests that do not need PostgreSQL behavior.
-
-## Cases that need a different design
-
-### Handlers must be synchronous
-
-PgQueuer does not run plain `def` handlers. Blocking libraries can be called from
-an async handler with `asyncio.to_thread()`, but applications built mainly around
-synchronous task functions may prefer a queue with native sync workers.
-
-### You need chains, groups, chords, or DAG orchestration
-
-PgQueuer schedules and processes independent jobs. It does not provide workflow
-primitives for expressing dependencies between jobs. Application code can enqueue
-follow-up work, and `CompletionWatcher` can wait for several jobs, but these are not
-a durable workflow graph.
-
-### Workers are written in several languages
-
-The queue tables are visible to any PostgreSQL client, but PgQueuer's worker,
-registration, retry, cancellation, and tracing APIs are Python APIs. A system that
-needs workers implemented in several languages should use a language-neutral
-protocol or broker.
-
-### The primary database should not carry queue traffic
-
-Queue writes, claims, heartbeats, and logs consume PostgreSQL resources. This is
-usually the intended tradeoff, but it may not suit systems that isolate background
-traffic from the application database. Test the expected workload and read
-[Performance Tuning](../guides/performance-tuning.md) before committing to the
-architecture.
-
-### Tasks need hard process isolation
-
-PgQueuer runs async handlers in the worker process. It does not provide a built-in
-process pool for CPU-heavy or untrusted code. Run such work in a separate service
-or use a task system designed around process isolation.
-
-## Requirements and boundaries
-
-| Concern | PgQueuer behavior |
-|---------|--------------------|
-| Python | 3.10 or newer |
-| PostgreSQL | 12 or newer |
-| Worker model | Asyncio; entrypoints must use `async def` |
-| Sync applications | Can enqueue through psycopg |
-| Delivery | At least once after worker-crash recovery; handlers should be idempotent |
-| Payload | Application-owned `bytes` payload |
-| Recurring work | Built-in 5-field or 6-field cron schedules |
-| Workflow graphs | Not provided |
-| Other languages | No worker SDK or language-neutral task protocol |
+Database load is measurable, so measure it: run your expected workload against a
+test instance before you commit to the architecture.
+[Performance Tuning](../guides/performance-tuning.md) covers the knobs.
 
 ## Next steps
 
-- [Install PgQueuer](installation.md)
 - [Build a producer and consumer](quickstart.md)
-- [Review the reliability model](../guides/reliability.md)
 - [Plan a production deployment](../guides/deployment.md)

--- a/docs/getting-started/when-to-use.md
+++ b/docs/getting-started/when-to-use.md
@@ -1,0 +1,107 @@
+# When to use PgQueuer
+
+PgQueuer is a good fit when your application already uses PostgreSQL and needs
+background work without another broker service. It is an async-first job queue,
+not a general workflow engine.
+
+## Good fits
+
+### Your application already depends on PostgreSQL
+
+Jobs, schedules, and execution logs live in PostgreSQL. You do not need Redis or
+RabbitMQ alongside it. Workers use `LISTEN/NOTIFY` for prompt wakeups and
+`FOR UPDATE SKIP LOCKED` to claim jobs safely.
+
+This design is useful when the queue should follow the same backup, access, and
+monitoring practices as the rest of your application database.
+
+### A database change and its job must commit together
+
+PgQueuer accepts connections created by your application. A producer can enqueue
+a job inside the transaction that updates application data, so both changes commit
+or roll back together.
+
+### Your handlers are asynchronous
+
+Entrypoint handlers use `async def`, which suits jobs that spend most of their
+time on database, HTTP, or other network I/O. Synchronous applications can still
+enqueue jobs through `SyncPsycopgDriver`, but workers and handlers remain
+asynchronous. See [Drivers](../reference/drivers.md).
+
+### You need queue controls without a separate scheduler
+
+PgQueuer includes:
+
+- priority and delayed execution
+- cron schedules with minute or second precision
+- database-wide concurrency limits per entrypoint
+- deduplication for queued and running jobs
+- cancellation and completion notifications
+- durable retries and manual re-queueing
+- heartbeat-based recovery after a worker crash
+
+The [Core Concepts](core-concepts.md) and [Reliability Model](../guides/reliability.md)
+describe how these controls interact.
+
+### Operators need to inspect the queue
+
+PgQueuer exposes queue state through PostgreSQL tables, CLI commands, Prometheus
+metrics, distributed tracing, and an optional web dashboard. The in-memory adapter
+provides the same queue API for tests that do not need PostgreSQL behavior.
+
+## Cases that need a different design
+
+### Handlers must be synchronous
+
+PgQueuer does not run plain `def` handlers. Blocking libraries can be called from
+an async handler with `asyncio.to_thread()`, but applications built mainly around
+synchronous task functions may prefer a queue with native sync workers.
+
+### You need chains, groups, chords, or DAG orchestration
+
+PgQueuer schedules and processes independent jobs. It does not provide workflow
+primitives for expressing dependencies between jobs. Application code can enqueue
+follow-up work, and `CompletionWatcher` can wait for several jobs, but these are not
+a durable workflow graph.
+
+### Workers are written in several languages
+
+The queue tables are visible to any PostgreSQL client, but PgQueuer's worker,
+registration, retry, cancellation, and tracing APIs are Python APIs. A system that
+needs workers implemented in several languages should use a language-neutral
+protocol or broker.
+
+### The primary database should not carry queue traffic
+
+Queue writes, claims, heartbeats, and logs consume PostgreSQL resources. This is
+usually the intended tradeoff, but it may not suit systems that isolate background
+traffic from the application database. Test the expected workload and read
+[Performance Tuning](../guides/performance-tuning.md) before committing to the
+architecture.
+
+### Tasks need hard process isolation
+
+PgQueuer runs async handlers in the worker process. It does not provide a built-in
+process pool for CPU-heavy or untrusted code. Run such work in a separate service
+or use a task system designed around process isolation.
+
+## Requirements and boundaries
+
+| Concern | PgQueuer behavior |
+|---------|--------------------|
+| Python | 3.10 or newer |
+| PostgreSQL | 12 or newer |
+| Worker model | Asyncio; entrypoints must use `async def` |
+| Sync applications | Can enqueue through psycopg |
+| Delivery | At least once after worker-crash recovery; handlers should be idempotent |
+| Payload | Application-owned `bytes` payload |
+| Recurring work | Built-in 5-field or 6-field cron schedules |
+| Workflow graphs | Not provided |
+| Other languages | No worker SDK or language-neutral task protocol |
+
+## Next steps
+
+- [Install PgQueuer](installation.md)
+- [Build a producer and consumer](quickstart.md)
+- [Review the reliability model](../guides/reliability.md)
+- [Plan a production deployment](../guides/deployment.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -192,5 +192,6 @@ are backed by PostgreSQL and you want a simpler operational footprint.
 - **[Installation](getting-started/installation.md)**: install PgQueuer and set up the database schema
 - **[Quick Start](getting-started/quickstart.md)**: build your first consumer and producer in 5 minutes
 - **[Core Concepts](getting-started/core-concepts.md)**: understand jobs, entrypoints, and the status lifecycle
+- **[When to Use PgQueuer](getting-started/when-to-use.md)**: check whether its worker model and PostgreSQL architecture fit your application
 - **[Architecture](reference/architecture.md)**: how data flows from producer to consumer
 - **[Upgrading from 0.x](getting-started/upgrading.md)**: migration guide for users coming from pre-1.0 releases

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,7 +9,7 @@ can enqueue jobs through psycopg. Applications own payload serialization and pas
 
 ## Start here
 
-- [When to use PgQueuer](https://raw.githubusercontent.com/janbjorge/pgqueuer/main/docs/getting-started/when-to-use.md): Fit, requirements, and boundaries
+- [When to use PgQueuer](https://raw.githubusercontent.com/janbjorge/pgqueuer/main/docs/getting-started/when-to-use.md): Fit criteria and design limits
 - [Installation](https://raw.githubusercontent.com/janbjorge/pgqueuer/main/docs/getting-started/installation.md): Package extras, schema setup, and connections
 - [Quick start](https://raw.githubusercontent.com/janbjorge/pgqueuer/main/docs/getting-started/quickstart.md): Producer, consumer, and worker example
 - [Core concepts](https://raw.githubusercontent.com/janbjorge/pgqueuer/main/docs/getting-started/core-concepts.md): Jobs, entrypoints, statuses, and schedules

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
       - Core Concepts: getting-started/core-concepts.md
+      - When to Use PgQueuer: getting-started/when-to-use.md
       - Upgrading from 0.x: getting-started/upgrading.md
   - Guides:
       - Job Processing:


### PR DESCRIPTION
## Summary
- add `docs/getting-started/when-to-use.md` for deciding whether PgQueuer's design fits an application
- keep the page focused on the limits, since the home page already argues for the PostgreSQL-backed design
- replace the duplicated fit/no-fit lists in the Celery comparison with a pointer to the guide

## Notes
The page deliberately does not restate features documented elsewhere. The fit
case links to `index.md#why-postgresql`, and the nav already lists the guides a
feature-index table would have pointed at.

The limits table is the part no other page covers, including three boundaries
checked against the source rather than assumed:
- return values are not stored; `CompletionWatcher.wait_for` returns `JOB_STATUS`
  (`pgqueuer/core/completion.py:84`, `pgqueuer/domain/models.py:82-99`)
- payloads are `bytes`, so there is no argument signature to validate against
- handlers share the worker process; there is no built-in process pool

Also drops a pointer that promised supported Python and PostgreSQL versions in
`installation.md`, which does not document them. Those live in the README
(Python 3.11+, PostgreSQL 12+), which disagrees with `pyproject.toml`
(`requires-python = ">=3.10"`). Left alone here; worth a separate fix.

The `llms.txt` entry for the page is retitled to match what it now covers.

## Test plan
- [x] `uv run mkdocs build --strict` passes, no broken links
- [x] `git diff --check`

## Project
Implements item 06 in the [PgQueuer adoption and ecosystem project](https://github.com/users/janbjorge/projects/2).
