### PR TITLE
docs: correct the documented Python floor to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you already run PostgreSQL, it can do double duty as your job queue. That mea
 
 ## Installation
 
-PgQueuer targets Python 3.10+ and PostgreSQL 12+:
+PgQueuer targets Python 3.10+ and PostgreSQL 13+:
 
 ```bash
 pip install pgqueuer

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you already run PostgreSQL, it can do double duty as your job queue. That mea
 
 ## Installation
 
-PgQueuer targets Python 3.11+ and PostgreSQL 12+:
+PgQueuer targets Python 3.10+ and PostgreSQL 12+:
 
 ```bash
 pip install pgqueuer


### PR DESCRIPTION
## Summary
- README stated "Python 3.11+" while `pyproject.toml:23` declares `requires-python = ">=3.10"`, ships a 3.10 classifier, and sets mypy's `python_version = "3.10"`. CI has tested 3.10 all along.
- The rest of the repo was already correct: `docs/development/development.md:10` says 3.10+, and `docs/reference/drivers.md:88` documents the 3.10 event-loop workaround. The README was the only place contradicting the metadata.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- One line of prose in README.md. No code, config, or packaging changed, so the local check suite has nothing to exercise here. CI covers it.

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests (not applicable, prose only)
- [x] I have updated documentation if necessary