### PR TITLE
docs: scope out mixed concurrency limits per entrypoint

### DIFF
--- a/docs/guides/concurrency-control.md
+++ b/docs/guides/concurrency-control.md
@@ -18,6 +18,12 @@ async def process_data(job: Job) -> None:
 This is useful for protecting external services with connection pool limits or
 memory-intensive operations.
 
+Every worker that registers an entrypoint must declare the same
+`concurrency_limit` for it. The limit is passed to the dequeue query by the
+worker doing the dequeue, so a fleet where workers disagree has no single
+value to enforce and the highest one wins. Mixed limits for one entrypoint
+are not supported.
+
 ## Serialized processing
 
 Ensure jobs of the same type are processed strictly one at a time:

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -519,6 +519,9 @@ class QueryQueueBuilder:
         queue_table = self.qualified.queue_table
 
         if capacity_gated:
+            # The limit comes from the dequeuing worker's own registration, so the
+            # fleet has to agree on it. Workers declaring different limits for one
+            # entrypoint is unsupported; the highest one wins.
             composer.cte(
                 "params",
                 f"""


### PR DESCRIPTION
The dequeue query reads concurrency_limit from the arguments the dequeuing worker passes, which come from that worker's own entrypoint registration. A fleet whose workers declare different limits for one entrypoint therefore has no single value to enforce, and the worker with the highest limit generates the most capacity slots.

Document this as unsupported rather than trying to reconcile the values in SQL, and note the assumption where the params CTE reads it.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
