### PR TITLE
docs: add ADR-0002, workers claim jobs by lock contention

### DIFF
--- a/docs/adr/ADR-0002-workers-claim-by-lock-contention.md
+++ b/docs/adr/ADR-0002-workers-claim-by-lock-contention.md
@@ -1,0 +1,75 @@
+# ADR-0002: Workers claim jobs by row-level lock contention, not assignment
+
+## Status
+
+Accepted (retroactive: documents existing behavior)
+
+## Context
+
+With job state in PostgreSQL (ADR-0001), multiple workers must divide the
+queued rows among themselves without running the same job twice. Two
+families of designs exist: a coordinator that assigns work to named
+workers through partitions, shards, or leases, and contention, where
+every worker races for eligible rows and the database's locking
+arbitrates.
+
+## Decision
+
+Any worker may claim any eligible job by winning a row-level lock. The
+claim query selects ready rows with `FOR UPDATE SKIP LOCKED`, so
+concurrent workers skip rows already locked by others instead of
+blocking or double-claiming. There is no coordinator process, no worker
+registry, and no assignment of partitions or shards to particular
+workers.
+
+## Consequences
+
+### Positive Consequences
+
+- Workers are homogeneous and stateless. Adding one needs no
+  registration; removing one leaves nothing to deregister.
+- No coordinator to elect, operate, or lose.
+- Claim safety is delegated to PostgreSQL's row locking; correctness
+  does not depend on workers cooperating with each other.
+
+### Negative Consequences
+
+- No fairness guarantee between workers: a fast worker close to the
+  database may win a disproportionate share of jobs.
+- Claiming concentrates lock traffic on the head of the queue; every
+  claim is a database round-trip under contention.
+- Job-to-worker affinity (routing a job to one specific machine) is not
+  expressible in the claim model; entrypoint naming is the workaround.
+
+## Alternatives Considered
+
+### Coordinator assigning work to named workers
+
+Partitioned or leased assignment gives fairness and affinity, but it
+requires worker identity, registration, and a rebalance protocol, plus
+something to run them. Rejected: PgQueuer ships no service of its own
+(ADR-0001), and the coordination machinery outweighs the problem at the
+scale a Postgres-backed queue serves.
+
+### Blocking `FOR UPDATE` without `SKIP LOCKED`
+
+Workers would queue on the same head rows and serialize. Rejected:
+throughput collapses as soon as a second worker starts.
+
+### Advisory locks per job
+
+The same contention model, but ownership would live in session state and
+vanish on disconnect or through a pooler. Rejected in favor of locking
+the job rows themselves; liveness is tracked as data instead
+(ADR-0005).
+
+## Not covered by this ADR
+
+The claim query's shape (single-statement CTE, batching, priority
+ordering), how concurrency limits gate claiming (ADR-0006), how stale
+jobs are detected and re-claimed (ADR-0005).
+
+## References
+
+- [ADR index and backlog](README.md)
+- [Row Locking & SKIP LOCKED](../reference/skip-locked.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,8 +17,8 @@ Conventions:
 
 ## Index
 
-(None merged yet. Check an item off in the backlog and list the merged
-record here.)
+- [ADR-0001: Job state lives in PostgreSQL](ADR-0001-job-state-lives-in-postgresql.md)
+- [ADR-0002: Workers claim jobs by row-level lock contention, not assignment](ADR-0002-workers-claim-by-lock-contention.md)
 
 ## Backlog
 
@@ -29,7 +29,7 @@ leaves open.
 
 ### Core model
 
-- [ ] **ADR-0001: Job state lives in PostgreSQL**
+- [x] **ADR-0001: Job state lives in PostgreSQL**
   - Decision: the queue's source of truth is a PostgreSQL database the user
     already operates; PgQueuer introduces no broker process.
   - Fork: dedicated broker (Redis/RabbitMQ/SQS) vs. the relational DB
@@ -39,7 +39,7 @@ leaves open.
     Everything downstream (0002 through 0011) inherits this.
   - Not covered: table layout, SQL, driver choice.
 
-- [ ] **ADR-0002: Workers claim jobs by row-level lock contention, not assignment**
+- [x] **ADR-0002: Workers claim jobs by row-level lock contention, not assignment**
   - Decision: any worker may claim any eligible job by winning a row lock.
     There is no coordinator and no assignment of partitions or shards to
     particular workers.


### PR DESCRIPTION
Records the claim model as an ADR: any worker claims any eligible job by winning a row-level lock (`FOR UPDATE SKIP LOCKED`); no coordinator, no worker registry, no partition assignment.

- Follows the ADR-0001 template (Status / Context / Decision / Consequences / Alternatives Considered / Not covered / References).
- Alternatives considered: coordinator assignment, blocking `FOR UPDATE`, per-job advisory locks.
- Updates the ADR index: lists merged ADR-0001 and ADR-0002, checks both off in the backlog.

`uv run mkdocs build --strict` passes.