### PR TITLE
docs: add ADR-0024, SQL is assembled by the composer

### DIFF
--- a/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
+++ b/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
@@ -35,7 +35,7 @@ each reachable shape is a reviewable, snapshot-testable SQL artifact.
 Two corollaries:
 
 - "Not configured" is expressed as absence (`None`) at every boundary,
-  never as a sentinel value — a sentinel reads as configuration and
+  never as a sentinel value. A sentinel reads as configuration and
   silently re-enables the fragment it means to disable.
 - The composer stays transparent: fragment bodies are embedded
   verbatim, never rewritten, so what the author wrote is what Postgres

--- a/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
+++ b/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
@@ -6,11 +6,11 @@ Accepted (adoption is incremental; dequeue is the first adopter)
 
 ## Context
 
-Statements used to be f-strings with hand-numbered `$N` placeholders,
-with the matching argument list assembled separately at each call
-site. That holds while a statement has one shape. The dequeue
-statement broke the pattern: concurrency gates come and go with
-configuration, an optional fragment invalidates every placeholder
+Statements used to be hand-assembled text with hand-numbered
+placeholders, with the matching argument list maintained separately at
+each call site. That holds while a statement has one shape. The
+dequeue statement broke the pattern: concurrency gates come and go
+with configuration, an optional fragment invalidates every placeholder
 number after it, and the bind values must appear and disappear in
 lockstep somewhere else in the code. Rendering every gate always and
 neutralizing unused ones with sentinel values is no better: every
@@ -21,11 +21,11 @@ SQL it is given, not the values bound to it.
 
 SQL is assembled by the composer. Statements are built from fragments;
 every runtime value is coupled to its auto-numbered placeholder as it
-is bound, and the text and argument tuple emerge as one pair. A
+is bound, and the text and argument list emerge as one pair. A
 statement renders only the fragments its configuration needs, and one
-configuration always renders byte-identical, snapshot-tested text.
-"Not configured" is absence (`None`) at every boundary, never a
-sentinel value, and the composer embeds fragment bodies verbatim.
+configuration always renders identical text. "Not configured" is
+expressed as absence, never as a sentinel value, and the composer
+never rewrites fragment text.
 
 Adoption is incremental: dequeue is composed today, the remaining
 builders migrate when next touched, and a statement that gains a
@@ -36,11 +36,11 @@ DDL migrates last, if ever.
 
 ### Positive consequences
 
-- Placeholder numbering cannot drift: a `$N` exists if and only if its
-  value was bound.
+- Placeholder numbering cannot drift: a placeholder exists exactly
+  when its value was bound.
 - Optional features cost nothing where they are unused.
-- Deterministic per-shape text makes snapshots the review surface and
-  keeps prepared-statement caches at one entry per shape.
+- Deterministic per-shape text makes rendered snapshots the review
+  surface for SQL changes.
 
 ### Negative consequences
 
@@ -50,7 +50,7 @@ DDL migrates last, if ever.
 
 ## Alternatives considered
 
-### Hand-numbered f-strings per statement (the previous design)
+### Hand-numbered text per statement (the previous design)
 
 Fine while every statement has one shape; collapses under conditional
 fragments, as the dequeue statement demonstrated (renumbering churn,
@@ -69,7 +69,7 @@ record) exchanges plain SQL text.
 
 ## Not covered by this ADR
 
-Migration order, per-statement CTE mechanics, text caching, the
+Migration order, per-statement fragment mechanics, caching, the
 snapshot workflow, and the placeholder implementation. The dequeue
 shapes are described in the
 [dequeue composition model](../design/dequeue-composition.md).

--- a/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
+++ b/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
@@ -2,105 +2,76 @@
 
 ## Status
 
-Accepted (adoption is incremental; the dequeue statement is the first
-adopter)
+Accepted (adoption is incremental; dequeue is the first adopter)
 
 ## Context
 
-Every statement the library sends used to be built the same way: an
-f-string with hand-numbered `$N` placeholders in one place, and the
-matching argument list assembled separately at the call site. That
-holds exactly as long as each statement has one shape. The dequeue
+Statements used to be f-strings with hand-numbered `$N` placeholders,
+with the matching argument list assembled separately at each call
+site. That holds while a statement has one shape. The dequeue
 statement broke the pattern: concurrency gates come and go with
-configuration, an optional fragment invalidates every hand-written
-placeholder number after it, and the bind values must appear and
-disappear in lockstep somewhere else in the code. Text and argument
-tuple are two facts that must never drift, maintained by hand in two
-places.
-
-The alternative failure mode is just as costly: rendering every
-optional fragment always and neutralizing unused ones with sentinel
-values makes every worker pay every feature's bookkeeping, because
-PostgreSQL plans the SQL it is given, not the values bound to it.
+configuration, an optional fragment invalidates every placeholder
+number after it, and the bind values must appear and disappear in
+lockstep somewhere else in the code. Rendering every gate always and
+neutralizing unused ones with sentinel values is no better: every
+worker pays every feature's bookkeeping, because PostgreSQL plans the
+SQL it is given, not the values bound to it.
 
 ## Decision
 
-SQL is assembled by the composer. A statement is built from fragments;
-every runtime value is coupled to its auto-numbered placeholder at the
-moment it is bound; the rendered text and the argument tuple emerge as
-one pair. Statements render only the fragments their configuration
-needs, and one configuration always renders byte-identical text, so
-each reachable shape is a reviewable, snapshot-testable SQL artifact.
+SQL is assembled by the composer. Statements are built from fragments;
+every runtime value is coupled to its auto-numbered placeholder as it
+is bound, and the text and argument tuple emerge as one pair. A
+statement renders only the fragments its configuration needs, and one
+configuration always renders byte-identical, snapshot-tested text.
+"Not configured" is absence (`None`) at every boundary, never a
+sentinel value, and the composer embeds fragment bodies verbatim.
 
-Two corollaries:
-
-- "Not configured" is expressed as absence (`None`) at every boundary,
-  never as a sentinel value. A sentinel reads as configuration and
-  silently re-enables the fragment it means to disable.
-- The composer stays transparent: fragment bodies are embedded
-  verbatim, never rewritten, so what the author wrote is what Postgres
-  receives.
-
-Adoption is incremental. The dequeue statement is composed today; the
-remaining builders migrate when they are next touched, and any
-statement that gains a conditional fragment migrates at that moment
-rather than growing a second hand-numbered variant. Static,
-argument-free DDL carries no numbering risk and migrates last, if
-ever.
+Adoption is incremental: dequeue is composed today, the remaining
+builders migrate when next touched, and a statement that gains a
+conditional fragment migrates at that moment. Static, argument-free
+DDL migrates last, if ever.
 
 ## Consequences
 
 ### Positive consequences
 
 - Placeholder numbering cannot drift: a `$N` exists if and only if its
-  value was bound, however many optional fragments surround it.
-- Optional features cost nothing where they are unused; workers without
-  concurrency gates run gate-free SQL.
-- Deterministic per-shape text makes snapshots the review surface for
-  SQL changes and keeps driver-side prepared-statement caches at one
-  entry per shape.
+  value was bound.
+- Optional features cost nothing where they are unused.
+- Deterministic per-shape text makes snapshots the review surface and
+  keeps prepared-statement caches at one entry per shape.
 
 ### Negative consequences
 
-- Two assembly styles coexist until migration completes; a reader of
-  `qb.py` meets both.
-- The composer is an in-house abstraction contributors must learn, and
-  it must be held to the transparency rule above or it becomes its own
-  source of SQL bugs.
-- Every composed shape needs its own snapshot and plan coverage; a
-  shape production cannot reach can hide an untested one it can.
+- Two assembly styles coexist until migration completes.
+- The composer is an in-house abstraction contributors must learn.
+- Every composed shape needs its own snapshot and plan coverage.
 
 ## Alternatives considered
 
 ### Hand-numbered f-strings per statement (the previous design)
 
 Fine while every statement has one shape; collapses under conditional
-fragments, where the dequeue statement demonstrated both failure modes
-(renumbering churn, or sentinel-neutralized gates that everyone pays
-for).
+fragments, as the dequeue statement demonstrated (renumbering churn,
+or sentinel-neutralized gates that everyone pays for).
 
 ### A hand-written statement per shape
 
-Static SQL files, one per configuration combination. Rejected: the
-variant count doubles with each optional fragment and the shared
-skeleton is duplicated into every copy, so a fix must be repeated once
-per file.
+Rejected: the variant count doubles with each optional fragment, and
+every fix must be repeated once per copy.
 
 ### An external query-builder dependency
 
-An expression-tree builder (SQLAlchemy Core or similar) composes
-conditional SQL natively. Rejected: a heavyweight dependency for a
-handful of statements, the driver port's lowest-common-denominator
-contract (a backlog record) exchanges plain SQL text, and the
-library's SQL is deliberately reviewable as SQL.
+Rejected: a heavyweight dependency for a handful of statements, and
+the driver port's lowest-common-denominator contract (a backlog
+record) exchanges plain SQL text.
 
 ## Not covered by this ADR
 
-The migration order of the remaining builders (maintainer judgement,
-statement by statement), the CTE mechanics of any one statement, the
-caching of rendered text, the snapshot-update workflow, and the
-placeholder implementation. The dequeue statement's shapes and
-invariants are described in the
+Migration order, per-statement CTE mechanics, text caching, the
+snapshot workflow, and the placeholder implementation. The dequeue
+shapes are described in the
 [dequeue composition model](../design/dequeue-composition.md).
 
 ## References

--- a/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
+++ b/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
@@ -1,0 +1,110 @@
+# ADR-0024: SQL statements are assembled by the composer
+
+## Status
+
+Accepted (adoption is incremental; the dequeue statement is the first
+adopter)
+
+## Context
+
+Every statement the library sends used to be built the same way: an
+f-string with hand-numbered `$N` placeholders in one place, and the
+matching argument list assembled separately at the call site. That
+holds exactly as long as each statement has one shape. The dequeue
+statement broke the pattern: concurrency gates come and go with
+configuration, an optional fragment invalidates every hand-written
+placeholder number after it, and the bind values must appear and
+disappear in lockstep somewhere else in the code. Text and argument
+tuple are two facts that must never drift, maintained by hand in two
+places.
+
+The alternative failure mode is just as costly: rendering every
+optional fragment always and neutralizing unused ones with sentinel
+values makes every worker pay every feature's bookkeeping, because
+PostgreSQL plans the SQL it is given, not the values bound to it.
+
+## Decision
+
+SQL is assembled by the composer. A statement is built from fragments;
+every runtime value is coupled to its auto-numbered placeholder at the
+moment it is bound; the rendered text and the argument tuple emerge as
+one pair. Statements render only the fragments their configuration
+needs, and one configuration always renders byte-identical text, so
+each reachable shape is a reviewable, snapshot-testable SQL artifact.
+
+Two corollaries:
+
+- "Not configured" is expressed as absence (`None`) at every boundary,
+  never as a sentinel value — a sentinel reads as configuration and
+  silently re-enables the fragment it means to disable.
+- The composer stays transparent: fragment bodies are embedded
+  verbatim, never rewritten, so what the author wrote is what Postgres
+  receives.
+
+Adoption is incremental. The dequeue statement is composed today; the
+remaining builders migrate when they are next touched, and any
+statement that gains a conditional fragment migrates at that moment
+rather than growing a second hand-numbered variant. Static,
+argument-free DDL carries no numbering risk and migrates last, if
+ever.
+
+## Consequences
+
+### Positive consequences
+
+- Placeholder numbering cannot drift: a `$N` exists if and only if its
+  value was bound, however many optional fragments surround it.
+- Optional features cost nothing where they are unused; workers without
+  concurrency gates run gate-free SQL.
+- Deterministic per-shape text makes snapshots the review surface for
+  SQL changes and keeps driver-side prepared-statement caches at one
+  entry per shape.
+
+### Negative consequences
+
+- Two assembly styles coexist until migration completes; a reader of
+  `qb.py` meets both.
+- The composer is an in-house abstraction contributors must learn, and
+  it must be held to the transparency rule above or it becomes its own
+  source of SQL bugs.
+- Every composed shape needs its own snapshot and plan coverage; a
+  shape production cannot reach can hide an untested one it can.
+
+## Alternatives considered
+
+### Hand-numbered f-strings per statement (the previous design)
+
+Fine while every statement has one shape; collapses under conditional
+fragments, where the dequeue statement demonstrated both failure modes
+(renumbering churn, or sentinel-neutralized gates that everyone pays
+for).
+
+### A hand-written statement per shape
+
+Static SQL files, one per configuration combination. Rejected: the
+variant count doubles with each optional fragment and the shared
+skeleton is duplicated into every copy, so a fix must be repeated once
+per file.
+
+### An external query-builder dependency
+
+An expression-tree builder (SQLAlchemy Core or similar) composes
+conditional SQL natively. Rejected: a heavyweight dependency for a
+handful of statements, the driver port's lowest-common-denominator
+contract (a backlog record) exchanges plain SQL text, and the
+library's SQL is deliberately reviewable as SQL.
+
+## Not covered by this ADR
+
+The migration order of the remaining builders (maintainer judgement,
+statement by statement), the CTE mechanics of any one statement, the
+caching of rendered text, the snapshot-update workflow, and the
+placeholder implementation. The dequeue statement's shapes and
+invariants are described in the
+[dequeue composition model](../design/dequeue-composition.md).
+
+## References
+
+- [ADR index and backlog](README.md)
+- [Dequeue composition model](../design/dequeue-composition.md)
+- [Row locking & SKIP LOCKED reference](../reference/skip-locked.md)

--- a/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
+++ b/docs/adr/ADR-0024-sql-is-assembled-by-the-composer.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (adoption is incremental; dequeue is the first adopter)
+Accepted (adoption is incremental; dequeue migrates first)
 
 ## Context
 
@@ -27,10 +27,10 @@ configuration always renders identical text. "Not configured" is
 expressed as absence, never as a sentinel value, and the composer
 never rewrites fragment text.
 
-Adoption is incremental: dequeue is composed today, the remaining
-builders migrate when next touched, and a statement that gains a
-conditional fragment migrates at that moment. Static, argument-free
-DDL migrates last, if ever.
+Adoption is incremental and has not started yet: dequeue migrates
+first, the remaining builders follow when next touched, and a
+statement that gains a conditional fragment migrates at that moment.
+Static, argument-free DDL migrates last, if ever.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -242,21 +242,17 @@ leaves open.
     context, degradation mechanics.
 
 - [x] **ADR-0024: SQL statements are assembled by the composer**
-  - Decision: statements are built from conditional fragments with every
-    bind coupled to its auto-numbered placeholder; text and argument
-    tuple emerge as one pair. Unconfigured features are absence (`None`),
-    never sentinel values. Adoption is incremental; dequeue is first.
-  - Fork: composer vs. hand-numbered f-strings per statement vs. an
-    external query-builder dependency.
-  - Consequences: placeholder numbering cannot drift; optional gates
-    render only where configured; two styles coexist until migration
-    completes; every composed shape needs snapshot and plan coverage.
-  - Pointers: `SqlComposer`/`ComposedQuery` in
-    `pgqueuer/adapters/persistence/composer.py`; first adopter
-    `QueryQueueBuilder.build_dequeue_query` in `qb.py`; shapes in
-    `test/query_shapes/`.
-  - Not covered: migration order, per-statement CTE mechanics, text
-    caching, snapshot workflow (see the dequeue composition model).
+  - Decision: statements are built from conditional fragments, binds
+    auto-numbered, text and args emerging as one pair; unconfigured is
+    `None`, never a sentinel. Adoption is incremental; dequeue is first.
+  - Fork: composer vs. hand-numbered f-strings vs. an external query
+    builder.
+  - Consequences: numbering cannot drift; unused gates render nothing;
+    two styles coexist until migration completes.
+  - Pointers: `SqlComposer` in `pgqueuer/adapters/persistence/composer.py`;
+    first adopter `QueryQueueBuilder.build_dequeue_query` in `qb.py`.
+  - Not covered: migration order and mechanics (see the dequeue
+    composition model).
 
 ### Runtime & process
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ Conventions:
 - [ADR-0003: Notifications signal that something changed, never carry job data](ADR-0003-notifications-signal-not-carry.md)
 - [ADR-0004: Delivery is at-least-once](ADR-0004-delivery-is-at-least-once.md)
 - [ADR-0005: Worker liveness is an application-level signal, not DB session state](ADR-0005-worker-liveness-is-application-signal.md)
+- [ADR-0024: SQL statements are assembled by the composer](ADR-0024-sql-is-assembled-by-the-composer.md)
 
 ## Backlog
 
@@ -240,6 +241,23 @@ leaves open.
   - Not covered: the integration list, header namespacing for trace
     context, degradation mechanics.
 
+- [x] **ADR-0024: SQL statements are assembled by the composer**
+  - Decision: statements are built from conditional fragments with every
+    bind coupled to its auto-numbered placeholder; text and argument
+    tuple emerge as one pair. Unconfigured features are absence (`None`),
+    never sentinel values. Adoption is incremental; dequeue is first.
+  - Fork: composer vs. hand-numbered f-strings per statement vs. an
+    external query-builder dependency.
+  - Consequences: placeholder numbering cannot drift; optional gates
+    render only where configured; two styles coexist until migration
+    completes; every composed shape needs snapshot and plan coverage.
+  - Pointers: `SqlComposer`/`ComposedQuery` in
+    `pgqueuer/adapters/persistence/composer.py`; first adopter
+    `QueryQueueBuilder.build_dequeue_query` in `qb.py`; shapes in
+    `test/query_shapes/`.
+  - Not covered: migration order, per-statement CTE mechanics, text
+    caching, snapshot workflow (see the dequeue composition model).
+
 ### Runtime & process
 
 - [ ] **ADR-0019: The scaling unit is the process; the runner supervises one manager**
@@ -304,7 +322,8 @@ leaves open.
 Implementation detail; documented in AGENTS.md or reference docs and free to
 change without touching a record:
 
-- The single-statement claim query shape, index definitions, query-plan tests
+- The claim query's CTE mechanics, index definitions, query-plan tests
+  (the composition *policy* is ADR-0024; the rendered shapes stay detail)
 - Advisory locking in statistics aggregation; batching, jitter, debounce
 - Tool picks: import-linter, testcontainers, pydantic-settings, htmx
 - The in-memory adapter (consequence of 0014 + 0021)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -243,14 +243,15 @@ leaves open.
 
 - [x] **ADR-0024: SQL statements are assembled by the composer**
   - Decision: statements are built from conditional fragments, binds
-    auto-numbered, text and args emerging as one pair; unconfigured is
-    `None`, never a sentinel. Adoption is incremental; dequeue is first.
-  - Fork: composer vs. hand-numbered f-strings vs. an external query
-    builder.
+    auto-numbered, text and arguments emerging as one pair; unconfigured
+    is absence, never a sentinel. Adoption is incremental; dequeue is
+    first.
+  - Fork: composer vs. hand-numbered text per statement vs. an external
+    query builder.
   - Consequences: numbering cannot drift; unused gates render nothing;
     two styles coexist until migration completes.
-  - Pointers: `SqlComposer` in `pgqueuer/adapters/persistence/composer.py`;
-    first adopter `QueryQueueBuilder.build_dequeue_query` in `qb.py`.
+  - Pointers: composer and query builder in
+    `pgqueuer/adapters/persistence/`.
   - Not covered: migration order and mechanics (see the dequeue
     composition model).
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -242,6 +242,10 @@ for jobs: row-lock claim plus heartbeat-based staleness recovery (ADR-0022).
 
 ## Sub-models
 
+- [Dequeue composition model](dequeue-composition.md): how the claim
+  statement is assembled from the concurrency gates in use — shapes,
+  bind order, invariants, and the tests that guard them (ADR-0024).
+
 Planned split-outs once a section outgrows this document; each keeps a
 summary here:
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -243,8 +243,8 @@ for jobs: row-lock claim plus heartbeat-based staleness recovery (ADR-0022).
 ## Sub-models
 
 - [Dequeue composition model](dequeue-composition.md): how the claim
-  statement is assembled from the concurrency gates in use — shapes,
-  bind order, invariants, and the tests that guard them (ADR-0024).
+  statement is assembled from the concurrency gates in use, with the
+  shapes, bind order, invariants, and guarding tests (ADR-0024).
 
 Planned split-outs once a section outgrows this document; each keeps a
 summary here:

--- a/docs/design/dequeue-composition.md
+++ b/docs/design/dequeue-composition.md
@@ -1,11 +1,9 @@
 # Dequeue composition model
 
-This document models how the claim statement is assembled from the
-concurrency gates in use. The dequeue statement is the first adopter of
-the composer policy. This document describes *what is*; the *why* lives
-in [ADR-0024](../adr/ADR-0024-sql-is-assembled-by-the-composer.md).
-It is a sub-model of the [system design](README.md); the participants
-and the claim-time invariants named there apply unchanged.
+How the claim statement is assembled from the concurrency gates in
+use. This document describes *what is*; the *why* lives in
+[ADR-0024](../adr/ADR-0024-sql-is-assembled-by-the-composer.md). It is
+a sub-model of the [system design](README.md).
 
 ## Flow
 
@@ -45,8 +43,7 @@ regenerate an intended change with `PGQUEUER_UPDATE_SNAPSHOTS=1`.
 
 ## Bind order
 
-Fixed per shape; the composer numbers placeholders in bind order, so a
-fragment that is left out never leaves a gap.
+Fixed per shape; a fragment that is left out never leaves a gap.
 
 | Placeholder | Value                          | Present         |
 |-------------|--------------------------------|-----------------|
@@ -59,35 +56,30 @@ fragment that is left out never leaves a gap.
 
 ## Components
 
-| Component         | Type         | Description                                            |
-|-------------------|--------------|--------------------------------------------------------|
-| SqlComposer       | Service      | Chains CTE fragments, auto-numbers binds; embeds bodies verbatim (`adapters/persistence/composer.py`) |
-| ComposedQuery     | Value Object | Immutable pairing of rendered SQL and its argument tuple |
-| QueryQueueBuilder | Service      | Selects gates, composes the shape, caches rendered text per shape (`adapters/persistence/qb.py`) |
+| Component         | Type         | Description                                       |
+|-------------------|--------------|---------------------------------------------------|
+| SqlComposer       | Service      | Chains CTE fragments, auto-numbers binds, embeds bodies verbatim |
+| ComposedQuery     | Value Object | Immutable pairing of rendered SQL and its arguments |
+| QueryQueueBuilder | Service      | Selects gates, composes the shape, caches text per shape |
 | Gate shape        | Value Object | The `(capacity-gated, budget-gated)` pair; cache key and test axis |
 
 ## Invariants
 
-- Unlimited is `None` at every boundary. `QueueManager.run` normalizes
-  its legacy `0` to `None`; no sentinel integer reaches the builder.
-- SQL text is a function of the gate shape and table names only.
-  Rendered text is cached per shape on the builder instance; arguments
+- Unlimited is `None` at every boundary; `QueueManager.run` normalizes
+  its legacy `0` to `None`.
+- Rendered text is cached per shape on the builder instance; arguments
   are re-bound on every call and never shared between calls.
-- Entrypoint names and their limits are parallel lists of equal length;
-  the builder rejects a mismatch.
-- Every `$N` placeholder maps onto exactly one bound argument, with no
-  gaps and no extras (asserted per shape in `test/test_dequeue_shapes.py`).
-- The stale-job re-pick deliberately skips the capacity gate:
-  re-picking transfers ownership of an already-counted row, and gating
-  it would deadlock recovery (comment in the `next_stale` CTE).
+- Entrypoint names and limits are parallel lists of equal length; the
+  builder rejects a mismatch.
+- Every `$N` maps onto exactly one bound argument.
+- The stale-job re-pick skips the capacity gate on purpose: re-picking
+  transfers ownership of an already-counted row, and gating it would
+  deadlock recovery.
 
 ## Guards
 
-- `test/test_composer.py` covers composer behavior: bind numbering,
-  verbatim bodies, comment rendering, immutability.
-- `test/test_dequeue_shapes.py` covers the snapshot per shape,
-  placeholder accounting, per-shape caching, argument isolation, and
-  gate semantics against a real database.
-- `test/test_query_plan_regression.py` holds the EXPLAIN guards: every
-  shape stays on the entrypoint-leading indexes and scans
-  O(entrypoints × batch) rows.
+- `test/test_composer.py`: composer behavior.
+- `test/test_dequeue_shapes.py`: snapshots, placeholder accounting,
+  caching, argument isolation, gate semantics.
+- `test/test_query_plan_regression.py`: every shape stays on the
+  entrypoint-leading indexes and scans O(entrypoints × batch) rows.

--- a/docs/design/dequeue-composition.md
+++ b/docs/design/dequeue-composition.md
@@ -2,8 +2,8 @@
 
 This document models how the claim statement is assembled from the
 concurrency gates in use. The dequeue statement is the first adopter of
-the composer policy; it describes *what is*, and the *why* lives in
-[ADR-0024](../adr/ADR-0024-sql-is-assembled-by-the-composer.md).
+the composer policy. This document describes *what is*; the *why* lives
+in [ADR-0024](../adr/ADR-0024-sql-is-assembled-by-the-composer.md).
 It is a sub-model of the [system design](README.md); the participants
 and the claim-time invariants named there apply unchanged.
 
@@ -75,19 +75,19 @@ fragment that is left out never leaves a gap.
   are re-bound on every call and never shared between calls.
 - Entrypoint names and their limits are parallel lists of equal length;
   the builder rejects a mismatch.
-- Every `$N` placeholder maps onto exactly one bound argument — no
-  gaps, no extras (asserted per shape in `test/test_dequeue_shapes.py`).
+- Every `$N` placeholder maps onto exactly one bound argument, with no
+  gaps and no extras (asserted per shape in `test/test_dequeue_shapes.py`).
 - The stale-job re-pick deliberately skips the capacity gate:
   re-picking transfers ownership of an already-counted row, and gating
   it would deadlock recovery (comment in the `next_stale` CTE).
 
 ## Guards
 
-- `test/test_composer.py` — composer behavior: bind numbering, verbatim
-  bodies, comment rendering, immutability.
-- `test/test_dequeue_shapes.py` — snapshot per shape, placeholder
-  accounting, per-shape caching, argument isolation, gate semantics
-  against a real database.
-- `test/test_query_plan_regression.py` — EXPLAIN guards that every
+- `test/test_composer.py` covers composer behavior: bind numbering,
+  verbatim bodies, comment rendering, immutability.
+- `test/test_dequeue_shapes.py` covers the snapshot per shape,
+  placeholder accounting, per-shape caching, argument isolation, and
+  gate semantics against a real database.
+- `test/test_query_plan_regression.py` holds the EXPLAIN guards: every
   shape stays on the entrypoint-leading indexes and scans
   O(entrypoints × batch) rows.

--- a/docs/design/dequeue-composition.md
+++ b/docs/design/dequeue-composition.md
@@ -1,0 +1,93 @@
+# Dequeue composition model
+
+This document models how the claim statement is assembled from the
+concurrency gates in use. The dequeue statement is the first adopter of
+the composer policy; it describes *what is*, and the *why* lives in
+[ADR-0024](../adr/ADR-0024-sql-is-assembled-by-the-composer.md).
+It is a sub-model of the [system design](README.md); the participants
+and the claim-time invariants named there apply unchanged.
+
+## Flow
+
+```
+QueueManager.run / fetch_jobs (core/qm.py)
+      │ batch size, entrypoint limits, worker budget (None = unlimited)
+      ▼
+Queries.dequeue (adapters/persistence/queries.py)
+      │
+      ▼
+QueryQueueBuilder.build_dequeue_query (adapters/persistence/qb.py)
+      │ gate predicates:
+      │   capacity-gated = any per-entrypoint limit > 0
+      │   budget-gated   = worker budget is not None
+      ▼
+SqlComposer (adapters/persistence/composer.py)
+      │ bind() every runtime value → $N; cte() per required fragment
+      ▼
+ComposedQuery(sql, args) ──► Driver.fetch(sql, *args)
+```
+
+The two gate predicates select one of four shapes. SQL text depends
+only on the shape and the installation's table names; every runtime
+value travels as a bound argument.
+
+## Shapes
+
+| Shape           | Capacity gate | Budget gate | Extra CTEs                  | Snapshot                     |
+|-----------------|---------------|-------------|-----------------------------|------------------------------|
+| No gates        | off           | off         | —                           | `dequeue_no_gates.sql`       |
+| Entrypoint gate | on            | off         | `params, picked, available` | `dequeue_entrypoint_gate.sql`|
+| Global gate     | off           | on          | `worker_load`               | `dequeue_global_gate.sql`    |
+| Both gates      | on            | on          | all of the above            | `dequeue_both_gates.sql`     |
+
+Snapshots live in `test/query_shapes/` and are byte-compared;
+regenerate an intended change with `PGQUEUER_UPDATE_SNAPSHOTS=1`.
+
+## Bind order
+
+Fixed per shape; the composer numbers placeholders in bind order, so a
+fragment that is left out never leaves a gap.
+
+| Placeholder | Value                          | Present         |
+|-------------|--------------------------------|-----------------|
+| `$1`        | batch size                     | always          |
+| `$2`        | entrypoint names               | always          |
+| `$3`        | queue manager id               | always          |
+| `$4`        | heartbeat timeout              | always          |
+| next        | per-entrypoint limits          | capacity-gated  |
+| next        | worker budget                  | budget-gated    |
+
+## Components
+
+| Component         | Type         | Description                                            |
+|-------------------|--------------|--------------------------------------------------------|
+| SqlComposer       | Service      | Chains CTE fragments, auto-numbers binds; embeds bodies verbatim (`adapters/persistence/composer.py`) |
+| ComposedQuery     | Value Object | Immutable pairing of rendered SQL and its argument tuple |
+| QueryQueueBuilder | Service      | Selects gates, composes the shape, caches rendered text per shape (`adapters/persistence/qb.py`) |
+| Gate shape        | Value Object | The `(capacity-gated, budget-gated)` pair; cache key and test axis |
+
+## Invariants
+
+- Unlimited is `None` at every boundary. `QueueManager.run` normalizes
+  its legacy `0` to `None`; no sentinel integer reaches the builder.
+- SQL text is a function of the gate shape and table names only.
+  Rendered text is cached per shape on the builder instance; arguments
+  are re-bound on every call and never shared between calls.
+- Entrypoint names and their limits are parallel lists of equal length;
+  the builder rejects a mismatch.
+- Every `$N` placeholder maps onto exactly one bound argument — no
+  gaps, no extras (asserted per shape in `test/test_dequeue_shapes.py`).
+- The stale-job re-pick deliberately skips the capacity gate:
+  re-picking transfers ownership of an already-counted row, and gating
+  it would deadlock recovery (comment in the `next_stale` CTE).
+
+## Guards
+
+- `test/test_composer.py` — composer behavior: bind numbering, verbatim
+  bodies, comment rendering, immutability.
+- `test/test_dequeue_shapes.py` — snapshot per shape, placeholder
+  accounting, per-shape caching, argument isolation, gate semantics
+  against a real database.
+- `test/test_query_plan_regression.py` — EXPLAIN guards that every
+  shape stays on the entrypoint-leading indexes and scans
+  O(entrypoints × batch) rows.

--- a/docs/design/dequeue-composition.md
+++ b/docs/design/dequeue-composition.md
@@ -7,79 +7,48 @@ a sub-model of the [system design](README.md).
 
 ## Flow
 
-```
-QueueManager.run / fetch_jobs (core/qm.py)
-      │ batch size, entrypoint limits, worker budget (None = unlimited)
-      ▼
-Queries.dequeue (adapters/persistence/queries.py)
-      │
-      ▼
-QueryQueueBuilder.build_dequeue_query (adapters/persistence/qb.py)
-      │ gate predicates:
-      │   capacity-gated = any per-entrypoint limit > 0
-      │   budget-gated   = worker budget is not None
-      ▼
-SqlComposer (adapters/persistence/composer.py)
-      │ bind() every runtime value → $N; cte() per required fragment
-      ▼
-ComposedQuery(sql, args) ──► Driver.fetch(sql, *args)
-```
+The queue manager passes the batch size, the per-entrypoint limits,
+and the worker budget to the repository. The query builder derives two
+gate predicates from them (is any entrypoint limit configured, is a
+worker budget configured) and the composer assembles the statement
+those gates need, pairing the text with its arguments for the driver.
 
-The two gate predicates select one of four shapes. SQL text depends
-only on the shape and the installation's table names; every runtime
-value travels as a bound argument.
+The two predicates select one of four shapes. The rendered text
+depends only on the shape and the installation's table names; every
+runtime value travels as a bound argument.
 
 ## Shapes
 
-| Shape           | Capacity gate | Budget gate | Extra CTEs                  | Snapshot                     |
-|-----------------|---------------|-------------|-----------------------------|------------------------------|
-| No gates        | off           | off         | —                           | `dequeue_no_gates.sql`       |
-| Entrypoint gate | on            | off         | `params, picked, available` | `dequeue_entrypoint_gate.sql`|
-| Global gate     | off           | on          | `worker_load`               | `dequeue_global_gate.sql`    |
-| Both gates      | on            | on          | all of the above            | `dequeue_both_gates.sql`     |
-
-Snapshots live in `test/query_shapes/` and are byte-compared;
-regenerate an intended change with `PGQUEUER_UPDATE_SNAPSHOTS=1`.
-
-## Bind order
-
-Fixed per shape; a fragment that is left out never leaves a gap.
-
-| Placeholder | Value                          | Present         |
-|-------------|--------------------------------|-----------------|
-| `$1`        | batch size                     | always          |
-| `$2`        | entrypoint names               | always          |
-| `$3`        | queue manager id               | always          |
-| `$4`        | heartbeat timeout              | always          |
-| next        | per-entrypoint limits          | capacity-gated  |
-| next        | worker budget                  | budget-gated    |
+| Shape           | Entrypoint limits | Worker budget |
+|-----------------|-------------------|---------------|
+| No gates        | off               | off           |
+| Entrypoint gate | on                | off           |
+| Global gate     | off               | on            |
+| Both gates      | on                | on            |
 
 ## Components
 
-| Component         | Type         | Description                                       |
-|-------------------|--------------|---------------------------------------------------|
-| SqlComposer       | Service      | Chains CTE fragments, auto-numbers binds, embeds bodies verbatim |
-| ComposedQuery     | Value Object | Immutable pairing of rendered SQL and its arguments |
-| QueryQueueBuilder | Service      | Selects gates, composes the shape, caches text per shape |
-| Gate shape        | Value Object | The `(capacity-gated, budget-gated)` pair; cache key and test axis |
+| Component     | Type         | Description                                        |
+|---------------|--------------|----------------------------------------------------|
+| Composer      | Service      | Assembles a statement from fragments; couples each value to its placeholder as it is bound |
+| Composed query| Value Object | Immutable pairing of rendered text and arguments   |
+| Query builder | Service      | Derives the gate predicates and composes the shape |
+| Gate shape    | Value Object | The pair of gate predicates; selects the statement |
+
+The composer and builder live in `pgqueuer/adapters/persistence/`.
 
 ## Invariants
 
-- Unlimited is `None` at every boundary; `QueueManager.run` normalizes
-  its legacy `0` to `None`.
-- Rendered text is cached per shape on the builder instance; arguments
-  are re-bound on every call and never shared between calls.
-- Entrypoint names and limits are parallel lists of equal length; the
-  builder rejects a mismatch.
-- Every `$N` maps onto exactly one bound argument.
-- The stale-job re-pick skips the capacity gate on purpose: re-picking
-  transfers ownership of an already-counted row, and gating it would
-  deadlock recovery.
+- "Unlimited" is expressed as absence at every boundary, never as a
+  sentinel value.
+- One gate configuration always renders identical text; arguments are
+  bound fresh on every claim and never shared between claims.
+- The stale-job re-pick skips the entrypoint gate on purpose:
+  re-picking transfers ownership of an already-counted job, and gating
+  it would deadlock recovery.
 
 ## Guards
 
-- `test/test_composer.py`: composer behavior.
-- `test/test_dequeue_shapes.py`: snapshots, placeholder accounting,
-  caching, argument isolation, gate semantics.
-- `test/test_query_plan_regression.py`: every shape stays on the
-  entrypoint-leading indexes and scans O(entrypoints × batch) rows.
+Each shape's rendered text is snapshot-tested, and plan-regression
+tests assert every shape stays on the entrypoint-leading indexes and
+scans work proportional to entrypoints × batch, not the backlog.

--- a/docs/design/dequeue-composition.md
+++ b/docs/design/dequeue-composition.md
@@ -7,13 +7,34 @@ a sub-model of the [system design](README.md).
 
 ## Flow
 
-The queue manager passes the batch size, the per-entrypoint limits,
-and the worker budget to the repository. The query builder derives two
-gate predicates from them (is any entrypoint limit configured, is a
-worker budget configured) and the composer assembles the statement
-those gates need, pairing the text with its arguments for the driver.
+```
+┌───────────────┐
+│ Queue manager │ batch size, entrypoint limits, worker budget
+└───────┬───────┘
+        │
+        ▼
+┌───────────────┐  derives the gate shape from what is configured
+│ Query builder │  and picks the fragments that shape needs
+└───────┬───────┘
+        │ fragments and values, in a fixed order
+        ▼
+┌───────────────┐  couples each value to its placeholder as it is
+│   Composer    │  bound; chains the fragments into one statement
+└───────┬───────┘
+        │
+        ▼
+┌────────────────┐
+│ Composed query │ immutable pair: rendered text + arguments
+└───────┬────────┘
+        │
+        ▼
+┌───────────────┐
+│    Driver     │ sends the pair to PostgreSQL
+└───────────────┘
+```
 
-The two predicates select one of four shapes. The rendered text
+The two gate predicates (is any entrypoint limit configured, is a
+worker budget configured) select one of four shapes. The rendered text
 depends only on the shape and the installation's table names; every
 runtime value travels as a bound argument.
 

--- a/docs/design/dequeue-composition.md
+++ b/docs/design/dequeue-composition.md
@@ -1,7 +1,8 @@
 # Dequeue composition model
 
 How the claim statement is assembled from the concurrency gates in
-use. This document describes *what is*; the *why* lives in
+use. This document describes the target design; the *why* and the
+adoption status live in
 [ADR-0024](../adr/ADR-0024-sql-is-assembled-by-the-composer.md). It is
 a sub-model of the [system design](README.md).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
   - Reference:
       - CLI: reference/cli.md
       - System Design: design/README.md
+      - Dequeue Composition: design/dequeue-composition.md
       - Architecture: reference/architecture.md
       - Row Locking & SKIP LOCKED: reference/skip-locked.md
       - Drivers: reference/drivers.md


### PR DESCRIPTION
Records the direction set by #763: SQL statements are assembled by the composer (auto-numbered binds, text and args emerge as one pair, `None` for unconfigured features, never sentinels). Dequeue is the first adopter; remaining builders migrate when next touched.

Adds the dequeue composition model as the first sub-model split out of the system design doc: shapes, bind order, invariants, guards. ADR index/backlog and mkdocs nav updated.