### PR TITLE
fix(qm): pass unlimited max_concurrent_tasks as None

### DIFF
--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -4,7 +4,6 @@ import asyncio
 import contextlib
 import dataclasses
 import random
-import sys
 import uuid
 from collections.abc import MutableMapping
 from contextlib import nullcontext, suppress
@@ -392,9 +391,11 @@ class QueueManager:
         """
         await self.verify_structure()
 
-        max_concurrent_tasks = max_concurrent_tasks or sys.maxsize
+        # 0 has always meant unlimited; keep unlimited as None all the way to
+        # the dequeue query so it composes without the worker-budget CTEs.
+        max_concurrent_tasks = max_concurrent_tasks or None
 
-        if max_concurrent_tasks < 2 * batch_size:
+        if max_concurrent_tasks is not None and max_concurrent_tasks < 2 * batch_size:
             raise RuntimeError("max_concurrent_tasks must be at least twice the batch size.")
 
         async with (

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -164,6 +164,36 @@ async def test_drain_mode(
     assert len(jobs) == N
 
 
+@pytest.mark.parametrize("max_concurrent_tasks", (None, 0))
+async def test_run_unlimited_budget_reaches_dequeue_as_none(
+    apgdriver: db.Driver,
+    max_concurrent_tasks: int | None,
+) -> None:
+    """run() forwards unlimited max_concurrent_tasks (None or legacy 0) to dequeue as None."""
+    q = Queries(apgdriver)
+    qm = QueueManager(Queries(apgdriver))
+    seen = list[int | None]()
+
+    original = qm.queries.dequeue
+
+    async def spying_dequeue(*args: Any, **kwargs: Any) -> Any:
+        seen.append(kwargs["global_concurrency_limit"])
+        return await original(*args, **kwargs)
+
+    qm.queries.dequeue = spying_dequeue  # type: ignore[method-assign]
+
+    @qm.entrypoint("fetch")
+    async def fetch(job: Job) -> None: ...
+
+    await q.enqueue("fetch", None, 0)
+
+    async with async_timeout.timeout(10):
+        await qm.run(mode=QueueExecutionMode.drain, max_concurrent_tasks=max_concurrent_tasks)
+
+    assert seen
+    assert set(seen) == {None}
+
+
 async def test_periodic_log_aggregation_loops_until_shutdown() -> None:
     """The periodic task calls aggregate_logs repeatedly and stops on shutdown."""
     calls = 0


### PR DESCRIPTION
`run()` coerced `None` (and the legacy `0`) to `sys.maxsize` before `fetch_jobs`, so a worker with no limit still sent a concrete budget to the dequeue query. Unlimited now stays absent end to end.

The current query already handles a NULL budget, so this is behaviour-neutral today. It matters for #763, where the absent budget is what lets the statement skip the per-worker bookkeeping entirely.

New test asserts both `None` and `0` reach `dequeue` as `None` through a real drain run.