### PR TITLE
docs: add ADR-0001, job state lives in PostgreSQL

### DIFF
--- a/docs/adr/ADR-0001-job-state-lives-in-postgresql.md
+++ b/docs/adr/ADR-0001-job-state-lives-in-postgresql.md
@@ -1,0 +1,43 @@
+# ADR-0001: Job state lives in PostgreSQL
+
+- Status: Accepted (retroactive)
+- Date: 2026-08-23
+
+## Context
+
+A job queue needs a home for its state: queued jobs, running jobs,
+outcomes. The common answer is a dedicated broker such as Redis, RabbitMQ,
+or SQS. A broker is one more service to deploy, monitor, back up, and
+secure, and a job enqueued to it can never join the application's database
+transaction.
+
+## Decision
+
+The queue's source of truth is a PostgreSQL database the user already
+operates. PgQueuer is a library plus a schema. It introduces no broker
+process and no service of its own.
+
+## Alternatives considered
+
+- Dedicated broker (Redis, RabbitMQ, SQS): higher raw throughput and
+  purpose-built queue features, but new infrastructure and no
+  transactional enqueue alongside business data.
+- Database-agnostic SQL: portability across RDBMSes would forbid the
+  PostgreSQL features the design leans on, such as row locking behavior
+  and notifications. Rejected; PgQueuer is Postgres-only.
+
+## Consequences
+
+- Enqueue can share a transaction with business writes: the job exists
+  exactly when the commit succeeded.
+- The operational burden is the user's existing Postgres; backup, HA, and
+  monitoring are already in place.
+- The throughput ceiling is Postgres itself. Workloads beyond that need a
+  dedicated broker and are out of scope.
+- Every downstream decision (claiming, notifications, delivery
+  guarantees) is constrained to what PostgreSQL offers.
+
+## Not covered by this ADR
+
+Table layout and SQL, client-library choice (ADR-0014), how workers claim
+jobs (ADR-0002), what notifications carry (ADR-0003).

--- a/docs/adr/ADR-0001-job-state-lives-in-postgresql.md
+++ b/docs/adr/ADR-0001-job-state-lives-in-postgresql.md
@@ -1,7 +1,8 @@
 # ADR-0001: Job state lives in PostgreSQL
 
-- Status: Accepted (retroactive)
-- Date: 2026-08-23
+## Status
+
+Accepted (retroactive: documents existing behavior)
 
 ## Context
 
@@ -17,27 +18,45 @@ The queue's source of truth is a PostgreSQL database the user already
 operates. PgQueuer is a library plus a schema. It introduces no broker
 process and no service of its own.
 
-## Alternatives considered
-
-- Dedicated broker (Redis, RabbitMQ, SQS): higher raw throughput and
-  purpose-built queue features, but new infrastructure and no
-  transactional enqueue alongside business data.
-- Database-agnostic SQL: portability across RDBMSes would forbid the
-  PostgreSQL features the design leans on, such as row locking behavior
-  and notifications. Rejected; PgQueuer is Postgres-only.
-
 ## Consequences
+
+### Positive Consequences
 
 - Enqueue can share a transaction with business writes: the job exists
   exactly when the commit succeeded.
 - The operational burden is the user's existing Postgres; backup, HA, and
   monitoring are already in place.
+- One less system to secure and keep on-call for.
+
+### Negative Consequences
+
 - The throughput ceiling is Postgres itself. Workloads beyond that need a
   dedicated broker and are out of scope.
+- Queue traffic and business queries compete for the same database
+  resources.
 - Every downstream decision (claiming, notifications, delivery
   guarantees) is constrained to what PostgreSQL offers.
+
+## Alternatives Considered
+
+### Dedicated broker (Redis, RabbitMQ, SQS)
+
+Higher raw throughput and purpose-built queue features. Rejected because
+it adds new infrastructure and gives up transactional enqueue alongside
+business data, which is the core value proposition.
+
+### Database-agnostic SQL
+
+Portability across RDBMSes would forbid the PostgreSQL features the
+design leans on, such as row locking behavior and notifications.
+Rejected; PgQueuer is Postgres-only.
 
 ## Not covered by this ADR
 
 Table layout and SQL, client-library choice (ADR-0014), how workers claim
 jobs (ADR-0002), what notifications carry (ADR-0003).
+
+## References
+
+- [ADR index and backlog](README.md)
+- [When PgQueuer fits](../getting-started/when-to-use.md)


### PR DESCRIPTION
## What

First record from the ADR backlog (#753): the queue's source of truth is a PostgreSQL database the user already operates; PgQueuer ships no broker process.

## Notes

- Follows the team ADR template: Status, Context, Decision, Consequences (positive/negative), Alternatives Considered, References, plus the PgQueuer-specific "Not covered by this ADR" section required by the backlog conventions.
- Status is Accepted (retroactive): this documents existing behavior, the PR is the review of the record, not of the decision.
- The same file also rides the open `docs/system-design` branch (identical blob, merges clean either way).
- Backlog checkbox flip for 0001 comes with the next backlog touch.