### PR TITLE
docs: add ADR-0005, worker liveness is an application-level signal

### DIFF
--- a/docs/adr/ADR-0005-worker-liveness-is-application-signal.md
+++ b/docs/adr/ADR-0005-worker-liveness-is-application-signal.md
@@ -1,0 +1,79 @@
+# ADR-0005: Worker liveness is an application-level signal, not DB session state
+
+## Status
+
+Accepted (retroactive: documents existing behavior)
+
+## Context
+
+At-least-once delivery (ADR-0004) promises that a job owned by a dead
+worker reaches another worker. Something has to define "dead". The
+database offers a tempting shortcut: tie ownership to the session, for
+example through advisory locks, so a lost connection releases the jobs
+by itself. But connections are the least stable part of the stack.
+Poolers swap them, networks drop them, and a worker that reconnects
+after a blip is still alive and still mid-job.
+
+## Decision
+
+Workers prove liveness in data. Each running job carries a heartbeat
+timestamp that its worker refreshes periodically; a job whose heartbeat
+is older than a configured timeout counts as abandoned and becomes
+claimable again through the ordinary claim path (ADR-0002). Job
+ownership survives disconnects, reconnects, and pooler churn, because
+nothing about it lives in the DB session.
+
+## Consequences
+
+### Positive consequences
+
+- Ownership survives connection churn: a worker behind a pooler or a
+  flaky network keeps its jobs as long as it keeps heartbeating.
+- Liveness is queryable. An operator can inspect heartbeat age per job
+  with plain SQL instead of decoding lock tables.
+- Recovery needs no extra moving parts; stale detection is one
+  predicate inside the claim query that every worker already runs.
+
+### Negative consequences
+
+- Recovery latency is bounded by the timeout, not instant. A crashed
+  worker's jobs wait out the stale window before re-delivery.
+- A worker that stalls without dying, for example on a blocked event
+  loop, misses heartbeats and gets its job re-delivered while the
+  original run may still finish. This is the duplicate-run case
+  ADR-0004 already requires entrypoints to tolerate.
+- Heartbeats cost writes: every running job refreshes its row
+  periodically for as long as it runs.
+
+## Alternatives considered
+
+### Session-scoped locks or connection state
+
+Advisory locks or `FOR UPDATE` locks held for the duration of the run
+release the instant the connection dies, which makes detection free and
+immediate. Rejected: the same mechanism releases jobs on every pooler
+swap and network blip, turning routine connection churn into spurious
+re-deliveries, and lock state is awkward for operators to inspect.
+
+### External liveness service
+
+A membership registry (etcd-style leases, or a sidecar that watches
+workers) can separate "process alive" from "connection alive".
+Rejected: PgQueuer introduces no service beyond the user's Postgres
+(ADR-0001).
+
+### No liveness signal, manual requeue
+
+Abandoned jobs stay picked until an operator intervenes. Rejected: a
+crash at 3 a.m. should not need a human before the queue drains again.
+
+## Not covered by this ADR
+
+Heartbeat intervals and timeout defaults, batching of heartbeat
+updates, the index that makes stale lookup cheap, and how schedules
+reuse the heartbeat idea (a backlogged record covers the scheduler).
+
+## References
+
+- [ADR index and backlog](README.md)
+- [Heartbeat monitoring guide](../guides/heartbeat.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ Conventions:
 - [ADR-0002: Workers claim jobs by row-level lock contention, not assignment](ADR-0002-workers-claim-by-lock-contention.md)
 - [ADR-0003: Notifications signal that something changed, never carry job data](ADR-0003-notifications-signal-not-carry.md)
 - [ADR-0004: Delivery is at-least-once](ADR-0004-delivery-is-at-least-once.md)
+- [ADR-0005: Worker liveness is an application-level signal, not DB session state](ADR-0005-worker-liveness-is-application-signal.md)
 
 ## Backlog
 
@@ -76,7 +77,7 @@ leaves open.
     to failed jobs (the `on_failure` disposition is a consequence, not a
     decision).
 
-- [ ] **ADR-0005: Worker liveness is an application-level signal, not DB session state**
+- [x] **ADR-0005: Worker liveness is an application-level signal, not DB session state**
   - Decision: workers periodically prove liveness in data (heartbeat
     timestamps); job ownership does not die with the DB connection.
   - Fork: application heartbeat vs. session-scoped locks or connection


### PR DESCRIPTION
Records the heartbeat decision: running jobs carry a timestamp their worker refreshes; a heartbeat older than the timeout makes the job claimable again through the ordinary claim path; ownership survives disconnects and pooler churn because none of it lives in DB session state.

- Alternatives considered: session-scoped locks or connection state, external liveness service, manual requeue.
- Not covered: intervals and defaults, heartbeat batching, the stale-lookup index, schedule heartbeats.
- Updates the ADR index and checks ADR-0005 off in the backlog.

`uv run mkdocs build --strict` passes.