### PR TITLE
test: cover fleet contention on a limited entrypoint

### DIFF
--- a/test/test_slot_contention.py
+++ b/test/test_slot_contention.py
@@ -1,0 +1,94 @@
+"""Workers denied capacity on a limited entrypoint re-poll instead of sleeping (#761)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from datetime import timedelta
+
+import asyncpg
+import pytest
+
+from pgqueuer.db import AsyncpgDriver
+from pgqueuer.models import Job
+from pgqueuer.qm import QueueManager
+from pgqueuer.queries import Queries
+
+
+async def drain_with_fleet(
+    dsn: str,
+    n_workers: int,
+    n_jobs: int,
+    concurrency_limit: int,
+    handler_sleep: float,
+    dequeue_timeout: timedelta,
+) -> float:
+    """Run *n_workers* managers over a shared limited entrypoint, return wall seconds."""
+    async with contextlib.AsyncExitStack() as stack:
+
+        async def connect() -> asyncpg.Connection:
+            connection = await asyncpg.connect(dsn=dsn)
+            stack.push_async_callback(connection.close)
+            return connection
+
+        await Queries(AsyncpgDriver(await connect())).enqueue(
+            ["contended"] * n_jobs,
+            [None] * n_jobs,
+            [0] * n_jobs,
+        )
+
+        drained = asyncio.Event()
+        processed = 0
+        managers = list[QueueManager]()
+
+        for _ in range(n_workers):
+            manager = QueueManager(Queries(AsyncpgDriver(await connect())))
+
+            @manager.entrypoint("contended", concurrency_limit=concurrency_limit)
+            async def contended(_: Job) -> None:
+                nonlocal processed
+                await asyncio.sleep(handler_sleep)
+                processed += 1
+                if processed >= n_jobs:
+                    drained.set()
+
+            managers.append(manager)
+
+        async def stop_when_drained() -> None:
+            await drained.wait()
+            for manager in managers:
+                manager.shutdown.set()
+
+        workers = [m.run(batch_size=10, dequeue_timeout=dequeue_timeout) for m in managers]
+        started = time.monotonic()
+        await asyncio.gather(stop_when_drained(), *workers)
+        elapsed = time.monotonic() - started
+
+        assert processed == n_jobs
+        return elapsed
+
+
+@pytest.mark.parametrize("n_workers", (1, 4, 16))
+async def test_slot_contention_does_not_park_workers(
+    dsn: str,
+    n_workers: int,
+    n_jobs: int = 30,
+    concurrency_limit: int = 1,
+    handler_sleep: float = 0.05,
+    dequeue_timeout: timedelta = timedelta(seconds=10),
+) -> None:
+    """A fleet contending for one capacity slot drains without waiting out a timeout."""
+    elapsed = await drain_with_fleet(
+        dsn,
+        n_workers,
+        n_jobs,
+        concurrency_limit,
+        handler_sleep,
+        dequeue_timeout,
+    )
+
+    assert elapsed < dequeue_timeout.total_seconds(), (
+        f"{n_workers} workers took {elapsed:.2f}s to drain {n_jobs} jobs, "
+        f"which means at least one worker waited out the {dequeue_timeout} dequeue timeout"
+    )


### PR DESCRIPTION
Sixteen workers contending for a single capacity slot leave all but one with an empty batch on every pass, which ends the drain loop and sends them to wait. Nothing covered how long that wait lasts.

The wake-up comes from _effective_dequeue_timeout, which returns min_dequeue_poll_interval while eligible queued work remains rather than the full dequeue_timeout. A regression there would slow the fleet to one job per timeout instead of one per handler.

Verified the bound is not vacuous by stubbing the notification wait to never fire: the drain still completes in 3.6s, confirming the fast re-poll rather than NOTIFY is what carries this case.

## Summary
- Provide a short description of the changes.
- Reference related issues when applicable.

## Testing
- [ ] `uv sync --all-extras --frozen && uv run ruff check . && uv run ruff format . --check && uv run lint-imports && uv run mypy . && uv run pytest` passed
- [ ] Additional testing steps

## Checklist
- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have added or updated tests
- [ ] I have updated documentation if necessary
