### PR TITLE
fix: swallow only slot-index unique violations on dequeue

### DIFF
--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -27,13 +27,16 @@ def is_unique_violation(exc: Exception) -> bool:
     return sqlstate.is_unique_violation(exc)
 
 
-def lost_capacity_slot_race(exc: Exception) -> bool:
+def lost_capacity_slot_race(exc: Exception, slot_index: str) -> bool:
     """Return True if a concurrent dequeue took the capacity slot this claim wanted.
 
-    The loser sees the unique violation directly, or a deadlock when several
-    limited entrypoints in one batch make two dequeues cross each other.
+    The loser sees a unique violation on *slot_index*, or a deadlock when
+    several limited entrypoints in one batch make two dequeues cross each
+    other. Other unique violations are not a lost slot and must propagate.
     """
-    return sqlstate.is_unique_violation(exc) or sqlstate.is_deadlock_detected(exc)
+    if sqlstate.is_deadlock_detected(exc):
+        return True
+    return sqlstate.is_unique_violation(exc) and sqlstate.constraint_of(exc) == slot_index
 
 
 @dataclasses.dataclass
@@ -186,11 +189,13 @@ class Queries:
         )
         # Losing the slot race means the capacity went to another worker, which
         # is the same outcome as finding nothing claimable: report an empty
-        # batch and let the poll loop try again.
+        # batch and let the poll loop try again. Match the slot index by name
+        # so a 23505 on any other unique constraint still surfaces.
+        slot_index = f"{self.qbe.settings.queue_table}_picked_slot_idx"
         try:
             rows = await self.driver.fetch(query.sql, *query.args)
         except Exception as exc:
-            if lost_capacity_slot_race(exc):
+            if lost_capacity_slot_race(exc, slot_index):
                 return []
             raise
         return [models.Job.model_validate(row) for row in rows]

--- a/pgqueuer/adapters/persistence/sqlstate.py
+++ b/pgqueuer/adapters/persistence/sqlstate.py
@@ -7,7 +7,7 @@ follows the same convention.
 
 from __future__ import annotations
 
-from pgqueuer.ports.driver import SqlStateError
+from pgqueuer.ports.driver import ConstraintNamed, DiagnosticError, SqlStateError
 
 UNIQUE_VIOLATION = "23505"
 DEADLOCK_DETECTED = "40P01"
@@ -17,6 +17,21 @@ def code_of(exc: BaseException) -> str | None:
     """Return the SQLSTATE *exc* carries, or None if it carries none."""
     if isinstance(exc, SqlStateError) and isinstance(exc.sqlstate, str):
         return exc.sqlstate
+    return None
+
+
+def constraint_of(exc: BaseException) -> str | None:
+    """Return the constraint *exc* names, or None if it names none.
+
+    asyncpg puts ``constraint_name`` on the exception; psycopg puts it on
+    ``exc.diag``.
+    """
+    if isinstance(exc, ConstraintNamed) and isinstance(exc.constraint_name, str):
+        return exc.constraint_name
+    if isinstance(exc, DiagnosticError) and isinstance(exc.diag, ConstraintNamed):
+        name = exc.diag.constraint_name
+        if isinstance(name, str):
+            return name
     return None
 
 

--- a/pgqueuer/ports/driver.py
+++ b/pgqueuer/ports/driver.py
@@ -20,6 +20,22 @@ class SqlStateError(Protocol):
     def sqlstate(self) -> str | None: ...
 
 
+@runtime_checkable
+class ConstraintNamed(Protocol):
+    """Exception or diagnostic that names the violated constraint."""
+
+    @property
+    def constraint_name(self) -> str | None: ...
+
+
+@runtime_checkable
+class DiagnosticError(Protocol):
+    """psycopg-style error whose ``diag`` carries constraint details."""
+
+    @property
+    def diag(self) -> object: ...
+
+
 class TaskManagerPort(Protocol):
     """Protocol for managing background asyncio tasks."""
 

--- a/test/test_sqlstate.py
+++ b/test/test_sqlstate.py
@@ -1,11 +1,41 @@
 from __future__ import annotations
 
+import uuid
+from datetime import timedelta
+
 import asyncpg
 import psycopg
 import pytest
 
 from pgqueuer.adapters.persistence import sqlstate
-from pgqueuer.adapters.persistence.queries import lost_capacity_slot_race
+from pgqueuer.adapters.persistence.queries import Queries, lost_capacity_slot_race
+from pgqueuer.domain.settings import DBSettings
+from pgqueuer.models import Job
+from pgqueuer.queries import EntrypointExecutionParameter
+
+SLOT_INDEX = f"{DBSettings().queue_table}_picked_slot_idx"
+OTHER_INDEX = f"{DBSettings().queue_table}_unique_dedupe_key"
+
+
+class AsyncpgNamedUnique(asyncpg.UniqueViolationError):
+    def __init__(self, constraint_name: str | None) -> None:
+        super().__init__()
+        self.constraint_name = constraint_name
+
+
+class _Diag:
+    def __init__(self, constraint_name: str | None) -> None:
+        self.constraint_name = constraint_name
+
+
+class PsycopgNamedUnique(Exception):
+    """psycopg exposes the constraint on ``diag``, which is not settable on the real error."""
+
+    sqlstate = sqlstate.UNIQUE_VIOLATION
+
+    def __init__(self, constraint_name: str | None) -> None:
+        super().__init__()
+        self.diag = _Diag(constraint_name)
 
 
 @pytest.mark.parametrize(
@@ -38,19 +68,74 @@ def test_code_of_ignores_a_sqlstate_that_is_not_a_string() -> None:
 
 
 @pytest.mark.parametrize(
+    "exc, expected",
+    (
+        (AsyncpgNamedUnique(SLOT_INDEX), SLOT_INDEX),
+        (PsycopgNamedUnique(SLOT_INDEX), SLOT_INDEX),
+        (AsyncpgNamedUnique(None), None),
+        (PsycopgNamedUnique(None), None),
+        (asyncpg.UniqueViolationError(), None),
+        (ValueError("not from the database"), None),
+    ),
+)
+def test_constraint_of_reads_the_name_both_drivers_carry(
+    exc: Exception,
+    expected: str | None,
+) -> None:
+    assert sqlstate.constraint_of(exc) == expected
+
+
+@pytest.mark.parametrize(
     "exc, lost",
     (
-        (asyncpg.UniqueViolationError(), True),
+        (AsyncpgNamedUnique(SLOT_INDEX), True),
+        (PsycopgNamedUnique(SLOT_INDEX), True),
         (asyncpg.DeadlockDetectedError(), True),
-        (psycopg.errors.UniqueViolation(), True),
         (psycopg.errors.DeadlockDetected(), True),
+        (AsyncpgNamedUnique(OTHER_INDEX), False),
+        (PsycopgNamedUnique(OTHER_INDEX), False),
+        (asyncpg.UniqueViolationError(), False),
+        (psycopg.errors.UniqueViolation(), False),
         (asyncpg.SerializationError(), False),
         (psycopg.errors.NotNullViolation(), False),
         (ValueError("not from the database"), False),
     ),
 )
-def test_lost_capacity_slot_race_matches_only_the_slot_race(
+def test_lost_capacity_slot_race_matches_only_the_slot_index(
     exc: Exception,
     lost: bool,
 ) -> None:
-    assert lost_capacity_slot_race(exc) is lost
+    assert lost_capacity_slot_race(exc, SLOT_INDEX) is lost
+
+
+class _FetchBoom:
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+
+    async def fetch(self, query: str, *args: object) -> list[dict]:
+        raise self.exc
+
+
+async def _dequeue(driver: object) -> list[Job]:
+    return await Queries(driver).dequeue(  # type: ignore[arg-type]
+        batch_size=1,
+        entrypoints={"fetch": EntrypointExecutionParameter(1)},
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=None,
+        heartbeat_timeout=timedelta(seconds=30),
+    )
+
+
+async def test_dequeue_returns_empty_on_slot_unique_violation() -> None:
+    assert await _dequeue(_FetchBoom(AsyncpgNamedUnique(SLOT_INDEX))) == []
+    assert await _dequeue(_FetchBoom(PsycopgNamedUnique(SLOT_INDEX))) == []
+    assert await _dequeue(_FetchBoom(asyncpg.DeadlockDetectedError())) == []
+
+
+async def test_dequeue_reraises_unrelated_unique_violation() -> None:
+    with pytest.raises(asyncpg.UniqueViolationError):
+        await _dequeue(_FetchBoom(AsyncpgNamedUnique(OTHER_INDEX)))
+    with pytest.raises(PsycopgNamedUnique):
+        await _dequeue(_FetchBoom(PsycopgNamedUnique(OTHER_INDEX)))
+    with pytest.raises(asyncpg.UniqueViolationError):
+        await _dequeue(_FetchBoom(asyncpg.UniqueViolationError()))

--- a/test/test_sqlstate.py
+++ b/test/test_sqlstate.py
@@ -10,6 +10,7 @@ import pytest
 from pgqueuer.adapters.persistence import sqlstate
 from pgqueuer.adapters.persistence.queries import Queries, lost_capacity_slot_race
 from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import Job
 from pgqueuer.queries import EntrypointExecutionParameter
 
@@ -119,8 +120,8 @@ class _FetchBoom:
 async def _dequeue(driver: object) -> list[Job]:
     return await Queries(driver).dequeue(  # type: ignore[arg-type]
         batch_size=1,
-        entrypoints={"fetch": EntrypointExecutionParameter(1)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={QueueEntrypoint("fetch"): EntrypointExecutionParameter(1)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )


### PR DESCRIPTION
## Summary
- Treat a dequeue `23505` as a lost capacity slot only when it names `{queue_table}_picked_slot_idx`.
- Deadlocks still map to an empty batch; every other unique violation still raises.

Split from #780.

## Test plan
- [x] `test/test_sqlstate.py`: slot index / deadlock → `[]`, other `23505` re-raised
- [ ] `uv run pytest test/test_sqlstate.py`