### PR TITLE
refactor(qb): name the two claim sets

### DIFF
--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -571,25 +571,24 @@ class QueryQueueBuilder:
         budget_and = ""
         eligible_limit = batch
         if budget_gated:
+            # headroom, not the total, is what stops a batch overshooting: the total
+            # only says whether a dequeue may start, never how much it may take.
             composer.cte(
                 "worker_load",
                 f"""
-                    SELECT COUNT(*) AS total
+                    SELECT
+                        COUNT(*) AS total,
+                        GREATEST(LEAST({batch}, {global_limit} - COUNT(*)), 0) AS headroom
                     FROM {queue_table}
                     WHERE queue_manager_id = {queue_manager}
                       AND entrypoint = ANY({eps})
                 """,
-                comment="This worker's total picked jobs (scalar, for max_concurrent_tasks).",
+                comment="This worker's picked jobs, and how many more this batch may claim.",
             )
             under_budget = f"(SELECT total FROM worker_load) < {global_limit}"
             budget_where = f"WHERE {under_budget}"
             budget_and = f"AND {under_budget}"
-            # The eligible LIMIT hard-caps this worker's total picked rows: the binary
-            # worker_load condition only stops a dequeue from starting once over budget,
-            # it does not stop one batch from overshooting it.
-            eligible_limit = (
-                f"GREATEST(LEAST({batch}, {global_limit} - (SELECT total FROM worker_load)), 0)"
-            )
+            eligible_limit = "(SELECT headroom FROM worker_load)"
 
         if capacity_gated:
             composer.cte(
@@ -723,7 +722,7 @@ class QueryQueueBuilder:
                 WHERE id IN (SELECT id FROM eligible)
                 RETURNING *
             """,
-            comment="Atomically claim the jobs and log the pick event.",
+            comment="Claim every eligible job in one atomic UPDATE.",
         )
         composer.cte(
             "log_pick",
@@ -731,6 +730,7 @@ class QueryQueueBuilder:
                 INSERT INTO {self.qualified.queue_table_log} (job_id, status, entrypoint, priority)
                 SELECT id, status, entrypoint, priority FROM claimed
             """,
+            comment="Record the pick in the log table.",
         )
         query = composer.render("SELECT * FROM claimed ORDER BY priority DESC, id ASC;")
         self.dequeue_sql_cache[shape] = query.sql

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -592,11 +592,9 @@ class QueryQueueBuilder:
             )
 
         if capacity_gated:
-            # Windowing before the lock keeps the lock node out from under a LIMIT,
-            # where SKIP LOCKED slides down the backlog and past the cap (#761).
-            queued_body = f"""
-                SELECT job.id, job.priority
-                FROM (
+            composer.cte(
+                "unlimited_claims",
+                f"""
                     SELECT job.id, job.priority
                     FROM available
                     CROSS JOIN LATERAL (
@@ -610,7 +608,14 @@ class QueryQueueBuilder:
                         FOR UPDATE SKIP LOCKED
                     ) job
                     WHERE available.remaining IS NULL
-                    UNION ALL
+                """,
+                comment="Claims for entrypoints without a limit; lock straight down the backlog.",
+            )
+            # Windowing before the lock keeps the lock node out from under a LIMIT,
+            # where SKIP LOCKED slides down the backlog and past the cap (#761).
+            composer.cte(
+                "limited_claims",
+                f"""
                     SELECT job.id, job.priority
                     FROM available
                     CROSS JOIN LATERAL (
@@ -636,12 +641,23 @@ class QueryQueueBuilder:
                         LIMIT LEAST({batch}, available.remaining)
                     ) job
                     WHERE available.remaining IS NOT NULL
+                """,
+                comment="Claims for limited entrypoints; the window is fixed before the lock.",
+            )
+            queued_comment = "Both claim sets merged into one priority order."
+            queued_body = f"""
+                SELECT job.id, job.priority
+                FROM (
+                    SELECT id, priority FROM unlimited_claims
+                    UNION ALL
+                    SELECT id, priority FROM limited_claims
                 ) job
                 {budget_where}
                 ORDER BY job.priority DESC, job.id ASC
                 LIMIT {batch}
             """
         else:
+            queued_comment = "New queued jobs; LATERAL hits the (entrypoint, priority, id) index."
             queued_body = f"""
                 SELECT job.id, job.priority
                 FROM available
@@ -659,11 +675,7 @@ class QueryQueueBuilder:
                 ORDER BY job.priority DESC, job.id ASC
                 LIMIT {batch}
             """
-        composer.cte(
-            "next_queued",
-            queued_body,
-            comment="New queued jobs; LATERAL hits the (entrypoint, priority, id) index.",
-        )
+        composer.cte("next_queued", queued_body, comment=queued_comment)
 
         # The entrypoint concurrency gate is intentionally omitted here: re-picking a
         # stale job only transfers ownership of a row already counted in `picked`, so

--- a/test/query_shapes/dequeue_both_gates.sql
+++ b/test/query_shapes/dequeue_both_gates.sql
@@ -37,49 +37,59 @@ worker_load AS (
       AND entrypoint = ANY($2)
 ),
 
--- New queued jobs; LATERAL hits the (entrypoint, priority, id) index.
-next_queued AS (
+-- Claims for entrypoints without a limit; lock straight down the backlog.
+unlimited_claims AS (
     SELECT job.id, job.priority
-    FROM (
-        SELECT job.id, job.priority
-        FROM available
-        CROSS JOIN LATERAL (
-            SELECT candidate.id, candidate.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT candidate.id, candidate.priority
+        FROM pgqueuer candidate
+        WHERE candidate.entrypoint = available.entrypoint
+          AND candidate.status = 'queued'
+          AND candidate.execute_after < NOW()
+        ORDER BY candidate.priority DESC, candidate.id ASC
+        LIMIT $1
+        FOR UPDATE SKIP LOCKED
+    ) job
+    WHERE available.remaining IS NULL
+),
+
+-- Claims for limited entrypoints; the window is fixed before the lock.
+limited_claims AS (
+    SELECT job.id, job.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT locked.id, locked.priority
+        FROM (
+            SELECT candidate.id
             FROM pgqueuer candidate
             WHERE candidate.entrypoint = available.entrypoint
               AND candidate.status = 'queued'
               AND candidate.execute_after < NOW()
             ORDER BY candidate.priority DESC, candidate.id ASC
-            LIMIT $1
-            FOR UPDATE SKIP LOCKED
-        ) job
-        WHERE available.remaining IS NULL
-        UNION ALL
-        SELECT job.id, job.priority
-        FROM available
-        CROSS JOIN LATERAL (
-            SELECT locked.id, locked.priority
-            FROM (
-                SELECT candidate.id
-                FROM pgqueuer candidate
-                WHERE candidate.entrypoint = available.entrypoint
-                  AND candidate.status = 'queued'
-                  AND candidate.execute_after < NOW()
-                ORDER BY candidate.priority DESC, candidate.id ASC
-                LIMIT LEAST($1, available.remaining)
-            ) capped
-            CROSS JOIN LATERAL (
-                SELECT target.id, target.priority
-                FROM pgqueuer target
-                WHERE target.id = capped.id
-                  AND target.status = 'queued'
-                  AND target.execute_after < NOW()
-                FOR UPDATE OF target SKIP LOCKED
-            ) locked
-            ORDER BY locked.priority DESC, locked.id ASC
             LIMIT LEAST($1, available.remaining)
-        ) job
-        WHERE available.remaining IS NOT NULL
+        ) capped
+        CROSS JOIN LATERAL (
+            SELECT target.id, target.priority
+            FROM pgqueuer target
+            WHERE target.id = capped.id
+              AND target.status = 'queued'
+              AND target.execute_after < NOW()
+            FOR UPDATE OF target SKIP LOCKED
+        ) locked
+        ORDER BY locked.priority DESC, locked.id ASC
+        LIMIT LEAST($1, available.remaining)
+    ) job
+    WHERE available.remaining IS NOT NULL
+),
+
+-- Both claim sets merged into one priority order.
+next_queued AS (
+    SELECT job.id, job.priority
+    FROM (
+        SELECT id, priority FROM unlimited_claims
+        UNION ALL
+        SELECT id, priority FROM limited_claims
     ) job
     WHERE (SELECT total FROM worker_load) < $6
     ORDER BY job.priority DESC, job.id ASC

--- a/test/query_shapes/dequeue_both_gates.sql
+++ b/test/query_shapes/dequeue_both_gates.sql
@@ -29,9 +29,11 @@ available AS (
        OR COALESCE(picked.total, 0) < params.concurrency_limit
 ),
 
--- This worker's total picked jobs (scalar, for max_concurrent_tasks).
+-- This worker's picked jobs, and how many more this batch may claim.
 worker_load AS (
-    SELECT COUNT(*) AS total
+    SELECT
+        COUNT(*) AS total,
+        GREATEST(LEAST($1, $6 - COUNT(*)), 0) AS headroom
     FROM pgqueuer
     WHERE queue_manager_id = $3
       AND entrypoint = ANY($2)
@@ -118,10 +120,10 @@ eligible AS (
         SELECT id, priority FROM next_stale
     ) combined
     ORDER BY priority DESC, id ASC
-    LIMIT GREATEST(LEAST($1, $6 - (SELECT total FROM worker_load)), 0)
+    LIMIT (SELECT headroom FROM worker_load)
 ),
 
--- Atomically claim the jobs and log the pick event.
+-- Claim every eligible job in one atomic UPDATE.
 claimed AS (
     UPDATE pgqueuer
     SET status = 'picked',
@@ -132,6 +134,7 @@ claimed AS (
     RETURNING *
 ),
 
+-- Record the pick in the log table.
 log_pick AS (
     INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
     SELECT id, status, entrypoint, priority FROM claimed

--- a/test/query_shapes/dequeue_entrypoint_gate.sql
+++ b/test/query_shapes/dequeue_entrypoint_gate.sql
@@ -29,49 +29,59 @@ available AS (
        OR COALESCE(picked.total, 0) < params.concurrency_limit
 ),
 
--- New queued jobs; LATERAL hits the (entrypoint, priority, id) index.
-next_queued AS (
+-- Claims for entrypoints without a limit; lock straight down the backlog.
+unlimited_claims AS (
     SELECT job.id, job.priority
-    FROM (
-        SELECT job.id, job.priority
-        FROM available
-        CROSS JOIN LATERAL (
-            SELECT candidate.id, candidate.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT candidate.id, candidate.priority
+        FROM pgqueuer candidate
+        WHERE candidate.entrypoint = available.entrypoint
+          AND candidate.status = 'queued'
+          AND candidate.execute_after < NOW()
+        ORDER BY candidate.priority DESC, candidate.id ASC
+        LIMIT $1
+        FOR UPDATE SKIP LOCKED
+    ) job
+    WHERE available.remaining IS NULL
+),
+
+-- Claims for limited entrypoints; the window is fixed before the lock.
+limited_claims AS (
+    SELECT job.id, job.priority
+    FROM available
+    CROSS JOIN LATERAL (
+        SELECT locked.id, locked.priority
+        FROM (
+            SELECT candidate.id
             FROM pgqueuer candidate
             WHERE candidate.entrypoint = available.entrypoint
               AND candidate.status = 'queued'
               AND candidate.execute_after < NOW()
             ORDER BY candidate.priority DESC, candidate.id ASC
-            LIMIT $1
-            FOR UPDATE SKIP LOCKED
-        ) job
-        WHERE available.remaining IS NULL
-        UNION ALL
-        SELECT job.id, job.priority
-        FROM available
-        CROSS JOIN LATERAL (
-            SELECT locked.id, locked.priority
-            FROM (
-                SELECT candidate.id
-                FROM pgqueuer candidate
-                WHERE candidate.entrypoint = available.entrypoint
-                  AND candidate.status = 'queued'
-                  AND candidate.execute_after < NOW()
-                ORDER BY candidate.priority DESC, candidate.id ASC
-                LIMIT LEAST($1, available.remaining)
-            ) capped
-            CROSS JOIN LATERAL (
-                SELECT target.id, target.priority
-                FROM pgqueuer target
-                WHERE target.id = capped.id
-                  AND target.status = 'queued'
-                  AND target.execute_after < NOW()
-                FOR UPDATE OF target SKIP LOCKED
-            ) locked
-            ORDER BY locked.priority DESC, locked.id ASC
             LIMIT LEAST($1, available.remaining)
-        ) job
-        WHERE available.remaining IS NOT NULL
+        ) capped
+        CROSS JOIN LATERAL (
+            SELECT target.id, target.priority
+            FROM pgqueuer target
+            WHERE target.id = capped.id
+              AND target.status = 'queued'
+              AND target.execute_after < NOW()
+            FOR UPDATE OF target SKIP LOCKED
+        ) locked
+        ORDER BY locked.priority DESC, locked.id ASC
+        LIMIT LEAST($1, available.remaining)
+    ) job
+    WHERE available.remaining IS NOT NULL
+),
+
+-- Both claim sets merged into one priority order.
+next_queued AS (
+    SELECT job.id, job.priority
+    FROM (
+        SELECT id, priority FROM unlimited_claims
+        UNION ALL
+        SELECT id, priority FROM limited_claims
     ) job
     ORDER BY job.priority DESC, job.id ASC
     LIMIT $1

--- a/test/query_shapes/dequeue_entrypoint_gate.sql
+++ b/test/query_shapes/dequeue_entrypoint_gate.sql
@@ -111,7 +111,7 @@ eligible AS (
     LIMIT $1
 ),
 
--- Atomically claim the jobs and log the pick event.
+-- Claim every eligible job in one atomic UPDATE.
 claimed AS (
     UPDATE pgqueuer
     SET status = 'picked',
@@ -122,6 +122,7 @@ claimed AS (
     RETURNING *
 ),
 
+-- Record the pick in the log table.
 log_pick AS (
     INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
     SELECT id, status, entrypoint, priority FROM claimed

--- a/test/query_shapes/dequeue_global_gate.sql
+++ b/test/query_shapes/dequeue_global_gate.sql
@@ -4,9 +4,11 @@ available AS (
     SELECT UNNEST($2::text[]) AS entrypoint
 ),
 
--- This worker's total picked jobs (scalar, for max_concurrent_tasks).
+-- This worker's picked jobs, and how many more this batch may claim.
 worker_load AS (
-    SELECT COUNT(*) AS total
+    SELECT
+        COUNT(*) AS total,
+        GREATEST(LEAST($1, $5 - COUNT(*)), 0) AS headroom
     FROM pgqueuer
     WHERE queue_manager_id = $3
       AND entrypoint = ANY($2)
@@ -53,10 +55,10 @@ eligible AS (
         SELECT id, priority FROM next_stale
     ) combined
     ORDER BY priority DESC, id ASC
-    LIMIT GREATEST(LEAST($1, $5 - (SELECT total FROM worker_load)), 0)
+    LIMIT (SELECT headroom FROM worker_load)
 ),
 
--- Atomically claim the jobs and log the pick event.
+-- Claim every eligible job in one atomic UPDATE.
 claimed AS (
     UPDATE pgqueuer
     SET status = 'picked',
@@ -67,6 +69,7 @@ claimed AS (
     RETURNING *
 ),
 
+-- Record the pick in the log table.
 log_pick AS (
     INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
     SELECT id, status, entrypoint, priority FROM claimed

--- a/test/query_shapes/dequeue_no_gates.sql
+++ b/test/query_shapes/dequeue_no_gates.sql
@@ -46,7 +46,7 @@ eligible AS (
     LIMIT $1
 ),
 
--- Atomically claim the jobs and log the pick event.
+-- Claim every eligible job in one atomic UPDATE.
 claimed AS (
     UPDATE pgqueuer
     SET status = 'picked',
@@ -57,6 +57,7 @@ claimed AS (
     RETURNING *
 ),
 
+-- Record the pick in the log table.
 log_pick AS (
     INSERT INTO pgqueuer_log (job_id, status, entrypoint, priority)
     SELECT id, status, entrypoint, priority FROM claimed


### PR DESCRIPTION
The capacity-gated `next_queued` body held a `UNION ALL` of two lateral scans inside a subquery, and you had to read to the bottom of each arm to find `available.remaining IS NULL` before you knew which was which.

Each arm is now its own CTE. `unlimited_claims` locks straight down the backlog; `limited_claims` fixes its window before locking. `next_queued` merges the two into one priority order, so its body is four lines rather than forty-six, and both arms get a name and a comment line that shows up in a Postgres log.

The plan is equivalent: three `LockRows` nodes and four index scans before and after, on the same indexes. One structural change, and it is the opposite of the risk: `next_queued` no longer carries a locking clause, so the planner inlines it into `eligible` and materializes the two claim CTEs instead. Each locking CTE is still materialized and fully evaluated, so the window is still fixed before the lock. Node count goes 46 to 47.

Second commit does the same to the budget cap. The `eligible` LIMIT carried `GREATEST(LEAST(batch, limit - (SELECT total FROM worker_load)), 0)` inline under a three-line comment saying what it was for; `worker_load` now returns that as `headroom`, so the LIMIT reads `LIMIT (SELECT headroom FROM worker_load)`. It is a trade, since the cap is no longer in front of the reader, but the nested `GREATEST/LEAST` was not self-explanatory either. Plans diffed identical for the `both_gates` shape.

Also fixes a label that lied: `claimed` said it logged the pick event, which `log_pick` does. `log_pick` had no label at all.

Two things I looked at and left alone. `eligible`'s `UNION ALL` has the same shape but both arms are already named CTEs, so splitting would only rename them. `limited_claims` is still three levels deep, because its window is correlated to `available.entrypoint` and `available.remaining` and a CTE cannot be lateral-correlated. The flat `ROW_NUMBER() OVER (PARTITION BY entrypoint ...)` form reads better but has to number the whole backlog before filtering, where the LATERAL stops at the index.

Ungated shapes move only by the `log_pick` comment. 155 passed, mypy 156, ruff, import-linter 4/4.