### PR TITLE
refactor(qb): compose the dequeue statement per active gates

### DIFF
--- a/docs/reference/skip-locked.md
+++ b/docs/reference/skip-locked.md
@@ -146,7 +146,7 @@ next_queued AS (        -- fresh work
 ),
 next_stale AS (         -- jobs from a crashed worker
     SELECT q.id FROM pgqueuer q
-    WHERE q.status='picked' AND q.heartbeat < NOW() - $6::interval
+    WHERE q.status='picked' AND q.heartbeat < NOW() - $4::interval
     ORDER BY q.priority DESC, q.id ASC
     FOR UPDATE SKIP LOCKED LIMIT $1
 ),
@@ -158,7 +158,7 @@ eligible AS (           -- merge, cap to batch size
 ),
 claimed AS (            -- atomic claim
     UPDATE pgqueuer SET status='picked', updated=NOW(), heartbeat=NOW(),
-        queue_manager_id=$4
+        queue_manager_id=$3
     WHERE id IN (SELECT id FROM eligible) RETURNING *
 )
 SELECT * FROM claimed ORDER BY priority DESC, id ASC;

--- a/pgqueuer/adapters/persistence/composer.py
+++ b/pgqueuer/adapters/persistence/composer.py
@@ -22,10 +22,14 @@ class SqlComposer:
     text is deterministic for a given fragment set, so driver-side prepared
     statement caches see one entry per query shape.
 
-    CTE bodies are embedded verbatim — never rewritten — so SQL string
-    literals pass through untouched. ``clauses`` assembles a statement from
-    one clause per argument, so an optional clause is an empty string rather
-    than a newline the caller has to splice in by hand.
+    The composer owns every bit of whitespace, so no SQL literal carries
+    indentation. ``cte`` takes one clause per argument and strips each before
+    indenting the block; an optional clause is an empty string rather than a
+    newline spliced in by hand. ``where`` renders a condition list under one
+    keyword, and ``nest`` indents a body under a header, so nesting depth is
+    declared by the call structure instead of typed into a literal. Because
+    each clause is normalised on its own, a multi-line SQL string literal
+    cannot span two clauses.
 
     Usage example::
 
@@ -48,10 +52,37 @@ class SqlComposer:
         """Join clauses onto their own lines, dropping the ones left empty."""
         return "\n".join(part for part in parts if part)
 
-    def cte(self, name: str, body: str, comment: str = "") -> None:
-        # Dedent + strip lets callers pass indented triple-quoted comment blocks.
-        comment_text = textwrap.dedent(comment).strip()
-        header = "".join(f"-- {line}\n" for line in comment_text.splitlines())
+    @staticmethod
+    def where(*conditions: str, joiner: str = "AND") -> str:
+        """Render a WHERE from conditions, dropping empty ones; no conditions renders nothing."""
+        kept = [condition for condition in conditions if condition]
+        if not kept:
+            return ""
+        # Right-align the joiner in the width of WHERE so every condition starts
+        # in the same column: "WHERE a", "  AND b", "   OR c".
+        continuation = f"\n{joiner:>{len('WHERE')}} "
+        return "WHERE " + continuation.join(kept)
+
+    @staticmethod
+    def nest(header: str, *body: str, footer: str = "") -> str:
+        """Indent body one level under header, so nesting is declared rather than typed."""
+        kept = [part for part in body if part]
+        indented = textwrap.indent("\n".join(kept), "    ")
+        return "\n".join(part for part in (header, indented, footer) if part)
+
+    def cte(self, name: str, *clauses: str, comment: str = "") -> None:
+        """Append a named CTE built from one clause per argument.
+
+        A comment must be a single line: it orients whoever reads the
+        statement in a Postgres log, while the reasoning behind a clause
+        belongs in a Python comment next to the code that decides it.
+        """
+        if "\n" in comment:
+            raise ValueError("A CTE comment must be a single line")
+
+        dedented = [textwrap.dedent(clause).strip() for clause in clauses]
+        body = textwrap.indent("\n".join(part for part in dedented if part), "    ")
+        header = f"-- {comment}\n" if comment else ""
         self.fragments.append(f"{header}{name} AS (\n{body}\n)")
 
     def render(self, final: str) -> ComposedQuery:

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import uuid
 from datetime import timedelta
 from typing import Generator
 
@@ -460,126 +461,234 @@ ALTER TABLE {self.qualified.statistics_table} RESET (
 @dataclasses.dataclass
 class QueryQueueBuilder:
     settings: DBSettings = dataclasses.field(default_factory=DBSettings)
+    # Rendered dequeue SQL per (capacity-gated, budget-gated) shape. The bind
+    # order is fixed per shape, so cached text pairs with freshly bound args.
+    dequeue_sql_cache: dict[tuple[bool, bool], str] = dataclasses.field(default_factory=dict)
 
     @property
     def qualified(self) -> QualifiedNames:
         return self.settings.qualified
 
-    def build_dequeue_query(self) -> str:
-        t = self.qualified.queue_table
-        t_log = self.qualified.queue_table_log
-        return f"""WITH
--- Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.
-params AS (
-    SELECT
-        UNNEST($2::text[])   AS entrypoint,
-        UNNEST($3::bigint[]) AS concurrency_limit
-),
+    def build_dequeue_query(
+        self,
+        *,
+        batch_size: int,
+        entrypoints: list[str],
+        concurrency_limits: list[int],
+        queue_manager_id: uuid.UUID,
+        global_concurrency_limit: int | None,
+        heartbeat_timeout: timedelta,
+    ) -> ComposedQuery:
+        """
+        Compose the dequeue statement for the concurrency gates actually in use.
 
--- Per-entrypoint count of picked jobs (global, all workers).
-picked AS (
-    SELECT entrypoint, COUNT(*) AS total
-    FROM {t}
-    WHERE queue_manager_id IS NOT NULL
-      AND entrypoint = ANY($2)
-    GROUP BY entrypoint
-),
+        Gate CTEs are selected from the runtime values: entrypoint capacity
+        machinery only when some ``concurrency_limits`` entry is positive, the
+        per-worker budget only when ``global_concurrency_limit`` is set. A
+        dequeue with no limits configured renders a plain pick-and-claim. The
+        composer pairs the SQL with its argument tuple, so parameter numbering
+        never drifts between query shapes.
 
--- This worker's total picked jobs (scalar, for max_concurrent_tasks).
-worker_load AS (
-    SELECT COUNT(*) AS total
-    FROM {t}
-    WHERE queue_manager_id = $4
-      AND entrypoint = ANY($2)
-),
+        The rendered text is cached per gate shape because dequeue rebuilds
+        its query every busy-loop iteration; values are re-bound on every
+        call, so cached SQL never pins or shares argument objects.
+        """
+        if len(entrypoints) != len(concurrency_limits):
+            raise ValueError("entrypoints and concurrency_limits must be the same length")
 
--- Entrypoints with free capacity (concurrency gate applied here instead of
--- row-scan). remaining is NULL for unlimited entrypoints; otherwise it caps
--- how many rows one dequeue may pick so a single statement cannot exceed
--- the entrypoint's concurrency_limit.
-available AS (
-    SELECT
-        p.entrypoint,
-        CASE
-            WHEN p.concurrency_limit <= 0 THEN NULL
-            ELSE p.concurrency_limit - COALESCE(pk.total, 0)
-        END AS remaining
-    FROM params p
-    LEFT JOIN picked pk ON pk.entrypoint = p.entrypoint
-    WHERE p.concurrency_limit <= 0
-       OR COALESCE(pk.total, 0) < p.concurrency_limit
-),
+        capacity_gated = any(limit > 0 for limit in concurrency_limits)
+        budget_gated = global_concurrency_limit is not None
 
--- New queued jobs: per-entrypoint LATERAL lookup hits (entrypoint, priority, id) partial index.
--- LEAST($1, NULL) = $1, so unlimited entrypoints keep the full batch.
-next_queued AS (
-    SELECT q.id, q.priority
-    FROM available a
-    CROSS JOIN LATERAL (
-        SELECT q2.id, q2.priority
-        FROM {t} q2
-        WHERE q2.entrypoint = a.entrypoint
-          AND q2.status = 'queued'
-          AND q2.execute_after < NOW()
-        ORDER BY q2.priority DESC, q2.id ASC
-        LIMIT LEAST($1, a.remaining)
-        FOR UPDATE SKIP LOCKED
-    ) q
-    WHERE ($5::BIGINT IS NULL
-           OR (SELECT total FROM worker_load) < $5)
-    ORDER BY q.priority DESC, q.id ASC
-    LIMIT $1
-),
+        composer = SqlComposer()
+        batch = composer.bind(batch_size)
+        eps = composer.bind(list(entrypoints))
+        queue_manager = composer.bind(queue_manager_id)
+        heartbeat = composer.bind(heartbeat_timeout)
+        limits = ""
+        if capacity_gated:
+            limits = composer.bind(list(concurrency_limits))
 
--- Stale picked jobs whose heartbeat timed out. The concurrency gate from
--- next_queued is intentionally omitted: re-picking only transfers ownership
--- of a row already counted in `picked`, so net live execution is unchanged.
--- Applying the gate would deadlock recovery once leaked rows fill the slot.
-next_stale AS (
-    SELECT q.id, q.priority
-    FROM {t} q
-    JOIN params p ON p.entrypoint = q.entrypoint
-    WHERE q.status = 'picked'
-      AND q.heartbeat < NOW() - $6::interval
-      AND q.execute_after < NOW()
-      AND ($5::BIGINT IS NULL
-           OR (SELECT total FROM worker_load) < $5)
-    ORDER BY q.priority DESC, q.id ASC
-    FOR UPDATE SKIP LOCKED
-    LIMIT $1
-),
+        global_limit = ""
+        if budget_gated:
+            global_limit = composer.bind(global_concurrency_limit)
 
--- Merge both sets into one global priority order so a recovered stale job
--- competes on priority with fresh work instead of always losing to it.
--- The LIMIT hard-caps this worker's total picked rows at $5: the binary
--- worker_load gates above only stop a dequeue from starting once over
--- budget, they do not stop one batch from overshooting it.
-eligible AS (
-    SELECT id FROM (
-        SELECT id, priority FROM next_queued
-        UNION ALL
-        SELECT id, priority FROM next_stale
-    ) combined
-    ORDER BY priority DESC, id ASC
-    LIMIT GREATEST(LEAST($1, COALESCE($5 - (SELECT total FROM worker_load), $1)), 0)
-),
+        shape = (capacity_gated, budget_gated)
+        if (cached_sql := self.dequeue_sql_cache.get(shape)) is not None:
+            return ComposedQuery(sql=cached_sql, args=tuple(composer.values))
 
--- Atomically claim the jobs and log the pick event.
-claimed AS (
-    UPDATE {t}
-    SET status = 'picked',
-        updated   = NOW(),
-        heartbeat = NOW(),
-        queue_manager_id = $4
-    WHERE id IN (SELECT id FROM eligible)
-    RETURNING *
-),
-log_pick AS (
-    INSERT INTO {t_log} (job_id, status, entrypoint, priority)
-    SELECT id, status, entrypoint, priority FROM claimed
-)
-SELECT * FROM claimed ORDER BY priority DESC, id ASC;
-"""  # noqa
+        queue_table = self.qualified.queue_table
+
+        if capacity_gated:
+            unpacked_params = composer.nest(
+                "SELECT",
+                f"UNNEST({eps}::text[]) AS entrypoint,",
+                f"UNNEST({limits}::bigint[]) AS concurrency_limit",
+            )
+            composer.cte(
+                "params",
+                unpacked_params,
+                comment="Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.",
+            )
+
+            picked_where = composer.where(
+                "queue_manager_id IS NOT NULL",
+                f"entrypoint = ANY({eps})",
+            )
+            composer.cte(
+                "picked",
+                "SELECT entrypoint, COUNT(*) AS total",
+                f"FROM {queue_table}",
+                picked_where,
+                "GROUP BY entrypoint",
+                comment="Per-entrypoint count of picked jobs (global, all workers).",
+            )
+
+            # Applying the gate here rather than per row keeps a saturated entrypoint
+            # from scanning its queued backlog at all. remaining is NULL for unlimited
+            # entrypoints; otherwise it caps how many rows one dequeue may pick, so a
+            # single statement cannot exceed the entrypoint's concurrency_limit.
+            remaining_capacity = composer.nest(
+                "CASE",
+                "WHEN params.concurrency_limit <= 0 THEN NULL",
+                "ELSE params.concurrency_limit - COALESCE(picked.total, 0)",
+                footer="END AS remaining",
+            )
+            available_columns = composer.nest(
+                "SELECT",
+                "params.entrypoint,",
+                remaining_capacity,
+            )
+            available_where = composer.where(
+                "params.concurrency_limit <= 0",
+                "COALESCE(picked.total, 0) < params.concurrency_limit",
+                joiner="OR",
+            )
+            composer.cte(
+                "available",
+                available_columns,
+                "FROM params",
+                "LEFT JOIN picked ON picked.entrypoint = params.entrypoint",
+                available_where,
+                comment="Entrypoints with free capacity; remaining caps a single dequeue.",
+            )
+            # LEAST(batch, NULL) = batch, so unlimited entrypoints keep the full batch.
+            lateral_limit = f"LEAST({batch}, available.remaining)"
+        else:
+            composer.cte(
+                "available",
+                f"SELECT UNNEST({eps}::text[]) AS entrypoint",
+                comment="No entrypoint carries a concurrency limit; all are available.",
+            )
+            lateral_limit = batch
+
+        budget_condition = ""
+        eligible_limit = batch
+        if budget_gated:
+            worker_load_where = composer.where(
+                f"queue_manager_id = {queue_manager}",
+                f"entrypoint = ANY({eps})",
+            )
+            composer.cte(
+                "worker_load",
+                "SELECT COUNT(*) AS total",
+                f"FROM {queue_table}",
+                worker_load_where,
+                comment="This worker's total picked jobs (scalar, for max_concurrent_tasks).",
+            )
+            budget_condition = f"(SELECT total FROM worker_load) < {global_limit}"
+            # The eligible LIMIT hard-caps this worker's total picked rows: the binary
+            # worker_load condition only stops a dequeue from starting once over budget,
+            # it does not stop one batch from overshooting it.
+            eligible_limit = (
+                f"GREATEST(LEAST({batch}, {global_limit} - (SELECT total FROM worker_load)), 0)"
+            )
+
+        candidate_where = composer.where(
+            "candidate.entrypoint = available.entrypoint",
+            "candidate.status = 'queued'",
+            "candidate.execute_after < NOW()",
+        )
+        candidate_lookup = composer.nest(
+            "CROSS JOIN LATERAL (",
+            "SELECT candidate.id, candidate.priority",
+            f"FROM {queue_table} candidate",
+            candidate_where,
+            "ORDER BY candidate.priority DESC, candidate.id ASC",
+            f"LIMIT {lateral_limit}",
+            "FOR UPDATE SKIP LOCKED",
+            footer=") job",
+        )
+        queued_gate = composer.where(budget_condition)
+        composer.cte(
+            "next_queued",
+            "SELECT job.id, job.priority",
+            "FROM available",
+            candidate_lookup,
+            queued_gate,
+            "ORDER BY job.priority DESC, job.id ASC",
+            f"LIMIT {batch}",
+            comment="New queued jobs; LATERAL hits the (entrypoint, priority, id) index.",
+        )
+
+        # The entrypoint concurrency gate is intentionally omitted here: re-picking a
+        # stale job only transfers ownership of a row already counted in `picked`, so
+        # net live execution is unchanged. Applying the gate would deadlock recovery
+        # once leaked rows fill the slot.
+        stale_gate = composer.where(
+            "stale.status = 'picked'",
+            f"stale.entrypoint = ANY({eps})",
+            f"stale.heartbeat < NOW() - {heartbeat}::interval",
+            "stale.execute_after < NOW()",
+            budget_condition,
+        )
+        composer.cte(
+            "next_stale",
+            "SELECT stale.id, stale.priority",
+            f"FROM {queue_table} stale",
+            stale_gate,
+            "ORDER BY stale.priority DESC, stale.id ASC",
+            "FOR UPDATE SKIP LOCKED",
+            f"LIMIT {batch}",
+            comment="Stale picked jobs whose heartbeat timed out.",
+        )
+
+        merged_candidates = composer.nest(
+            "SELECT id FROM (",
+            "SELECT id, priority FROM next_queued",
+            "UNION ALL",
+            "SELECT id, priority FROM next_stale",
+            footer=") combined",
+        )
+        composer.cte(
+            "eligible",
+            merged_candidates,
+            "ORDER BY priority DESC, id ASC",
+            f"LIMIT {eligible_limit}",
+            comment="Merge both sets into one priority order so stale competes with fresh.",
+        )
+
+        claim_assignments = composer.nest(
+            "SET status = 'picked',",
+            "updated   = NOW(),",
+            "heartbeat = NOW(),",
+            f"queue_manager_id = {queue_manager}",
+        )
+        composer.cte(
+            "claimed",
+            f"UPDATE {queue_table}",
+            claim_assignments,
+            "WHERE id IN (SELECT id FROM eligible)",
+            "RETURNING *",
+            comment="Atomically claim the jobs and log the pick event.",
+        )
+        composer.cte(
+            "log_pick",
+            f"INSERT INTO {self.qualified.queue_table_log} (job_id, status, entrypoint, priority)",
+            "SELECT id, status, entrypoint, priority FROM claimed",
+        )
+        query = composer.render("SELECT * FROM claimed ORDER BY priority DESC, id ASC;")
+        self.dequeue_sql_cache[shape] = query.sql
+        return query
 
     def build_has_queued_work(self) -> str:
         return f"""

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -181,15 +181,15 @@ class Queries:
         if batch_size < 1:
             raise ValueError("Batch size must be greater than or equal to one (1)")
 
-        rows = await self.driver.fetch(
-            self.qbq.build_dequeue_query(),
-            batch_size,
-            list(entrypoints.keys()),
-            [x.concurrency_limit for x in entrypoints.values()],
-            queue_manager_id,
-            global_concurrency_limit,
-            heartbeat_timeout,
+        query = self.qbq.build_dequeue_query(
+            batch_size=batch_size,
+            entrypoints=list(entrypoints.keys()),
+            concurrency_limits=[x.concurrency_limit for x in entrypoints.values()],
+            queue_manager_id=queue_manager_id,
+            global_concurrency_limit=global_concurrency_limit,
+            heartbeat_timeout=heartbeat_timeout,
         )
+        rows = await self.driver.fetch(query.sql, *query.args)
         return [models.Job.model_validate(row) for row in rows]
 
     @overload

--- a/test/query_shapes/dequeue_both_gates.sql
+++ b/test/query_shapes/dequeue_both_gates.sql
@@ -1,0 +1,99 @@
+WITH
+-- Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.
+params AS (
+    SELECT
+        UNNEST($2::text[]) AS entrypoint,
+        UNNEST($5::bigint[]) AS concurrency_limit
+),
+
+-- Per-entrypoint count of picked jobs (global, all workers).
+picked AS (
+    SELECT entrypoint, COUNT(*) AS total
+    FROM pgqueuer
+    WHERE queue_manager_id IS NOT NULL
+      AND entrypoint = ANY($2)
+    GROUP BY entrypoint
+),
+
+-- Entrypoints with free capacity; remaining caps a single dequeue.
+available AS (
+    SELECT
+        params.entrypoint,
+        CASE
+            WHEN params.concurrency_limit <= 0 THEN NULL
+            ELSE params.concurrency_limit - COALESCE(picked.total, 0)
+        END AS remaining
+    FROM params
+    LEFT JOIN picked ON picked.entrypoint = params.entrypoint
+    WHERE params.concurrency_limit <= 0
+       OR COALESCE(picked.total, 0) < params.concurrency_limit
+),
+
+-- This worker's total picked jobs (scalar, for max_concurrent_tasks).
+worker_load AS (
+    SELECT COUNT(*) AS total
+    FROM pgqueuer
+    WHERE queue_manager_id = $3
+      AND entrypoint = ANY($2)
+),
+
+-- New queued jobs; LATERAL hits the (entrypoint, priority, id) index.
+next_queued AS (
+    SELECT job.id, job.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT candidate.id, candidate.priority
+        FROM pgqueuer candidate
+        WHERE candidate.entrypoint = available.entrypoint
+          AND candidate.status = 'queued'
+          AND candidate.execute_after < NOW()
+        ORDER BY candidate.priority DESC, candidate.id ASC
+        LIMIT LEAST($1, available.remaining)
+        FOR UPDATE SKIP LOCKED
+    ) job
+    WHERE (SELECT total FROM worker_load) < $6
+    ORDER BY job.priority DESC, job.id ASC
+    LIMIT $1
+),
+
+-- Stale picked jobs whose heartbeat timed out.
+next_stale AS (
+    SELECT stale.id, stale.priority
+    FROM pgqueuer stale
+    WHERE stale.status = 'picked'
+      AND stale.entrypoint = ANY($2)
+      AND stale.heartbeat < NOW() - $4::interval
+      AND stale.execute_after < NOW()
+      AND (SELECT total FROM worker_load) < $6
+    ORDER BY stale.priority DESC, stale.id ASC
+    FOR UPDATE SKIP LOCKED
+    LIMIT $1
+),
+
+-- Merge both sets into one priority order so stale competes with fresh.
+eligible AS (
+    SELECT id FROM (
+        SELECT id, priority FROM next_queued
+        UNION ALL
+        SELECT id, priority FROM next_stale
+    ) combined
+    ORDER BY priority DESC, id ASC
+    LIMIT GREATEST(LEAST($1, $6 - (SELECT total FROM worker_load)), 0)
+),
+
+-- Atomically claim the jobs and log the pick event.
+claimed AS (
+    UPDATE pgqueuer
+    SET status = 'picked',
+        updated   = NOW(),
+        heartbeat = NOW(),
+        queue_manager_id = $3
+    WHERE id IN (SELECT id FROM eligible)
+    RETURNING *
+),
+
+log_pick AS (
+    INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
+    SELECT id, status, entrypoint, priority FROM claimed
+)
+SELECT * FROM claimed ORDER BY priority DESC, id ASC;

--- a/test/query_shapes/dequeue_entrypoint_gate.sql
+++ b/test/query_shapes/dequeue_entrypoint_gate.sql
@@ -1,0 +1,89 @@
+WITH
+-- Unpack per-entrypoint parameters; concurrency_limit 0 means unlimited.
+params AS (
+    SELECT
+        UNNEST($2::text[]) AS entrypoint,
+        UNNEST($5::bigint[]) AS concurrency_limit
+),
+
+-- Per-entrypoint count of picked jobs (global, all workers).
+picked AS (
+    SELECT entrypoint, COUNT(*) AS total
+    FROM pgqueuer
+    WHERE queue_manager_id IS NOT NULL
+      AND entrypoint = ANY($2)
+    GROUP BY entrypoint
+),
+
+-- Entrypoints with free capacity; remaining caps a single dequeue.
+available AS (
+    SELECT
+        params.entrypoint,
+        CASE
+            WHEN params.concurrency_limit <= 0 THEN NULL
+            ELSE params.concurrency_limit - COALESCE(picked.total, 0)
+        END AS remaining
+    FROM params
+    LEFT JOIN picked ON picked.entrypoint = params.entrypoint
+    WHERE params.concurrency_limit <= 0
+       OR COALESCE(picked.total, 0) < params.concurrency_limit
+),
+
+-- New queued jobs; LATERAL hits the (entrypoint, priority, id) index.
+next_queued AS (
+    SELECT job.id, job.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT candidate.id, candidate.priority
+        FROM pgqueuer candidate
+        WHERE candidate.entrypoint = available.entrypoint
+          AND candidate.status = 'queued'
+          AND candidate.execute_after < NOW()
+        ORDER BY candidate.priority DESC, candidate.id ASC
+        LIMIT LEAST($1, available.remaining)
+        FOR UPDATE SKIP LOCKED
+    ) job
+    ORDER BY job.priority DESC, job.id ASC
+    LIMIT $1
+),
+
+-- Stale picked jobs whose heartbeat timed out.
+next_stale AS (
+    SELECT stale.id, stale.priority
+    FROM pgqueuer stale
+    WHERE stale.status = 'picked'
+      AND stale.entrypoint = ANY($2)
+      AND stale.heartbeat < NOW() - $4::interval
+      AND stale.execute_after < NOW()
+    ORDER BY stale.priority DESC, stale.id ASC
+    FOR UPDATE SKIP LOCKED
+    LIMIT $1
+),
+
+-- Merge both sets into one priority order so stale competes with fresh.
+eligible AS (
+    SELECT id FROM (
+        SELECT id, priority FROM next_queued
+        UNION ALL
+        SELECT id, priority FROM next_stale
+    ) combined
+    ORDER BY priority DESC, id ASC
+    LIMIT $1
+),
+
+-- Atomically claim the jobs and log the pick event.
+claimed AS (
+    UPDATE pgqueuer
+    SET status = 'picked',
+        updated   = NOW(),
+        heartbeat = NOW(),
+        queue_manager_id = $3
+    WHERE id IN (SELECT id FROM eligible)
+    RETURNING *
+),
+
+log_pick AS (
+    INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
+    SELECT id, status, entrypoint, priority FROM claimed
+)
+SELECT * FROM claimed ORDER BY priority DESC, id ASC;

--- a/test/query_shapes/dequeue_global_gate.sql
+++ b/test/query_shapes/dequeue_global_gate.sql
@@ -1,0 +1,74 @@
+WITH
+-- No entrypoint carries a concurrency limit; all are available.
+available AS (
+    SELECT UNNEST($2::text[]) AS entrypoint
+),
+
+-- This worker's total picked jobs (scalar, for max_concurrent_tasks).
+worker_load AS (
+    SELECT COUNT(*) AS total
+    FROM pgqueuer
+    WHERE queue_manager_id = $3
+      AND entrypoint = ANY($2)
+),
+
+-- New queued jobs; LATERAL hits the (entrypoint, priority, id) index.
+next_queued AS (
+    SELECT job.id, job.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT candidate.id, candidate.priority
+        FROM pgqueuer candidate
+        WHERE candidate.entrypoint = available.entrypoint
+          AND candidate.status = 'queued'
+          AND candidate.execute_after < NOW()
+        ORDER BY candidate.priority DESC, candidate.id ASC
+        LIMIT $1
+        FOR UPDATE SKIP LOCKED
+    ) job
+    WHERE (SELECT total FROM worker_load) < $5
+    ORDER BY job.priority DESC, job.id ASC
+    LIMIT $1
+),
+
+-- Stale picked jobs whose heartbeat timed out.
+next_stale AS (
+    SELECT stale.id, stale.priority
+    FROM pgqueuer stale
+    WHERE stale.status = 'picked'
+      AND stale.entrypoint = ANY($2)
+      AND stale.heartbeat < NOW() - $4::interval
+      AND stale.execute_after < NOW()
+      AND (SELECT total FROM worker_load) < $5
+    ORDER BY stale.priority DESC, stale.id ASC
+    FOR UPDATE SKIP LOCKED
+    LIMIT $1
+),
+
+-- Merge both sets into one priority order so stale competes with fresh.
+eligible AS (
+    SELECT id FROM (
+        SELECT id, priority FROM next_queued
+        UNION ALL
+        SELECT id, priority FROM next_stale
+    ) combined
+    ORDER BY priority DESC, id ASC
+    LIMIT GREATEST(LEAST($1, $5 - (SELECT total FROM worker_load)), 0)
+),
+
+-- Atomically claim the jobs and log the pick event.
+claimed AS (
+    UPDATE pgqueuer
+    SET status = 'picked',
+        updated   = NOW(),
+        heartbeat = NOW(),
+        queue_manager_id = $3
+    WHERE id IN (SELECT id FROM eligible)
+    RETURNING *
+),
+
+log_pick AS (
+    INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
+    SELECT id, status, entrypoint, priority FROM claimed
+)
+SELECT * FROM claimed ORDER BY priority DESC, id ASC;

--- a/test/query_shapes/dequeue_no_gates.sql
+++ b/test/query_shapes/dequeue_no_gates.sql
@@ -1,0 +1,64 @@
+WITH
+-- No entrypoint carries a concurrency limit; all are available.
+available AS (
+    SELECT UNNEST($2::text[]) AS entrypoint
+),
+
+-- New queued jobs; LATERAL hits the (entrypoint, priority, id) index.
+next_queued AS (
+    SELECT job.id, job.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT candidate.id, candidate.priority
+        FROM pgqueuer candidate
+        WHERE candidate.entrypoint = available.entrypoint
+          AND candidate.status = 'queued'
+          AND candidate.execute_after < NOW()
+        ORDER BY candidate.priority DESC, candidate.id ASC
+        LIMIT $1
+        FOR UPDATE SKIP LOCKED
+    ) job
+    ORDER BY job.priority DESC, job.id ASC
+    LIMIT $1
+),
+
+-- Stale picked jobs whose heartbeat timed out.
+next_stale AS (
+    SELECT stale.id, stale.priority
+    FROM pgqueuer stale
+    WHERE stale.status = 'picked'
+      AND stale.entrypoint = ANY($2)
+      AND stale.heartbeat < NOW() - $4::interval
+      AND stale.execute_after < NOW()
+    ORDER BY stale.priority DESC, stale.id ASC
+    FOR UPDATE SKIP LOCKED
+    LIMIT $1
+),
+
+-- Merge both sets into one priority order so stale competes with fresh.
+eligible AS (
+    SELECT id FROM (
+        SELECT id, priority FROM next_queued
+        UNION ALL
+        SELECT id, priority FROM next_stale
+    ) combined
+    ORDER BY priority DESC, id ASC
+    LIMIT $1
+),
+
+-- Atomically claim the jobs and log the pick event.
+claimed AS (
+    UPDATE pgqueuer
+    SET status = 'picked',
+        updated   = NOW(),
+        heartbeat = NOW(),
+        queue_manager_id = $3
+    WHERE id IN (SELECT id FROM eligible)
+    RETURNING *
+),
+
+log_pick AS (
+    INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
+    SELECT id, status, entrypoint, priority FROM claimed
+)
+SELECT * FROM claimed ORDER BY priority DESC, id ASC;

--- a/test/test_composer.py
+++ b/test/test_composer.py
@@ -62,36 +62,111 @@ def test_ctes_are_chained_in_insertion_order() -> None:
     )
 
 
-def test_cte_bodies_are_embedded_verbatim() -> None:
-    # The composer must never rewrite a body: a blank line or a unicode line
-    # separator inside a SQL string literal is part of the literal's value.
+def test_cte_indents_a_body_written_at_python_indentation() -> None:
+    # The caller writes SQL wherever the surrounding Python sits; the composer
+    # strips that indentation and applies the one level a CTE body needs.
     composer = SqlComposer()
-    composer.cte("greeting", "    SELECT 'a\n\nb' AS blank, 'c\u2028d' AS separator")
-    query = composer.render("SELECT * FROM greeting")
-    assert "'a\n\nb'" in query.sql
-    assert "'c\u2028d'" in query.sql
+    composer.cte(
+        "ready",
+        """
+            SELECT id
+            FROM jobs
+        """,
+    )
+    query = composer.render("SELECT * FROM ready")
+    assert query.sql == "WITH\nready AS (\n    SELECT id\n    FROM jobs\n)\nSELECT * FROM ready"
+
+
+def test_cte_keeps_indentation_relative_within_a_clause() -> None:
+    composer = SqlComposer()
+    composer.cte(
+        "ready",
+        """
+            SELECT id FROM (
+                SELECT id FROM jobs
+            ) inner_jobs
+        """,
+    )
+    body = "    SELECT id FROM (\n        SELECT id FROM jobs\n    ) inner_jobs"
+    assert composer.render("SELECT * FROM ready").sql == (
+        f"WITH\nready AS (\n{body}\n)\nSELECT * FROM ready"
+    )
+
+
+def test_cte_joins_clauses_and_drops_empty_ones() -> None:
+    composer = SqlComposer()
+    composer.cte("ready", "SELECT id", "", "FROM jobs")
+    query = composer.render("SELECT * FROM ready")
+    assert query.sql == "WITH\nready AS (\n    SELECT id\n    FROM jobs\n)\nSELECT * FROM ready"
 
 
 def test_cte_without_comment_has_no_header() -> None:
     composer = SqlComposer()
-    composer.cte("ready", "    SELECT 1")
+    composer.cte("ready", "SELECT 1")
     assert composer.render("SELECT * FROM ready").sql.startswith("WITH\nready AS (")
 
 
-def test_cte_comment_renders_as_line_comments() -> None:
+def test_cte_comment_renders_as_a_line_comment() -> None:
     composer = SqlComposer()
-    composer.cte(
-        "ready",
-        "    SELECT 1",
-        comment="""
-            First line.
-            Second line.
-        """,
-    )
+    composer.cte("ready", "SELECT 1", comment="Jobs ready to run.")
     query = composer.render("SELECT * FROM ready")
     assert query.sql == (
-        "WITH\n-- First line.\n-- Second line.\nready AS (\n    SELECT 1\n)\nSELECT * FROM ready"
+        "WITH\n-- Jobs ready to run.\nready AS (\n    SELECT 1\n)\nSELECT * FROM ready"
     )
+
+
+def test_cte_rejects_a_multi_line_comment() -> None:
+    # A comment orients whoever reads the statement in a Postgres log. Rationale
+    # that needs a paragraph belongs in a Python comment, not in the rendered SQL.
+    composer = SqlComposer()
+    with pytest.raises(ValueError, match="single line"):
+        composer.cte("ready", "SELECT 1", comment="First line.\nSecond line.")
+
+
+def test_where_chains_conditions_under_one_keyword() -> None:
+    assert SqlComposer.where("a = 1", "b = 2") == "WHERE a = 1\n  AND b = 2"
+
+
+def test_where_drops_empty_conditions() -> None:
+    # An inactive gate contributes "" and must not leave a dangling AND behind.
+    assert SqlComposer.where("a = 1", "", "b = 2") == "WHERE a = 1\n  AND b = 2"
+
+
+def test_where_without_conditions_renders_nothing() -> None:
+    assert SqlComposer.where("") == ""
+    assert SqlComposer.where() == ""
+
+
+def test_where_aligns_every_condition_under_the_keyword() -> None:
+    # AND and OR are different widths; both must leave the conditions in one
+    # column so the caller never counts spaces to line them up.
+    conjunction = SqlComposer.where("a = 1", "b = 2")
+    disjunction = SqlComposer.where("a = 1", "b = 2", joiner="OR")
+    assert conjunction == "WHERE a = 1\n  AND b = 2"
+    assert disjunction == "WHERE a = 1\n   OR b = 2"
+    starts = {line.index("a = 1" if "a" in line else "b = 2") for line in conjunction.splitlines()}
+    assert starts == {len("WHERE ")}
+
+
+def test_nest_indents_the_body_under_the_header() -> None:
+    assert SqlComposer.nest("SELECT", "id,", "priority") == "SELECT\n    id,\n    priority"
+
+
+def test_nest_closes_with_a_footer() -> None:
+    nested = SqlComposer.nest("EXISTS (", "SELECT 1 FROM jobs", footer=") AS any_job")
+    assert nested == "EXISTS (\n    SELECT 1 FROM jobs\n) AS any_job"
+
+
+def test_nest_drops_empty_body_parts() -> None:
+    assert SqlComposer.nest("SELECT", "id", "") == "SELECT\n    id"
+
+
+def test_nest_deepens_indentation_when_composed() -> None:
+    # Nesting depth comes from the call structure, so an inner block indents
+    # relative to its parent without the caller typing either level.
+    inner = SqlComposer.nest("CASE", "WHEN a THEN 1", footer="END")
+    outer = SqlComposer.nest("SELECT", inner)
+    assert outer == "SELECT\n    CASE\n        WHEN a THEN 1\n    END"
 
 
 def test_composed_query_is_immutable() -> None:

--- a/test/test_dequeue_shapes.py
+++ b/test/test_dequeue_shapes.py
@@ -1,0 +1,179 @@
+"""Dequeue SQL shape follows the concurrency gates in use.
+
+The rendered SQL of every shape is snapshotted under test/query_shapes/ so a
+change to the composition machinery shows up in review as a plain SQL diff.
+Regenerate after an intended change with:
+
+    PGQUEUER_UPDATE_SNAPSHOTS=1 uv run pytest test/test_dequeue_shapes.py
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import re
+import uuid
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from pgqueuer import db, queries
+from pgqueuer.adapters.persistence import qb
+from pgqueuer.adapters.persistence.composer import ComposedQuery
+from pgqueuer.domain.settings import DBSettings
+
+SNAPSHOT_DIR = Path(__file__).parent / "query_shapes"
+
+
+def pinned_builder() -> qb.QueryQueueBuilder:
+    # Snapshots hard-code unprefixed table names; pin them so a developer's
+    # exported PGQUEUER_* env vars cannot skew the rendered SQL.
+    return qb.QueryQueueBuilder(
+        settings=DBSettings(db_schema=None, queue_table="pgqueuer", queue_table_log="pgqueuer_log")
+    )
+
+
+def compose(
+    concurrency_limit: int,
+    global_limit: int | None,
+    builder: qb.QueryQueueBuilder | None = None,
+) -> ComposedQuery:
+    return (builder or pinned_builder()).build_dequeue_query(
+        batch_size=10,
+        entrypoints=["fetch"],
+        concurrency_limits=[concurrency_limit],
+        queue_manager_id=uuid.UUID(int=0),
+        global_concurrency_limit=global_limit,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+
+
+def update_snapshots() -> bool:
+    return os.environ.get("PGQUEUER_UPDATE_SNAPSHOTS", "").lower() in ("1", "true")
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "concurrency_limit", "global_limit"),
+    [
+        ("dequeue_no_gates.sql", 0, None),
+        ("dequeue_entrypoint_gate.sql", 2, None),
+        ("dequeue_global_gate.sql", 0, 3),
+        ("dequeue_both_gates.sql", 2, 3),
+    ],
+)
+def test_dequeue_sql_matches_snapshot(
+    snapshot: str,
+    concurrency_limit: int,
+    global_limit: int | None,
+) -> None:
+    query = compose(concurrency_limit, global_limit)
+    # Every $N placeholder maps onto exactly one bound arg: no gaps, no extras.
+    placeholders = {int(n) for n in re.findall(r"\$(\d+)", query.sql)}
+    assert placeholders == set(range(1, len(query.args) + 1))
+
+    path = SNAPSHOT_DIR / snapshot
+    expected = query.sql + "\n"
+    if update_snapshots():
+        path.write_text(expected)
+    assert expected == path.read_text(), (
+        f"rendered dequeue SQL diverged from {path}; if intended, regenerate with "
+        "PGQUEUER_UPDATE_SNAPSHOTS=1"
+    )
+
+
+def test_dequeue_sql_is_cached_per_shape() -> None:
+    # Same gate shape reuses the rendered text: the busy loop must not
+    # recompose the statement every iteration, and driver-side prepared
+    # statement caches must see one entry per shape.
+    builder = pinned_builder()
+    first = compose(0, None, builder)
+    second = compose(0, None, builder)
+    assert first.sql is second.sql
+    assert compose(2, 3, builder).sql is compose(2, 3, builder).sql
+
+
+def test_dequeue_args_are_rebound_every_call() -> None:
+    # Cached SQL must never share argument objects between calls: a driver
+    # (a public Protocol) that mutates args in place must not poison later
+    # dequeues.
+    builder = pinned_builder()
+    first = compose(2, 3, builder)
+    entrypoints = first.args[1]
+    assert isinstance(entrypoints, list)
+    entrypoints.append("evil")
+
+    second = compose(2, 3, builder)
+    assert second.args[1] == ["fetch"]
+    assert second.args[4] == [2]
+
+
+def test_dequeue_rejects_mismatched_concurrency_limits() -> None:
+    # The old monolithic query NULL-padded surplus entrypoints out of the
+    # batch; per-gate composition would silently un-gate them instead.
+    with pytest.raises(ValueError, match="same length"):
+        pinned_builder().build_dequeue_query(
+            batch_size=10,
+            entrypoints=["a", "b"],
+            concurrency_limits=[0],
+            queue_manager_id=uuid.UUID(int=0),
+            global_concurrency_limit=None,
+            heartbeat_timeout=timedelta(seconds=30),
+        )
+
+
+@pytest.mark.parametrize(
+    ("concurrency_limit", "global_limit", "expected"),
+    [
+        (0, None, 5),
+        (2, None, 2),
+        (0, 3, 3),
+        (2, 3, 2),
+    ],
+)
+async def test_dequeue_shapes_respect_gates(
+    apgdriver: db.Driver,
+    concurrency_limit: int,
+    global_limit: int | None,
+    expected: int,
+) -> None:
+    q = queries.Queries(apgdriver)
+    await q.enqueue(["fetch"] * 5, [None] * 5, [0] * 5)
+
+    dequeue = functools.partial(
+        q.dequeue,
+        batch_size=10,
+        entrypoints={"fetch": queries.EntrypointExecutionParameter(concurrency_limit)},
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=global_limit,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+
+    first = await dequeue()
+    assert len(first) == expected
+
+    second = await dequeue()
+    assert second == []
+
+
+async def test_minimal_shape_recovers_stale_jobs(apgdriver: db.Driver) -> None:
+    q = queries.Queries(apgdriver)
+    await q.enqueue(["fetch"] * 2, [None] * 2, [0] * 2)
+
+    dequeue = functools.partial(
+        q.dequeue,
+        batch_size=10,
+        entrypoints={"fetch": queries.EntrypointExecutionParameter(0)},
+        global_concurrency_limit=None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+
+    picked = await dequeue(queue_manager_id=uuid.uuid4())
+    assert len(picked) == 2
+
+    await apgdriver.execute(
+        f"UPDATE {DBSettings().queue_table} SET heartbeat = NOW() - interval '1 hour'"
+    )
+
+    recovered = await dequeue(queue_manager_id=uuid.uuid4())
+    assert sorted(j.id for j in recovered) == sorted(j.id for j in picked)

--- a/test/test_query_plan_regression.py
+++ b/test/test_query_plan_regression.py
@@ -6,6 +6,8 @@ import json
 import uuid
 from datetime import timedelta
 
+import pytest
+
 from pgqueuer import db, queries
 from pgqueuer.adapters.persistence import qb
 
@@ -95,19 +97,34 @@ def _scan_summary(nodes: list[dict]) -> list[tuple]:
     ]
 
 
-async def test_dequeue_uses_entrypoint_priority_index(apgdriver: db.Driver) -> None:
-    """Dequeue's LATERAL reads the (entrypoint, priority, id) index, not a Seq Scan (#667)."""
+# Every dequeue shape: capacity-gated shapes render `LIMIT LEAST($n, remaining)`
+# in the LATERAL, ungated ones a plain `LIMIT $n` — the planner must stay on the
+# partial index for both variants.
+DEQUEUE_SHAPES = [
+    pytest.param(0, None, id="no_gates"),
+    pytest.param(1000, None, id="entrypoint_gate"),
+    pytest.param(0, 1000, id="global_gate"),
+    pytest.param(1000, 1000, id="both_gates"),
+]
+
+
+@pytest.mark.parametrize(("concurrency_limit", "global_limit"), DEQUEUE_SHAPES)
+async def test_dequeue_uses_entrypoint_priority_index(
+    apgdriver: db.Driver,
+    concurrency_limit: int,
+    global_limit: int | None,
+) -> None:
+    """Each shape's LATERAL reads the (entrypoint, priority, id) index, not a Seq Scan (#667)."""
     q = await _seed(apgdriver)
-    nodes = await _plan_nodes(
-        apgdriver,
-        q.qbq.build_dequeue_query(),
-        10,
-        ENTRYPOINTS,
-        [0] * len(ENTRYPOINTS),
-        uuid.uuid4(),
-        1000,
-        timedelta(seconds=30),
+    query = q.qbq.build_dequeue_query(
+        batch_size=10,
+        entrypoints=ENTRYPOINTS,
+        concurrency_limits=[concurrency_limit] * len(ENTRYPOINTS),
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=global_limit,
+        heartbeat_timeout=timedelta(seconds=30),
     )
+    nodes = await _plan_nodes(apgdriver, query.sql, *query.args)
     used = [
         n
         for n in nodes
@@ -147,21 +164,29 @@ async def test_has_queued_work_is_existence_probe(apgdriver: db.Driver) -> None:
     )
 
 
-async def test_dequeue_plan_scans_proportional_to_batch(apgdriver: db.Driver) -> None:
-    """Dequeue scans O(entrypoints*batch) rows, not the whole backlog (#668)."""
+@pytest.mark.parametrize(("concurrency_limit", "global_limit"), DEQUEUE_SHAPES)
+async def test_dequeue_plan_scans_proportional_to_batch(
+    apgdriver: db.Driver,
+    concurrency_limit: int,
+    global_limit: int | None,
+) -> None:
+    """Each dequeue shape scans O(entrypoints*batch) rows, not the whole backlog (#668).
+
+    The gated shapes matter most: their worker_load/picked probes must stay on
+    index scans, or every production dequeue walks the backlog.
+    """
     await _bulk_seed(apgdriver, BULK_ROWS, BULK_EPS)
     q = queries.Queries(apgdriver)
     eps = [f"ep_{i}" for i in range(BULK_EPS)]
-    nodes = await _analyze_nodes(
-        apgdriver,
-        q.qbq.build_dequeue_query(),
-        BATCH,
-        eps,
-        [0] * BULK_EPS,
-        uuid.uuid4(),
-        None,
-        timedelta(seconds=30),
+    query = q.qbq.build_dequeue_query(
+        batch_size=BATCH,
+        entrypoints=eps,
+        concurrency_limits=[concurrency_limit] * BULK_EPS,
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=global_limit,
+        heartbeat_timeout=timedelta(seconds=30),
     )
+    nodes = await _analyze_nodes(apgdriver, query.sql, *query.args)
 
     # Matches "Seq Scan" and "Parallel Seq Scan" — any full-table walk.
     seq = [n for n in _queue_scans(nodes) if (n.get("Node Type") or "").endswith("Seq Scan")]
@@ -178,7 +203,11 @@ async def test_dequeue_plan_scans_proportional_to_batch(apgdriver: db.Driver) ->
     )
 
 
-async def test_dequeue_gate_skips_saturated_entrypoints(apgdriver: db.Driver) -> None:
+@pytest.mark.parametrize("global_limit", [None, 1000], ids=["entrypoint_gate", "both_gates"])
+async def test_dequeue_gate_skips_saturated_entrypoints(
+    apgdriver: db.Driver,
+    global_limit: int | None,
+) -> None:
     """Saturated entrypoints are gated out by the CTE, not by scanning their queued rows (#668)."""
     await _bulk_seed(apgdriver, BULK_ROWS, BULK_EPS)
     # One picked job per entrypoint puts each at concurrency_limit=1, so the
@@ -196,16 +225,15 @@ async def test_dequeue_gate_skips_saturated_entrypoints(apgdriver: db.Driver) ->
 
     q = queries.Queries(apgdriver)
     eps = [f"ep_{i}" for i in range(BULK_EPS)]
-    nodes = await _analyze_nodes(
-        apgdriver,
-        q.qbq.build_dequeue_query(),
-        BATCH,
-        eps,
-        [1] * BULK_EPS,
-        uuid.uuid4(),
-        None,
-        timedelta(seconds=30),
+    query = q.qbq.build_dequeue_query(
+        batch_size=BATCH,
+        entrypoints=eps,
+        concurrency_limits=[1] * BULK_EPS,
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=global_limit,
+        heartbeat_timeout=timedelta(seconds=30),
     )
+    nodes = await _analyze_nodes(apgdriver, query.sql, *query.args)
 
     # Only the picked aggregate and stale probe touch the table (~BULK_EPS rows each);
     # the queued LATERAL must read nothing because every entrypoint is gated out.


### PR DESCRIPTION
Migrates the dequeue statement onto the composer from #766, per ADR-0024. It now renders only the gates the caller configured: entrypoint capacity when some limit is positive, the per-worker budget when one is set, a plain pick-and-claim when neither applies. Previously every gate rendered always and unused ones were neutralized with NULL, so every worker paid every gate's bookkeeping.

Rendered text is cached per gate shape on the builder; arguments are re-bound on every call, so cached SQL never shares argument objects. Each shape is snapshotted under `test/query_shapes/` so a composition change reads as a plain SQL diff, and the plan-regression guards now cover every shape.

Stacked on #766. The elision only reaches production once #767 lands, since `run()` otherwise sends `sys.maxsize` as the budget.