### PR TITLE
docs: record the schema manifest decision as ADR-0025

### DIFF
--- a/docs/adr/ADR-0025-the-schema-contract-is-a-declared-manifest.md
+++ b/docs/adr/ADR-0025-the-schema-contract-is-a-declared-manifest.md
@@ -1,0 +1,82 @@
+# ADR-0025: The schema contract is a declared manifest
+
+## Status
+
+Accepted
+
+## Context
+
+The library owns its schema lifecycle (ADR-0015) and migrates it as an
+idempotent, forward-only stream with no version table (ADR-0016). It had
+no stated answer to the other half: whether the schema a worker finds is
+one this code can drive.
+
+That was decided by a handful of probes, each added when an upgrade
+broke a deployment. The set recorded past incidents, not present
+requirements. It could not tell an old schema from a damaged one, went
+stale whenever DDL was added without a matching probe, and each manager
+checked a different subset.
+
+## Decision
+
+The database objects the library requires are declared, and startup
+verifies the installed schema against that declaration.
+
+The declaration is the only place that answers whether an object is
+required. Anything it demands must have a supported way to produce;
+anything optional is declared optional. Adding an object to the schema
+means adding it to the declaration in the same change. Removing one is a
+break in the public surface (ADR-0020).
+
+## Consequences
+
+### Positive consequences
+
+- Drift is reported as the objects that differ, not as the first query
+  to fail.
+- One artifact to review when the schema changes, checkable against the
+  schema the library installs.
+- Managers can be held to the objects they use.
+- Per-object versions let schema and library be compared without a
+  version table.
+
+### Negative consequences
+
+- The declaration and the DDL can drift; only tests keep them together.
+- A stricter gate can refuse a schema a previous release started on, so
+  the declaration must separate required objects from ones that only
+  help.
+- Requiring an object commits the upgrade path to creating it.
+- The declaration names objects, so it catches a dropped one and misses
+  an altered one. Covering that means declaring each object's shape.
+
+## Alternatives considered
+
+### Probing for the shapes the code uses (the previous design)
+
+Rejected. The probe set records past incidents, goes stale silently, and
+cannot distinguish an old schema from a damaged one.
+
+### Recording a single schema version and comparing numbers
+
+Rejected. It reintroduces the bookkeeping ADR-0016 avoids, is
+trustworthy only if nothing touches the schema out of band, and names no
+object.
+
+### Verifying nothing and letting queries fail
+
+Rejected. The failure arrives as a driver error after the worker has
+taken jobs, and carries no remedy.
+
+## Not covered by this ADR
+
+How the declaration is expressed, how the installed schema is read, how
+per-object versions are recorded, the severity vocabulary, and which
+objects are declared today. See the
+[schema manifest model](../design/schema-manifest.md).
+
+## References
+
+- [ADR index and backlog](README.md)
+- [Schema manifest model](../design/schema-manifest.md)
+- [Schema revision markers reference](../reference/schema-revision.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ Conventions:
 - [ADR-0004: Delivery is at-least-once](ADR-0004-delivery-is-at-least-once.md)
 - [ADR-0005: Worker liveness is an application-level signal, not DB session state](ADR-0005-worker-liveness-is-application-signal.md)
 - [ADR-0024: SQL statements are assembled by the composer](ADR-0024-sql-is-assembled-by-the-composer.md)
+- [ADR-0025: The schema contract is a declared manifest](ADR-0025-the-schema-contract-is-a-declared-manifest.md)
 
 ## Backlog
 
@@ -254,6 +255,20 @@ leaves open.
     `pgqueuer/adapters/persistence/`.
   - Not covered: migration order and mechanics (see the dequeue
     composition model).
+
+- [x] **ADR-0025: The schema contract is a declared manifest**
+  - Decision: the objects the library requires are declared, and startup
+    verifies the installed schema against that declaration instead of
+    probing for the shapes the code happens to use.
+  - Fork: declared contract vs. accumulated probes vs. a recorded schema
+    version number.
+  - Consequences: drift is reported as named objects rather than as the
+    first query to fail; the declaration must be maintained alongside the
+    DDL; requiring an object commits the upgrade path to creating it.
+  - Pointers: manifest and verdict in `pgqueuer/domain/`; the startup gate
+    in `pgqueuer/core/`.
+  - Not covered: how the declaration is expressed, how per-object versions
+    are recorded, the severity vocabulary (see the schema manifest model).
 
 ### Runtime & process
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -245,6 +245,9 @@ for jobs: row-lock claim plus heartbeat-based staleness recovery (ADR-0022).
 - [Dequeue composition model](dequeue-composition.md): how the claim
   statement is assembled from the concurrency gates in use, with the
   shapes, bind order, invariants, and guarding tests (ADR-0024).
+- [Schema manifest model](schema-manifest.md): the objects an
+  installation declares, how they depend on each other, and how a worker
+  turns that declaration into a startup verdict (ADR-0025).
 
 Planned split-outs once a section outgrows this document; each keeps a
 summary here:
@@ -252,7 +255,8 @@ summary here:
 - Job lifecycle model: statuses, retries, cancellation, and completion
   tracking in one place.
 - Scheduling model: schedule ownership, cadence, and cron semantics.
-- Schema & namespace model: installation objects, durability policies, and
-  the migration stream.
+- Namespace & migration model: durability policies and the migration
+  stream (the installed objects themselves are covered by the
+  [schema manifest model](schema-manifest.md)).
 - Observability model: the log/statistics pipeline, dashboard, metrics,
   and the MCP read surface.

--- a/docs/design/schema-manifest.md
+++ b/docs/design/schema-manifest.md
@@ -1,0 +1,134 @@
+# Schema manifest model
+
+What the library declares it needs from the database, and how a worker
+turns that into a startup decision. The *why* lives in
+[ADR-0025](../adr/ADR-0025-the-schema-contract-is-a-declared-manifest.md).
+Sub-model of the [system design](README.md); the operator view is the
+[schema revision markers reference](../reference/schema-revision.md).
+
+## Flow
+
+```
+┌───────────────┐
+│   Manifest    │ every object the running code requires,
+│  (declared)   │ named for this installation's namespace
+└───────┬───────┘
+        │
+        ▼
+┌───────────────┐  one read of the catalog for the declared names
+│    Catalog    │
+│   (observed)  │
+└───────┬───────┘
+        │
+        ▼
+┌───────────────┐  declared minus observed, reduced to root causes
+│   Verdict     │  and split by severity
+└───────┬───────┘
+        │
+        ▼
+┌───────────────┐
+│ Startup gate  │ refuse, warn, or proceed
+└───────────────┘
+```
+
+The manifest is derived from the installation's namespace, so one
+declaration covers every prefix and schema.
+
+## Dependency model
+
+Every declared object names the object it hangs off. The relation is
+containment, one level deep: no chain to walk, no cycle to break.
+
+```
+┌──────────────┐
+│ Installation │
+│  (namespace) │
+└──────┬───────┘
+       │ 1
+       ├────────────────┬──────────────────┬─────────────┐
+       ▼ 0..*           ▼ 0..*             ▼ 1           ▼ 1
+┌─────────────┐   ┌───────────┐      ┌──────────┐  ┌──────────┐
+│    Table    │   │  Routine  │      │   Type   │  │ Channel  │
+└──────┬──────┘   └───────────┘      └────┬─────┘  └──────────┘
+       │ 1                                │ 1
+       ├──────────┬──────────┐            ▼ 0..*
+       ▼ 0..*     ▼ 0..*     ▼ 0..*  ┌────────────┐
+┌───────────┐ ┌───────┐ ┌─────────┐  │ Enum value │
+│  Column   │ │ Index │ │ Trigger │  └────────────┘
+└───────────┘ └───────┘ └─────────┘
+```
+
+Two properties depend on this shape:
+
+- An absent table takes its columns, indexes and triggers with it, so a
+  verdict names the parent and drops the dependents it explains.
+- Every object resolves to a table or to the type, so a manager can be
+  held to the tables it uses. `SchedulerManager` does not touch the
+  queue-side objects.
+
+The manifest records no foreign keys, no ordering, and no "created by"
+edges. A dependency answers one question: is this object's absence
+already explained?
+
+## Components
+
+| Component     | Type         | Description                                          |
+|---------------|--------------|------------------------------------------------------|
+| Manifest      | Value Object | The objects the running code requires                |
+| Schema object | Value Object | One declared object: kind, name, parent, revision, severity |
+| Observation   | Value Object | What the catalog holds for a declared name, with its recorded revision |
+| Verdict       | Value Object | Not installed, incomplete, or usable, with what is absent, unstamped, or ahead |
+| Startup gate  | Service      | Turns a verdict into refuse, warn, or proceed for one manager |
+
+Manifest and verdict are pure domain values; reading the catalog belongs
+to the persistence adapter.
+
+## Severity
+
+Severity is a property of the object, not of the situation.
+
+| Severity   | Meaning                        | Absent object   |
+|------------|--------------------------------|-----------------|
+| `required` | Queries do not work without it | Refuse to start |
+| `advisory` | Only makes queries faster      | Warn and start  |
+
+A released install and the current manifest can differ by a performance
+index, and a schema that worked before a library upgrade must keep
+working. Uniqueness is never advisory: an index that arbitrates a
+conflict clause decides how the statement behaves.
+
+## Revision
+
+Each declared object carries the revision its current shape dates from,
+and the installed object records the revision that created it. Comparing
+the two shows which side is ahead without a version table (ADR-0016).
+During a rolling deploy the schema is upgraded first, so a worker that
+finds newer objects reports them and keeps running.
+
+A revision is per object and immutable once shipped. A bump may add
+objects or widen types; dropping or narrowing one is a major release.
+
+A revision records which library created an object. It is not evidence
+that the object still has that shape: editing an object in place does
+not change its recorded revision.
+
+## Limits
+
+Objects are matched by kind, name and parent. A dropped object is
+therefore caught, but an altered one is not: a column retyped, a
+constraint dropped, an index recreated over different columns under the
+same name, or a replaced function body all satisfy the manifest.
+Detecting those needs the declaration to carry each object's shape,
+which it does not today.
+
+## Invariants
+
+- The manifest is the only place that decides whether an object is
+  required.
+- Existence is checked independently of the recorded revision, so an
+  unstamped schema is verified as thoroughly as a stamped one.
+- A verdict names only root causes.
+- Whatever the verdict demands, the upgrade path must be able to create.
+  Otherwise the object is advisory.
+- An object the code no longer needs leaves the manifest only in a major
+  release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - CLI: reference/cli.md
       - System Design: design/README.md
       - Dequeue Composition: design/dequeue-composition.md
+      - Schema Manifest: design/schema-manifest.md
       - Architecture: reference/architecture.md
       - Row Locking & SKIP LOCKED: reference/skip-locked.md
       - Drivers: reference/drivers.md


### PR DESCRIPTION
Splits the architecture record out of #751 so the decision can be reviewed on its own. No code changes.

ADR-0025 holds one decision: the objects the library requires are declared, and startup verifies the installed schema against that declaration instead of probing for the shapes the code happens to use. Three alternatives are named and rejected (accumulated probes, a recorded schema version number, verifying nothing). Implementation is pushed to *Not covered*.

`docs/design/schema-manifest.md` is the model: manifest, observation, verdict, startup gate. Its dependency model is containment one level deep, which is what lets a verdict name root causes and lets a manager be scoped to the tables it uses.

Also indexed in the ADR README, linked from the design README, added to the mkdocs nav.

Two notes:

- Both documents link to `docs/reference/schema-revision.md`, which lands in #751. Those links dangle until that merges. `mkdocs build` runs without `--strict`, so the docs workflow still passes.
- 0006-0023 are backlog placeholders and 0024 is the composer record, so this takes 0025.