### PR TITLE
docs: cap comment length at two lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,8 +259,13 @@ Only add a comment when the **why** is non-obvious:
 - Task or issue refs in inline comments — link them in the PR description instead. Exception: regression tests may reference the issue ID in their docstring or `xfail` reason, because the issue is the test's reason to exist.
 - Banner section headers (`# ----- Layer 2 -----`) — let function names and module structure do the work
 - TODOs without an owner and a tracking link
+- Step-by-step narration of a block — a comment per step retells the code in prose. Annotate only the step that would surprise a reader.
 
 When a comment explains a non-obvious workaround, keep it short and put it adjacent to the line it explains. Prefer one line.
+
+**Two lines is the cap.** Not a target to fill — a ceiling. A comment that wants a third line is a comment that has stopped explaining a surprise and started teaching a subject; the subject belongs in an ADR (`docs/adr/`) or the PR description, and the comment cites it in one line. This applies hardest above a SQL literal or a long function, where an essay is easy to write and rarely read.
+
+If the comment prose in a function is a noticeable fraction of its code, that is a defect regardless of whether any single comment obeys the cap. Cut until each surviving line earns its place.
 
 ### Guiding Principles
 


### PR DESCRIPTION
The Comments section already said "default to no comments" and "prefer one line". A recent dequeue refactor still landed 373 words of comment prose in a 344-line function -- more than a word per line of code. Every paragraph looked justified on its own, which is why a qualitative rule did not catch them.

Two changes:

- **Two lines is the cap.** A ceiling, not a target. A comment that wants a third line has stopped explaining a surprise and started teaching a subject; the subject belongs in an ADR or the PR description.
- **A density check**, for when every comment obeys the cap and the function still drowns.

Also bans step-by-step narration of a block in the existing "do not write" list.

Docs only -- no code changes.