### PR TITLE
refactor(qb): compose the log_statistics query

### DIFF
--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -187,7 +187,8 @@ def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
         d = _db(ctx)
         await d.fetch(d.qbq.build_aggregate_log_data_to_statistics_query())
         interval = _parse_interval(period)
-        return await d.fetch(d.qbq.build_log_statistics_query(), limit, interval)
+        query = d.qbq.build_log_statistics_query(limit=limit, last=interval)
+        return await d.fetch(query.sql, *query.args)
 
     @mcp.tool()
     async def throughput_summary(

--- a/pgqueuer/adapters/persistence/composer.py
+++ b/pgqueuer/adapters/persistence/composer.py
@@ -23,15 +23,16 @@ class SqlComposer:
     statement caches see one entry per query shape.
 
     CTE bodies are embedded verbatim — never rewritten — so SQL string
-    literals pass through untouched. Optional lines are the caller's job:
-    interpolate them (including their leading newline) only when present.
+    literals pass through untouched. ``clauses`` assembles a statement from
+    one clause per argument, so an optional clause is an empty string rather
+    than a newline the caller has to splice in by hand.
 
     Usage example::
 
-        c = SqlComposer()
-        limit = c.bind(10)
-        c.cte("ready", f"SELECT id FROM jobs LIMIT {limit}")
-        query = c.render("SELECT * FROM ready")
+        composer = SqlComposer()
+        limit = composer.bind(10)
+        composer.cte("ready", f"SELECT id FROM jobs LIMIT {limit}")
+        query = composer.render("SELECT * FROM ready")
         await driver.fetch(query.sql, *query.args)
     """
 
@@ -41,6 +42,11 @@ class SqlComposer:
     def bind(self, value: object) -> str:
         self.values.append(value)
         return f"${len(self.values)}"
+
+    @staticmethod
+    def clauses(*parts: str) -> str:
+        """Join clauses onto their own lines, dropping the ones left empty."""
+        return "\n".join(part for part in parts if part)
 
     def cte(self, name: str, body: str, comment: str = "") -> None:
         # Dedent + strip lets callers pass indented triple-quoted comment blocks.

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -743,22 +743,20 @@ SELECT * FROM claimed ORDER BY priority DESC, id ASC;
         window = ""
         if last is not None:
             bound_last = composer.bind(last)
-            window = f"\n    WHERE created > NOW() - {bound_last}::interval"
+            window = f"WHERE created > NOW() - {bound_last}::interval"
 
         cap = ""
         if limit is not None:
             bound_limit = composer.bind(limit)
-            cap = f"\n    LIMIT {bound_limit}"
+            cap = f"LIMIT {bound_limit}"
 
-        statement = f"""SELECT
-        count,
-        created,
-        entrypoint,
-        priority,
-        status
-    FROM {self.qualified.statistics_table}{window}
-    ORDER BY id DESC{cap}
-    """
+        statement = composer.clauses(
+            "SELECT count, created, entrypoint, priority, status",
+            f"FROM {self.qualified.statistics_table}",
+            window,
+            "ORDER BY id DESC",
+            cap,
+        )
         return composer.render(statement)
 
     def build_update_heartbeat_query(self) -> str:

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import dataclasses
+from datetime import timedelta
 from typing import Generator
 
 from typing_extensions import assert_never
 
+from pgqueuer.adapters.persistence.composer import ComposedQuery, SqlComposer
 from pgqueuer.domain.settings import (
     DBSettings,
     Durability,
@@ -729,18 +731,35 @@ SELECT * FROM claimed ORDER BY priority DESC, id ASC;
     def build_delete_from_log_statistics_query(self) -> str:
         return f"""DELETE FROM {self.qualified.statistics_table} WHERE entrypoint = ANY($1)"""
 
-    def build_log_statistics_query(self) -> str:
-        return f"""SELECT
+    def build_log_statistics_query(
+        self,
+        *,
+        limit: int | None,
+        last: timedelta | None,
+    ) -> ComposedQuery:
+        """Read recent statistics rows; an unset limit/last elides its clause."""
+        composer = SqlComposer()
+
+        window = ""
+        if last is not None:
+            bound_last = composer.bind(last)
+            window = f"\n    WHERE created > NOW() - {bound_last}::interval"
+
+        cap = ""
+        if limit is not None:
+            bound_limit = composer.bind(limit)
+            cap = f"\n    LIMIT {bound_limit}"
+
+        statement = f"""SELECT
         count,
         created,
         entrypoint,
         priority,
         status
-    FROM {self.qualified.statistics_table}
-    WHERE ($2::interval IS NULL OR created > NOW() - $2)
-    ORDER BY id DESC
-    LIMIT $1
+    FROM {self.qualified.statistics_table}{window}
+    ORDER BY id DESC{cap}
     """
+        return composer.render(statement)
 
     def build_update_heartbeat_query(self) -> str:
         return f"""UPDATE {self.qualified.queue_table} SET heartbeat = NOW() WHERE id = ANY($1::bigint[])"""  # noqa: E501

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -436,14 +436,9 @@ class Queries:
         await self.driver.execute(
             self.qbq.build_aggregate_log_data_to_statistics_query(advisory_lock=False)
         )
-        return [
-            models.LogStatistics.model_validate(x)
-            for x in await self.driver.fetch(
-                self.qbq.build_log_statistics_query(),
-                limit,
-                last,
-            )
-        ]
+        query = self.qbq.build_log_statistics_query(limit=limit, last=last)
+        rows = await self.driver.fetch(query.sql, *query.args)
+        return [models.LogStatistics.model_validate(row) for row in rows]
 
     async def notify_job_cancellation(self, ids: list[models.JobId]) -> None:
         """Emit a ``cancellation_event`` NOTIFY carrying *ids*."""

--- a/test/test_composer.py
+++ b/test/test_composer.py
@@ -15,6 +15,20 @@ def test_bind_numbers_placeholders_in_order() -> None:
     assert composer.values == [10, ["a"], None]
 
 
+def test_clauses_puts_each_part_on_its_own_line() -> None:
+    assert SqlComposer.clauses("SELECT 1", "FROM jobs") == "SELECT 1\nFROM jobs"
+
+
+def test_clauses_drops_empty_parts() -> None:
+    # An unset filter contributes "" and must leave no blank line behind: the
+    # caller never has to own the newline that would otherwise precede it.
+    assert SqlComposer.clauses("SELECT 1", "", "FROM jobs", "") == "SELECT 1\nFROM jobs"
+
+
+def test_clauses_keeps_a_multi_line_part_intact() -> None:
+    assert SqlComposer.clauses("SELECT\n    id", "FROM jobs") == "SELECT\n    id\nFROM jobs"
+
+
 def test_render_pairs_sql_with_bound_args() -> None:
     composer = SqlComposer()
     limit = composer.bind(10)

--- a/test/test_log_statistics_shapes.py
+++ b/test/test_log_statistics_shapes.py
@@ -1,0 +1,60 @@
+"""The log_statistics statement carries only the clauses its filters ask for."""
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+
+import pytest
+
+from pgqueuer.adapters.persistence import qb
+from pgqueuer.adapters.persistence.composer import ComposedQuery
+from pgqueuer.domain.settings import DBSettings
+
+
+def compose(limit: int | None, last: timedelta | None) -> ComposedQuery:
+    # Pin the table name so a developer's exported PGQUEUER_* env vars cannot
+    # skew the rendered SQL.
+    settings = DBSettings(db_schema=None, statistics_table="pgqueuer_statistics")
+    builder = qb.QueryQueueBuilder(settings=settings)
+    return builder.build_log_statistics_query(limit=limit, last=last)
+
+
+@pytest.mark.parametrize(
+    ("limit", "last", "has_where", "has_limit"),
+    [
+        (None, None, False, False),
+        (10, None, False, True),
+        (None, timedelta(hours=1), True, False),
+        (10, timedelta(hours=1), True, True),
+    ],
+)
+def test_log_statistics_shape_follows_filters(
+    limit: int | None,
+    last: timedelta | None,
+    has_where: bool,
+    has_limit: bool,
+) -> None:
+    query = compose(limit, last)
+    assert ("WHERE" in query.sql) == has_where
+    assert ("LIMIT" in query.sql) == has_limit
+    # Every $N placeholder maps onto exactly one bound arg: no gaps, no extras.
+    placeholders = {int(n) for n in re.findall(r"\$(\d+)", query.sql)}
+    assert placeholders == set(range(1, len(query.args) + 1))
+
+
+def test_log_statistics_full_shape() -> None:
+    expected = """SELECT
+        count,
+        created,
+        entrypoint,
+        priority,
+        status
+    FROM pgqueuer_statistics
+    WHERE created > NOW() - $1::interval
+    ORDER BY id DESC
+    LIMIT $2
+    """
+    query = compose(10, timedelta(hours=1))
+    assert query.sql == expected
+    assert query.args == (timedelta(hours=1), 10)

--- a/test/test_log_statistics_shapes.py
+++ b/test/test_log_statistics_shapes.py
@@ -44,17 +44,11 @@ def test_log_statistics_shape_follows_filters(
 
 
 def test_log_statistics_full_shape() -> None:
-    expected = """SELECT
-        count,
-        created,
-        entrypoint,
-        priority,
-        status
-    FROM pgqueuer_statistics
-    WHERE created > NOW() - $1::interval
-    ORDER BY id DESC
-    LIMIT $2
-    """
+    expected = """SELECT count, created, entrypoint, priority, status
+FROM pgqueuer_statistics
+WHERE created > NOW() - $1::interval
+ORDER BY id DESC
+LIMIT $2"""
     query = compose(10, timedelta(hours=1))
     assert query.sql == expected
     assert query.args == (timedelta(hours=1), 10)

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -148,7 +148,8 @@ class TestMcpToolsIntegration:
         await q.enqueue("stats_ep", b"x", priority=0)
 
         await mcpdb.fetch(mcpdb.qbq.build_aggregate_log_data_to_statistics_query())
-        rows = await mcpdb.fetch(mcpdb.qbq.build_log_statistics_query(), 50, None)
+        stats_query = mcpdb.qbq.build_log_statistics_query(limit=50, last=None)
+        rows = await mcpdb.fetch(stats_query.sql, *stats_query.args)
         assert len(rows) >= 1
 
     async def test_stale_jobs_none_when_fresh(

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -887,7 +887,8 @@ async def test_aggregate_logs_populates_statistics_without_read(apgdriver: db.Dr
     await q.aggregate_logs()
 
     assert await _unaggregated_count(q) == 0
-    stats = await q.driver.fetch(q.qbq.build_log_statistics_query(), None, None)
+    stats_query = q.qbq.build_log_statistics_query(limit=None, last=None)
+    stats = await q.driver.fetch(stats_query.sql, *stats_query.args)
     assert sum(int(r["count"]) for r in stats) == 3 * N  # queued + picked + successful
 
 
@@ -956,7 +957,8 @@ async def test_upgrade_from_legacy_composite_index_still_aggregates(
     assert await _unaggregated_count(q) > 0
     await q.aggregate_logs()
     assert await _unaggregated_count(q) == 0
-    stats = await q.driver.fetch(q.qbq.build_log_statistics_query(), None, None)
+    stats_query = q.qbq.build_log_statistics_query(limit=None, last=None)
+    stats = await q.driver.fetch(stats_query.sql, *stats_query.args)
     assert sum(int(r["count"]) for r in stats) == 3 * N  # queued + picked + successful
 
 


### PR DESCRIPTION
`log_statistics` carried both filters as always-bound placeholders and let SQL
neutralize them: `WHERE ($2::interval IS NULL OR created > NOW() - $2)` for an
unset window, and `LIMIT $1` with a NULL argument for an unbounded read. The
statement read as if it always filtered, and every caller passed positional
`None`s to say "no filter".

Composed instead. An unset filter drops its clause, so the rendered SQL shows
exactly the filters in effect and `bind` numbers the placeholders that remain.
Four shapes, all covered by `test/test_log_statistics_shapes.py`.

Behaviour is unchanged: NULL-neutralized clauses and absent clauses select the
same rows. The window bind gains an explicit `::interval` cast; with no
comparison clause left to infer from, asyncpg cannot type the parameter and
Postgres rejects `timestamptz > interval`.

First builder to follow ADR-0024 after the dequeue statement.