### PR TITLE
feat(domain): add identity NewTypes and Job.slot

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,8 +50,24 @@ wins; nothing validates or rejects the mismatch.
   failure now restart in place. Review any external restart or alerting that
   relied on the process dying.
 
+### Added
+
+- `Job.slot` exposes the capacity seat a picked job holds under a
+  `concurrency_limit`; `None` for unlimited entrypoints and unpicked rows.
+- New identity types in `pgqueuer.domain.types` (re-exported from
+  `pgqueuer.types` and `pgqueuer.models`): `QueueEntrypoint`, `QueueManagerId`,
+  `Slot`. Job, log and statistics models now carry them; at runtime they are
+  plain `str`, `uuid.UUID` and `int`.
+
 ### Changed
 
+- Type annotations only, no runtime change: `dequeue()`, `queued_work()`,
+  `eligible_queued_work()` and `next_deferred_eta()` take `QueueEntrypoint` and
+  `QueueManagerId` instead of `str` and `uuid.UUID`, and
+  `QueueManager.entrypoint_registry` is keyed by `QueueEntrypoint`. Code that
+  calls these directly with literals needs `QueueEntrypoint("name")` to pass
+  mypy. `enqueue()`, `clear_queue()` and the `@entrypoint` decorator still take
+  `str`.
 - `QueryQueueBuilder.build_dequeue_query()` and `build_log_statistics_query()`
   take keyword-only arguments and return a `ComposedQuery` (`.sql`, `.args`)
   instead of a SQL string. Both are internal but reachable via `Queries.qbq`.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -190,8 +190,8 @@ Arrows denote dependency, not communication flow.
 
 | Component        | Type         | Description                                    |
 |------------------|--------------|------------------------------------------------|
-| JobId, ScheduleId| Value Object | `NewType` identities (`domain/types.py`)       |
-| Entrypoint       | Value Object | Name binding a job to its registered handler; schedules use the `CronEntrypoint` variant |
+| JobId, ScheduleId, QueueManagerId, Slot | Value Object | `NewType` identities (`domain/types.py`) |
+| Entrypoint       | Value Object | Name binding a job to its registered handler (`QueueEntrypoint`); schedules use the `CronEntrypoint` variant |
 | Payload          | Value Object | Opaque `bytes`; the library ships no serializer (ADR-0009) |
 | Headers          | Value Object | Side-channel dict for tracing propagation      |
 | Job status       | Value Object | `queued / picked / successful / exception / canceled / deleted / failed` |

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -16,6 +16,7 @@ A **job** is a unit of work stored as a row in the `pgqueuer` table. Each job ha
 | `execute_after` | `timestamp` | Earliest time the job can be picked up |
 | `attempts` | `int` | Number of previous retry attempts (starts at 0) |
 | `heartbeat` | `timestamp` | Last time the worker confirmed it is alive |
+| `slot` | `int \| None` | Capacity seat held while picked under a `concurrency_limit`; `None` otherwise |
 | `dedupe_key` | `str \| None` | Optional unique key to prevent duplicate enqueuing |
 
 Jobs are created by calling `Queries.enqueue()` and processed by functions registered

--- a/docs/reference/ports-and-adapters.md
+++ b/docs/reference/ports-and-adapters.md
@@ -144,7 +144,7 @@ pgqueuer/
 
   domain/
     models.py                 # Job, Schedule, Event, Context, statistics
-    types.py                  # JobId, JOB_STATUS, Channel, etc.
+    types.py                  # JobId, QueueEntrypoint, QueueManagerId, Slot, JOB_STATUS, etc.
     errors.py                 # Exception hierarchy
     settings.py               # DBSettings, Durability, DurabilityPolicy
 

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -20,7 +20,15 @@ from pgqueuer.adapters.persistence import qb, query_helpers
 from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
 from pgqueuer.domain import errors, models
 from pgqueuer.domain.models import utc_now
-from pgqueuer.domain.types import CronEntrypoint, JobId, OnConflict, ScheduleId, SortOrder
+from pgqueuer.domain.types import (
+    CronEntrypoint,
+    JobId,
+    OnConflict,
+    QueueEntrypoint,
+    QueueManagerId,
+    ScheduleId,
+    SortOrder,
+)
 from pgqueuer.ports import tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.ports.tracing import TracingProtocol
@@ -229,6 +237,7 @@ class InMemoryQueries:
                 "payload": normed.payload[i],
                 "attempts": 0,
                 "queue_manager_id": None,
+                "slot": None,
                 "headers": hdr,
             }
 
@@ -310,10 +319,10 @@ class InMemoryQueries:
 
     def _count_picked_jobs(
         self,
-        queue_manager_id: uuid.UUID,
-        entrypoints: dict[str, EntrypointExecutionParameter],
-    ) -> tuple[dict[str, int], int]:
-        picked_per_ep: dict[str, int] = {}
+        queue_manager_id: QueueManagerId,
+        entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
+    ) -> tuple[dict[QueueEntrypoint, int], int]:
+        picked_per_ep: dict[QueueEntrypoint, int] = {}
         total_picked = 0
         for job_id in self._picked_ids:
             j = self._jobs[job_id]
@@ -327,7 +336,7 @@ class InMemoryQueries:
     def _collect_stale_candidates(
         self,
         now: datetime,
-        entrypoints: dict[str, EntrypointExecutionParameter],
+        entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
         heartbeat_timeout: timedelta,
     ) -> list[dict[str, Any]]:
         candidates = [
@@ -361,8 +370,8 @@ class InMemoryQueries:
     async def dequeue(
         self,
         batch_size: int,
-        entrypoints: dict[str, EntrypointExecutionParameter],
-        queue_manager_id: uuid.UUID,
+        entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> list[models.Job]:
@@ -608,13 +617,13 @@ class InMemoryQueries:
             for (ep, pri, st), count in sorted(counts.items())
         ]
 
-    async def queued_work(self, entrypoints: list[str]) -> int:
+    async def queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
         ep_set = set(entrypoints)
         return sum(
             1 for j in self._jobs.values() if j["status"] == "queued" and j["entrypoint"] in ep_set
         )
 
-    async def eligible_queued_work(self, entrypoints: list[str]) -> int:
+    async def eligible_queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
         """Like ``queued_work`` but counting only jobs whose ``execute_after`` has passed."""
         now = utc_now()
         ep_set = set(entrypoints)
@@ -827,7 +836,7 @@ class InMemoryQueries:
         else:
             self._log.clear()
 
-    async def next_deferred_eta(self, entrypoints: list[str]) -> timedelta | None:
+    async def next_deferred_eta(self, entrypoints: list[QueueEntrypoint]) -> timedelta | None:
         """Return time until the soonest deferred job becomes eligible, or None."""
         now = utc_now()
         ep_set = set(entrypoints)

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import uuid
 from datetime import timedelta
 from typing import Generator
 
@@ -14,7 +13,7 @@ from pgqueuer.domain.settings import (
     DurabilityPolicy,
     QualifiedNames,
 )
-from pgqueuer.domain.types import OnConflict, SortOrder
+from pgqueuer.domain.types import OnConflict, QueueEntrypoint, QueueManagerId, SortOrder
 
 # Re-export for backward compatibility within the adapter layer
 __all__ = [
@@ -482,9 +481,9 @@ class QueryQueueBuilder:
         self,
         *,
         batch_size: int,
-        entrypoints: list[str],
+        entrypoints: list[QueueEntrypoint],
         concurrency_limits: list[int],
-        queue_manager_id: uuid.UUID,
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> ComposedQuery:

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -16,7 +16,7 @@ from typing_extensions import assert_never
 from pgqueuer.adapters.persistence import qb, query_helpers, sqlstate
 from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
 from pgqueuer.domain import errors, models, types
-from pgqueuer.domain.types import CronEntrypoint
+from pgqueuer.domain.types import CronEntrypoint, QueueEntrypoint, QueueManagerId
 from pgqueuer.ports import tracing
 from pgqueuer.ports.driver import Driver, SyncDriver
 from pgqueuer.ports.repository import EntrypointExecutionParameter
@@ -161,8 +161,8 @@ class Queries:
     async def dequeue(
         self,
         batch_size: int,
-        entrypoints: dict[str, EntrypointExecutionParameter],
-        queue_manager_id: uuid.UUID,
+        entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> list[models.Job]:
@@ -297,11 +297,11 @@ class Queries:
             return [models.JobId(row["id"]) for row in rows]
         assert_never(on_conflict)
 
-    async def queued_work(self, entrypoints: list[str]) -> int:
+    async def queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
         rows = await self.driver.fetch(self.qbq.build_has_queued_work(), entrypoints)
         return rows[0]["queued_work"] if rows else 0
 
-    async def eligible_queued_work(self, entrypoints: list[str]) -> int:
+    async def eligible_queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
         """Like ``queued_work`` but counting only jobs whose ``execute_after`` has passed."""
         rows = await self.driver.fetch(self.qbq.build_has_eligible_queued_work(), entrypoints)
         return rows[0]["queued_work"] if rows else 0
@@ -550,7 +550,7 @@ class Queries:
             for row in await self.driver.fetch(self.qbq.build_job_status_query(), ids)
         ]
 
-    async def next_deferred_eta(self, entrypoints: list[str]) -> timedelta | None:
+    async def next_deferred_eta(self, entrypoints: list[QueueEntrypoint]) -> timedelta | None:
         """Return time until the soonest deferred job becomes eligible, or None."""
         rows = await self.driver.fetch(self.qbq.build_next_deferred_eta_query(), entrypoints)
         return rows[0]["eta"] if rows and rows[0]["eta"] is not None else None

--- a/pgqueuer/core/executors.py
+++ b/pgqueuer/core/executors.py
@@ -124,8 +124,8 @@ class DatabaseRetryEntrypointExecutor(EntrypointExecutor):
 
 @dataclasses.dataclass
 class ScheduleExecutorFactoryParameters:
-    entrypoint: str
-    expression: str
+    entrypoint: types.CronEntrypoint
+    expression: types.CronExpression
     func: ScheduleCrontab
     clean_old: bool
     accepts_context: bool = False

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -47,13 +47,15 @@ class QueueManager:
     )
 
     # Per entrypoint
-    entrypoint_registry: dict[str, executors.AbstractEntrypointExecutor] = dataclasses.field(
-        init=False,
-        default_factory=dict,
+    entrypoint_registry: dict[types.QueueEntrypoint, executors.AbstractEntrypointExecutor] = (
+        dataclasses.field(
+            init=False,
+            default_factory=dict,
+        )
     )
-    queue_manager_id: uuid.UUID = dataclasses.field(
+    queue_manager_id: types.QueueManagerId = dataclasses.field(
         init=False,
-        default_factory=uuid.uuid4,
+        default_factory=lambda: types.QueueManagerId(uuid.uuid4()),
     )
     # Shared resources mapping propagated into each job Context.
     resources: MutableMapping = dataclasses.field(
@@ -150,10 +152,11 @@ class QueueManager:
         executor: executors.AbstractEntrypointExecutor,
     ) -> None:
         """Bind *name* to *executor*. Raises RuntimeError on duplicate name."""
-        if name in self.entrypoint_registry:
+        entrypoint = types.QueueEntrypoint(name)
+        if entrypoint in self.entrypoint_registry:
             raise RuntimeError(f"{name} already in registry, name must be unique.")
 
-        self.entrypoint_registry[name] = executor
+        self.entrypoint_registry[entrypoint] = executor
 
     def entrypoint(
         self,
@@ -180,7 +183,7 @@ class QueueManager:
         ``'hold'`` parks it with status ``'failed'`` for manual re-queue.
         """
 
-        if name in self.entrypoint_registry:
+        if types.QueueEntrypoint(name) in self.entrypoint_registry:
             raise RuntimeError(f"{name} already in registry, name must be unique.")
 
         if not isinstance(concurrency_limit, int):
@@ -218,7 +221,7 @@ class QueueManager:
 
         return register
 
-    def entrypoints_below_capacity_limits(self) -> set[str]:
+    def entrypoints_below_capacity_limits(self) -> set[types.QueueEntrypoint]:
         """All registered entrypoints; per-entrypoint limits are enforced in SQL."""
         return set(self.entrypoint_registry)
 

--- a/pgqueuer/domain/models.py
+++ b/pgqueuer/domain/models.py
@@ -19,7 +19,10 @@ from pgqueuer.domain.types import (
     CronEntrypoint,
     CronExpression,
     JobId,
+    QueueEntrypoint,
+    QueueManagerId,
     ScheduleId,
+    Slot,
 )
 
 
@@ -80,7 +83,11 @@ class AnyEvent(
 
 
 class Job(BaseModel):
-    """A queued or in-flight job row."""
+    """A queued or in-flight job row.
+
+    ``slot`` is the capacity seat held while picked under a ``concurrency_limit``;
+    None for unlimited entrypoints and for rows not currently picked.
+    """
 
     id: JobId
     priority: int
@@ -89,10 +96,11 @@ class Job(BaseModel):
     heartbeat: AwareDatetime
     execute_after: AwareDatetime
     status: JOB_STATUS
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     payload: bytes | None
     attempts: int = 0
-    queue_manager_id: uuid.UUID | None
+    queue_manager_id: QueueManagerId | None
+    slot: Slot | None = None
     headers: Annotated[
         dict[str, Any] | None,
         BeforeValidator(lambda x: None if x is None else from_json(x)),
@@ -118,7 +126,7 @@ class Log(BaseModel):
     job_id: JobId
     status: JOB_STATUS
     priority: int
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     traceback: Annotated[
         TracebackRecord | None,
         BeforeValidator(lambda x: None if x is None else from_json(x)),
@@ -130,7 +138,7 @@ class QueueStatistics(BaseModel):
     """Per-(entrypoint, priority, status) job count snapshot."""
 
     count: int
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     priority: int
     status: JOB_STATUS
 
@@ -140,7 +148,7 @@ class LogStatistics(BaseModel):
 
     count: int
     created: AwareDatetime
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     priority: int
     status: JOB_STATUS
 
@@ -195,7 +203,7 @@ class Schedule(BaseModel):
 class QueueAgeStats(BaseModel):
     """Per-entrypoint backlog age for queued jobs."""
 
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     queued_count: int
     oldest_created: AwareDatetime
     oldest_age_seconds: float
@@ -205,7 +213,7 @@ class QueueAgeStats(BaseModel):
 class JobDurationStats(BaseModel):
     """Per-entrypoint execution-duration percentiles derived from log transitions."""
 
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     completed: int
     p50_seconds: float
     p95_seconds: float
@@ -216,7 +224,7 @@ class JobDurationStats(BaseModel):
 class ThroughputStats(BaseModel):
     """Total processed jobs per (entrypoint, status) over a time window."""
 
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     status: JOB_STATUS
     total_count: int
 
@@ -225,7 +233,7 @@ class ThroughputBucket(BaseModel):
     """Per-minute processed-job count for one (entrypoint, status)."""
 
     bucket: AwareDatetime
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     status: JOB_STATUS
     count: int
 
@@ -233,11 +241,11 @@ class ThroughputBucket(BaseModel):
 class ActiveWorker(BaseModel):
     """A queue manager currently holding picked jobs."""
 
-    queue_manager_id: uuid.UUID
+    queue_manager_id: QueueManagerId
     active_jobs: int
     oldest_heartbeat: AwareDatetime
     newest_heartbeat: AwareDatetime
-    entrypoints: list[str]
+    entrypoints: list[QueueEntrypoint]
 
 
 class StaleJob(BaseModel):
@@ -245,13 +253,13 @@ class StaleJob(BaseModel):
 
     id: JobId
     priority: int
-    queue_manager_id: uuid.UUID | None
+    queue_manager_id: QueueManagerId | None
     created: AwareDatetime
     updated: AwareDatetime
     heartbeat: AwareDatetime
     execute_after: AwareDatetime
     status: JOB_STATUS
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     seconds_since_heartbeat: float
 
 
@@ -267,7 +275,7 @@ class TableInfo(BaseModel):
 class EntrypointStat(BaseModel):
     """Combined per-entrypoint health row: depth, latency, durations, failure rate."""
 
-    entrypoint: str
+    entrypoint: QueueEntrypoint
     queued: int
     picked: int
     oldest_age_seconds: float | None

--- a/pgqueuer/domain/types.py
+++ b/pgqueuer/domain/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from enum import Enum
 from typing import Literal, NewType
 
@@ -19,6 +20,9 @@ EVENT_TYPES = Literal[
 
 
 JobId = NewType("JobId", int)
+QueueEntrypoint = NewType("QueueEntrypoint", str)
+QueueManagerId = NewType("QueueManagerId", uuid.UUID)
+Slot = NewType("Slot", int)
 JOB_STATUS = Literal[
     "queued",
     "picked",

--- a/pgqueuer/models.py
+++ b/pgqueuer/models.py
@@ -26,7 +26,10 @@ from pgqueuer.domain.types import (
     CronEntrypoint,
     CronExpression,
     JobId,
+    QueueEntrypoint,
+    QueueManagerId,
     ScheduleId,
+    Slot,
 )
 
 __all__ = [
@@ -46,10 +49,13 @@ __all__ = [
     "Log",
     "LogStatistics",
     "OPERATIONS",
+    "QueueEntrypoint",
+    "QueueManagerId",
     "QueueStatistics",
     "Schedule",
     "ScheduleContext",
     "ScheduleId",
+    "Slot",
     "TableChangedEvent",
     "TracebackRecord",
 ]

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -9,7 +9,13 @@ from typing import Literal, Protocol, overload
 
 from pgqueuer.domain import models
 from pgqueuer.domain.settings import DBSettings
-from pgqueuer.domain.types import CronEntrypoint, OnConflict, SortOrder
+from pgqueuer.domain.types import (
+    CronEntrypoint,
+    OnConflict,
+    QueueEntrypoint,
+    QueueManagerId,
+    SortOrder,
+)
 from pgqueuer.ports.driver import Driver
 
 
@@ -32,8 +38,8 @@ class QueueRepositoryPort(Protocol):
     async def dequeue(
         self,
         batch_size: int,
-        entrypoints: dict[str, EntrypointExecutionParameter],
-        queue_manager_id: uuid.UUID,
+        entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> list[models.Job]: ...
@@ -134,9 +140,9 @@ class QueueRepositoryPort(Protocol):
 
     async def update_heartbeat(self, job_ids: list[models.JobId]) -> None: ...
 
-    async def queued_work(self, entrypoints: list[str]) -> int: ...
+    async def queued_work(self, entrypoints: list[QueueEntrypoint]) -> int: ...
 
-    async def eligible_queued_work(self, entrypoints: list[str]) -> int:
+    async def eligible_queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
         """Like ``queued_work`` but counting only jobs whose ``execute_after`` has passed."""
         ...
 
@@ -162,7 +168,7 @@ class QueueRepositoryPort(Protocol):
 
     async def clear_statistics_log(self, entrypoint: str | list[str] | None = None) -> None: ...
 
-    async def next_deferred_eta(self, entrypoints: list[str]) -> timedelta | None:
+    async def next_deferred_eta(self, entrypoints: list[QueueEntrypoint]) -> timedelta | None:
         """Return time until the soonest deferred job becomes eligible, or None."""
         ...
 

--- a/pgqueuer/types.py
+++ b/pgqueuer/types.py
@@ -12,8 +12,11 @@ from pgqueuer.domain.types import (
     JobId,
     OnConflict,
     OnFailure,
+    QueueEntrypoint,
     QueueExecutionMode,
+    QueueManagerId,
     ScheduleId,
+    Slot,
 )
 
 __all__ = [
@@ -26,6 +29,9 @@ __all__ = [
     "JobId",
     "OnConflict",
     "OnFailure",
+    "QueueEntrypoint",
     "QueueExecutionMode",
+    "QueueManagerId",
     "ScheduleId",
+    "Slot",
 ]

--- a/test/integration/test_persistence_queries_sql.py
+++ b/test/integration/test_persistence_queries_sql.py
@@ -18,7 +18,7 @@ import pytest
 from pgqueuer.adapters.persistence.queries import Queries
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.models import CronExpressionEntrypoint, TracebackRecord
-from pgqueuer.domain.types import CronEntrypoint, CronExpression
+from pgqueuer.domain.types import CronEntrypoint, CronExpression, QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
@@ -29,13 +29,13 @@ async def test_dequeue_locking_race_single_job_one_picker(
     q = Queries(apgdriver)
 
     await q.enqueue(["ep"], [None], [0])
-    qm1_id = uuid.uuid4()
-    qm2_id = uuid.uuid4()
+    qm1_id = QueueManagerId(uuid.uuid4())
+    qm2_id = QueueManagerId(uuid.uuid4())
 
     async def dequeue_1() -> list:
         return await q.dequeue(
             batch_size=1,
-            entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+            entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
             queue_manager_id=qm1_id,
             global_concurrency_limit=None,
             heartbeat_timeout=timedelta(seconds=30),
@@ -45,7 +45,7 @@ async def test_dequeue_locking_race_single_job_one_picker(
         await asyncio.sleep(0.001)
         return await q.dequeue(
             batch_size=1,
-            entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+            entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
             queue_manager_id=qm2_id,
             global_concurrency_limit=None,
             heartbeat_timeout=timedelta(seconds=30),
@@ -66,11 +66,11 @@ async def test_atomicity_dequeue_log_entry_created(
     q = Queries(apgdriver)
 
     jids = await q.enqueue(["ep"], [None], [0])
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     jobs = await q.dequeue(
         batch_size=1,
-        entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+        entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
         queue_manager_id=qm_id,
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -96,10 +96,10 @@ async def test_dedupe_constraint_partial_index(
     with pytest.raises(Exception):
         await q.enqueue(["ep"], [None], [0], dedupe_key=["k"], on_conflict="raise")
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await q.dequeue(
         batch_size=1,
-        entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+        entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
         queue_manager_id=qm_id,
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -147,10 +147,10 @@ async def test_stale_job_recovery_heartbeat_timeout(
 
     await q.enqueue(["ep"], [None], [0])
 
-    qm1_id = uuid.uuid4()
+    qm1_id = QueueManagerId(uuid.uuid4())
     jobs = await q.dequeue(
         batch_size=1,
-        entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+        entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
         queue_manager_id=qm1_id,
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=1),
@@ -161,10 +161,10 @@ async def test_stale_job_recovery_heartbeat_timeout(
 
     await asyncio.sleep(1.2)
 
-    qm2_id = uuid.uuid4()
+    qm2_id = QueueManagerId(uuid.uuid4())
     jobs2 = await q.dequeue(
         batch_size=1,
-        entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+        entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
         queue_manager_id=qm2_id,
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=1),
@@ -233,11 +233,11 @@ async def test_mark_job_cancellation(
     q = Queries(apgdriver)
 
     jids = await q.enqueue(["ep"], [None], [0])
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     jobs = await q.dequeue(
         batch_size=1,
-        entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+        entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
         queue_manager_id=qm_id,
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -260,11 +260,11 @@ async def test_traceback_jsonb_roundtrip(
     q = Queries(apgdriver)
 
     jids = await q.enqueue(["ep"], [None], [0])
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     jobs = await q.dequeue(
         batch_size=1,
-        entrypoints={"ep": EntrypointExecutionParameter(concurrency_limit=1)},
+        entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
         queue_manager_id=qm_id,
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),

--- a/test/test_concurrency_limit.py
+++ b/test/test_concurrency_limit.py
@@ -13,9 +13,12 @@ import pytest
 import pytest_asyncio
 
 from pgqueuer.db import AsyncpgDriver, Driver
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import Job
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import EntrypointExecutionParameter, Queries
+
+FETCH = QueueEntrypoint("fetch")
 
 
 @dataclass
@@ -228,8 +231,8 @@ async def test_concurrency_limit_holds_across_concurrent_dequeues(
         return asyncio.ensure_future(
             q.dequeue(
                 batch_size=concurrency_limit,
-                entrypoints={"fetch": EntrypointExecutionParameter(concurrency_limit)},
-                queue_manager_id=uuid.uuid4(),
+                entrypoints={FETCH: EntrypointExecutionParameter(concurrency_limit)},
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -278,8 +281,8 @@ async def test_concurrency_limit_holds_when_priority_arrives_mid_claim(
         return asyncio.ensure_future(
             q.dequeue(
                 batch_size=limit,
-                entrypoints={"fetch": EntrypointExecutionParameter(limit)},
-                queue_manager_id=uuid.uuid4(),
+                entrypoints={FETCH: EntrypointExecutionParameter(limit)},
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -325,8 +328,8 @@ async def test_concurrency_limit_rollback_releases_capacity_for_the_other_worker
         return asyncio.ensure_future(
             q.dequeue(
                 batch_size=concurrency_limit,
-                entrypoints={"fetch": EntrypointExecutionParameter(concurrency_limit)},
-                queue_manager_id=uuid.uuid4(),
+                entrypoints={FETCH: EntrypointExecutionParameter(concurrency_limit)},
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -368,20 +371,20 @@ async def test_slot_race_does_not_lose_unlimited_jobs_in_the_same_batch(
     await queries_monitor.enqueue(["tight"] * limit, [b"tight"] * limit, [0] * limit)
     await queries_monitor.enqueue(["loose"] * n_loose, [b"loose"] * n_loose, [0] * n_loose)
 
-    tight = {"tight": EntrypointExecutionParameter(limit)}
+    tight = {QueueEntrypoint("tight"): EntrypointExecutionParameter(limit)}
     both = {
-        "tight": EntrypointExecutionParameter(limit),
-        "loose": EntrypointExecutionParameter(0),
+        QueueEntrypoint("tight"): EntrypointExecutionParameter(limit),
+        QueueEntrypoint("loose"): EntrypointExecutionParameter(0),
     }
 
     def dequeue(
-        q: Queries, entrypoints: dict[str, EntrypointExecutionParameter]
+        q: Queries, entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter]
     ) -> asyncio.Task[list[Job]]:
         return asyncio.ensure_future(
             q.dequeue(
                 batch_size=10,
                 entrypoints=entrypoints,
-                queue_manager_id=uuid.uuid4(),
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -410,3 +413,31 @@ async def test_slot_race_does_not_lose_unlimited_jobs_in_the_same_batch(
     loose_ids.update(job.id for job in remaining if job.entrypoint == "loose")
     assert len(loose_ids) == n_loose
     assert all(job.entrypoint != "tight" for job in remaining)
+
+
+async def test_dequeue_assigns_capacity_slots(apgdriver: Driver) -> None:
+    """A limited entrypoint gets a distinct seat in ``Job.slot``; an unlimited one gets none."""
+    limit = 3
+    n_fetch = 2 * limit
+    n_loose = 2
+    q = Queries(apgdriver)
+    await q.enqueue(["fetch"] * n_fetch, [None] * n_fetch, [0] * n_fetch)
+    await q.enqueue(["loose"] * n_loose, [None] * n_loose, [0] * n_loose)
+
+    picked = await q.dequeue(
+        batch_size=10,
+        entrypoints={
+            FETCH: EntrypointExecutionParameter(limit),
+            QueueEntrypoint("loose"): EntrypointExecutionParameter(0),
+        },
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
+        global_concurrency_limit=None,
+        heartbeat_timeout=timedelta(minutes=10),
+    )
+
+    fetch = [job for job in picked if job.entrypoint == FETCH]
+    loose = [job for job in picked if job.entrypoint == "loose"]
+    assert len(fetch) == limit
+    assert {job.slot for job in fetch} == set(range(limit))
+    assert len(loose) == n_loose
+    assert all(job.slot is None for job in loose)

--- a/test/test_dequeue_shapes.py
+++ b/test/test_dequeue_shapes.py
@@ -22,6 +22,7 @@ from pgqueuer import db, queries
 from pgqueuer.adapters.persistence import qb
 from pgqueuer.adapters.persistence.composer import ComposedQuery
 from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 
 SNAPSHOT_DIR = Path(__file__).parent / "query_shapes"
 
@@ -41,9 +42,9 @@ def compose(
 ) -> ComposedQuery:
     return (builder or pinned_builder()).build_dequeue_query(
         batch_size=10,
-        entrypoints=["fetch"],
+        entrypoints=[QueueEntrypoint("fetch")],
         concurrency_limits=[concurrency_limit],
-        queue_manager_id=uuid.UUID(int=0),
+        queue_manager_id=QueueManagerId(uuid.UUID(int=0)),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -114,9 +115,9 @@ def test_dequeue_rejects_mismatched_concurrency_limits() -> None:
     with pytest.raises(ValueError, match="same length"):
         pinned_builder().build_dequeue_query(
             batch_size=10,
-            entrypoints=["a", "b"],
+            entrypoints=[QueueEntrypoint("a"), QueueEntrypoint("b")],
             concurrency_limits=[0],
-            queue_manager_id=uuid.UUID(int=0),
+            queue_manager_id=QueueManagerId(uuid.UUID(int=0)),
             global_concurrency_limit=None,
             heartbeat_timeout=timedelta(seconds=30),
         )
@@ -143,8 +144,10 @@ async def test_dequeue_shapes_respect_gates(
     dequeue = functools.partial(
         q.dequeue,
         batch_size=10,
-        entrypoints={"fetch": queries.EntrypointExecutionParameter(concurrency_limit)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={
+            QueueEntrypoint("fetch"): queries.EntrypointExecutionParameter(concurrency_limit)
+        },
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -163,17 +166,17 @@ async def test_minimal_shape_recovers_stale_jobs(apgdriver: db.Driver) -> None:
     dequeue = functools.partial(
         q.dequeue,
         batch_size=10,
-        entrypoints={"fetch": queries.EntrypointExecutionParameter(0)},
+        entrypoints={QueueEntrypoint("fetch"): queries.EntrypointExecutionParameter(0)},
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )
 
-    picked = await dequeue(queue_manager_id=uuid.uuid4())
+    picked = await dequeue(queue_manager_id=QueueManagerId(uuid.uuid4()))
     assert len(picked) == 2
 
     await apgdriver.execute(
         f"UPDATE {DBSettings().queue_table} SET heartbeat = NOW() - interval '1 hour'"
     )
 
-    recovered = await dequeue(queue_manager_id=uuid.uuid4())
+    recovered = await dequeue(queue_manager_id=QueueManagerId(uuid.uuid4()))
     assert sorted(j.id for j in recovered) == sorted(j.id for j in picked)

--- a/test/test_execute_after.py
+++ b/test/test_execute_after.py
@@ -9,6 +9,7 @@ from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core.applications import PgQueuer
 from pgqueuer.db import Driver
 from pgqueuer.domain.models import Job
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.queries import EntrypointExecutionParameter, Queries
 
 
@@ -18,8 +19,8 @@ async def test_execute_after_default_is_now(apgdriver: Driver) -> None:
         len(
             await Queries(apgdriver).dequeue(
                 10,
-                {"foo": EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -32,8 +33,8 @@ async def test_execute_after_default_is_now(apgdriver: Driver) -> None:
         len(
             await Queries(apgdriver).dequeue(
                 10,
-                {"foo": EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -49,8 +50,8 @@ async def test_execute_after_zero(apgdriver: Driver) -> None:
         len(
             await Queries(apgdriver).dequeue(
                 10,
-                {"foo": EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -66,8 +67,8 @@ async def test_execute_after_negative(apgdriver: Driver) -> None:
         len(
             await Queries(apgdriver).dequeue(
                 10,
-                {"foo": EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -81,8 +82,8 @@ async def test_execute_after_1_second(apgdriver: Driver) -> None:
     await Queries(apgdriver).enqueue("foo", None, 0, execute_after)
     before = await Queries(apgdriver).dequeue(
         10,
-        {"foo": EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -91,8 +92,8 @@ async def test_execute_after_1_second(apgdriver: Driver) -> None:
     await asyncio.sleep(execute_after.total_seconds())
     after = await Queries(apgdriver).dequeue(
         10,
-        {"foo": EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -105,8 +106,8 @@ async def test_execute_after_updated_gt_execute_after(apgdriver: Driver) -> None
     await asyncio.sleep(execute_after.total_seconds())
     after = await Queries(apgdriver).dequeue(
         10,
-        {"foo": EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -116,21 +117,21 @@ async def test_execute_after_updated_gt_execute_after(apgdriver: Driver) -> None
 
 async def test_next_deferred_eta_returns_none_when_empty(apgdriver: Driver) -> None:
     q = Queries(apgdriver)
-    eta = await q.next_deferred_eta(["foo"])
+    eta = await q.next_deferred_eta([QueueEntrypoint("foo")])
     assert eta is None
 
 
 async def test_next_deferred_eta_returns_none_for_ready_jobs(apgdriver: Driver) -> None:
     q = Queries(apgdriver)
     await q.enqueue("foo", None, 0)
-    eta = await q.next_deferred_eta(["foo"])
+    eta = await q.next_deferred_eta([QueueEntrypoint("foo")])
     assert eta is None
 
 
 async def test_next_deferred_eta_returns_timedelta(apgdriver: Driver) -> None:
     q = Queries(apgdriver)
     await q.enqueue("foo", None, 0, timedelta(seconds=10))
-    eta = await q.next_deferred_eta(["foo"])
+    eta = await q.next_deferred_eta([QueueEntrypoint("foo")])
     assert eta is not None
     assert eta.total_seconds() > 5
 
@@ -144,19 +145,19 @@ async def test_next_deferred_eta_returns_soonest_of_many(apgdriver: Driver) -> N
         [0, 0, 0],
         [timedelta(seconds=300), timedelta(seconds=30), timedelta(seconds=120)],
     )
-    eta = await q.next_deferred_eta(["foo"])
+    eta = await q.next_deferred_eta([QueueEntrypoint("foo")])
     assert eta is not None
     assert 20 < eta.total_seconds() <= 30
 
 
 async def test_next_deferred_eta_inmemory(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, 0, timedelta(seconds=10))
-    eta = await queries.next_deferred_eta(["ep"])
+    eta = await queries.next_deferred_eta([QueueEntrypoint("ep")])
     assert eta is not None
     assert eta.total_seconds() > 5
 
     # Unrelated entrypoint should return None
-    eta2 = await queries.next_deferred_eta(["other"])
+    eta2 = await queries.next_deferred_eta([QueueEntrypoint("other")])
     assert eta2 is None
 
 

--- a/test/test_executors.py
+++ b/test/test_executors.py
@@ -10,6 +10,7 @@ import anyio
 import pytest
 
 from pgqueuer.db import Driver
+from pgqueuer.domain.types import QueueEntrypoint
 from pgqueuer.executors import (
     AbstractEntrypointExecutor,
     EntrypointExecutor,
@@ -230,9 +231,11 @@ def test_entrypoint_auto_detects_context() -> None:
     @qm.entrypoint("unrelated_second")
     async def unrelated_second(job: Job, config: dict | None = None) -> None: ...
 
-    assert qm.entrypoint_registry["with_context"].parameters.accepts_context
-    assert not qm.entrypoint_registry["without_context"].parameters.accepts_context
-    assert not qm.entrypoint_registry["unrelated_second"].parameters.accepts_context
+    assert qm.entrypoint_registry[QueueEntrypoint("with_context")].parameters.accepts_context
+    assert not qm.entrypoint_registry[QueueEntrypoint("without_context")].parameters.accepts_context
+    assert not qm.entrypoint_registry[
+        QueueEntrypoint("unrelated_second")
+    ].parameters.accepts_context
 
 
 def test_entrypoint_explicit_flag_overrides_detection() -> None:
@@ -244,8 +247,8 @@ def test_entrypoint_explicit_flag_overrides_detection() -> None:
     @qm.entrypoint("forced_on", accepts_context=True)
     async def forced_on(job: Job) -> None: ...
 
-    assert not qm.entrypoint_registry["forced_off"].parameters.accepts_context
-    assert qm.entrypoint_registry["forced_on"].parameters.accepts_context
+    assert not qm.entrypoint_registry[QueueEntrypoint("forced_off")].parameters.accepts_context
+    assert qm.entrypoint_registry[QueueEntrypoint("forced_on")].parameters.accepts_context
 
 
 async def test_custom_threading_executor() -> None:

--- a/test/test_hold_failed.py
+++ b/test/test_hold_failed.py
@@ -13,7 +13,7 @@ from pgqueuer.core.applications import PgQueuer
 from pgqueuer.core.executors import DatabaseRetryEntrypointExecutor
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import QueueExecutionMode
+from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.queries import Queries
 
@@ -28,9 +28,9 @@ EP = EntrypointExecutionParameter(0)
 async def test_inmemory_hold_keeps_job(queries: InMemoryQueries) -> None:
     """on_failure='hold' keeps the job in the queue with status='failed'."""
     await queries.enqueue("ep", b"important-payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert len(jobs) == 1
     job = jobs[0]
@@ -49,9 +49,9 @@ async def test_inmemory_hold_keeps_job(queries: InMemoryQueries) -> None:
 async def test_inmemory_delete_removes_job(queries: InMemoryQueries) -> None:
     """Default on_failure='delete' removes the job from the queue."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     job = jobs[0]
 
@@ -68,9 +68,9 @@ async def test_inmemory_mixed_batch(queries: InMemoryQueries) -> None:
         [b"hold-me", b"delete-me"],
         [1, 1],
     )
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert len(jobs) == 2
 
@@ -89,14 +89,14 @@ async def test_inmemory_mixed_batch(queries: InMemoryQueries) -> None:
 async def test_inmemory_failed_not_dequeued(queries: InMemoryQueries) -> None:
     """Failed jobs are not returned by dequeue."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     await queries.log_jobs([(jobs[0], "failed", None)])
 
     jobs2 = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert len(jobs2) == 0
 
@@ -104,9 +104,9 @@ async def test_inmemory_failed_not_dequeued(queries: InMemoryQueries) -> None:
 async def test_inmemory_requeue_moves_to_queued(queries: InMemoryQueries) -> None:
     """requeue_jobs moves failed jobs back to queued."""
     await queries.enqueue("ep", b"payload", priority=5)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     await queries.log_jobs([(jobs[0], "failed", None)])
 
@@ -114,7 +114,7 @@ async def test_inmemory_requeue_moves_to_queued(queries: InMemoryQueries) -> Non
 
     # Now dequeue should return the job
     jobs2 = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert len(jobs2) == 1
     assert jobs2[0].id == jobs[0].id
@@ -125,9 +125,9 @@ async def test_inmemory_requeue_moves_to_queued(queries: InMemoryQueries) -> Non
 async def test_inmemory_requeue_resets_attempts(queries: InMemoryQueries) -> None:
     """Re-queued jobs have attempts reset to 0."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     job = jobs[0]
 
@@ -135,7 +135,7 @@ async def test_inmemory_requeue_resets_attempts(queries: InMemoryQueries) -> Non
     await queries.retry_job(job, timedelta(0), None)
     await queries.retry_job(job, timedelta(0), None)
     jobs2 = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert jobs2[0].attempts == 2
 
@@ -143,7 +143,7 @@ async def test_inmemory_requeue_resets_attempts(queries: InMemoryQueries) -> Non
     await queries.requeue_jobs([jobs2[0].id])
 
     jobs3 = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert jobs3[0].attempts == 0
 
@@ -151,9 +151,9 @@ async def test_inmemory_requeue_resets_attempts(queries: InMemoryQueries) -> Non
 async def test_inmemory_requeue_ignores_non_failed(queries: InMemoryQueries) -> None:
     """requeue_jobs only affects jobs with status='failed'."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     await queries.requeue_jobs([jobs[0].id])
     failed = await queries.list_failed_jobs()
@@ -165,9 +165,9 @@ async def test_inmemory_list_failed_ordered_by_created(queries: InMemoryQueries)
     for i in range(3):
         await queries.enqueue("ep", f"job-{i}".encode(), priority=1)
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     for j in jobs:
         await queries.log_jobs([(j, "failed", None)])
@@ -183,9 +183,9 @@ async def test_inmemory_list_failed_respects_limit(queries: InMemoryQueries) -> 
     for i in range(5):
         await queries.enqueue("ep", f"job-{i}".encode(), priority=1)
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     for j in jobs:
         await queries.log_jobs([(j, "failed", None)])
@@ -197,9 +197,9 @@ async def test_inmemory_list_failed_respects_limit(queries: InMemoryQueries) -> 
 async def test_inmemory_failed_releases_dedupe_key(queries: InMemoryQueries) -> None:
     """A held/failed job must release its dedupe_key so a new job can be enqueued."""
     await queries.enqueue("ep", b"first", priority=1, dedupe_key="unique-key")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
-        10, {"ep": EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
+        10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert len(jobs) == 1
 

--- a/test/test_inmemory.py
+++ b/test/test_inmemory.py
@@ -11,6 +11,7 @@ import time_machine
 
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.domain.errors import DuplicateJobError
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 # ---------------------------------------------------------------------------
@@ -58,10 +59,10 @@ async def test_dedupe_key_rejects_duplicate(queries: InMemoryQueries) -> None:
 
 async def test_dedupe_key_freed_after_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, dedupe_key="dk1")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -139,10 +140,10 @@ async def test_dedupe_key_on_conflict_skip_no_log_for_skipped(
 
 async def test_dedupe_key_on_conflict_skip_freed_after_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, dedupe_key="dk1")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -160,10 +161,10 @@ async def test_dedupe_key_on_conflict_skip_freed_after_log(queries: InMemoryQuer
 
 async def test_dequeue_basic(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", b"data")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -180,10 +181,10 @@ async def test_dequeue_priority_ordering(queries: InMemoryQueries) -> None:
         [b"lo", b"hi", b"med"],
         [1, 10, 5],
     )
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -195,10 +196,10 @@ async def test_dequeue_priority_ordering(queries: InMemoryQueries) -> None:
 
 async def test_dequeue_execute_after(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, execute_after=timedelta(hours=1))
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -213,8 +214,8 @@ async def test_dequeue_serialized_dispatch(queries: InMemoryQueries) -> None:
         [None, None],
         [0, 0],
     )
-    qm_id = uuid.uuid4()
-    params = {"ep": EntrypointExecutionParameter(1)}
+    qm_id = QueueManagerId(uuid.uuid4())
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(1)}
 
     # First dequeue should get 1 job (concurrency_limit=1 = only one at a time)
     jobs = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
@@ -231,8 +232,8 @@ async def test_dequeue_concurrency_limit(queries: InMemoryQueries) -> None:
         [None, None, None],
         [0, 0, 0],
     )
-    qm_id = uuid.uuid4()
-    params = {"ep": EntrypointExecutionParameter(2)}
+    qm_id = QueueManagerId(uuid.uuid4())
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(2)}
 
     jobs = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
     assert len(jobs) == 2
@@ -241,14 +242,25 @@ async def test_dequeue_concurrency_limit(queries: InMemoryQueries) -> None:
     assert len(jobs2) == 0
 
 
+async def test_dequeue_leaves_capacity_slot_unset(queries: InMemoryQueries) -> None:
+    """The in-memory adapter enforces limits by counting, so ``Job.slot`` stays None."""
+    await queries.enqueue("ep", None)
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(1)}
+
+    (job,) = await queries.dequeue(
+        10, params, QueueManagerId(uuid.uuid4()), None, heartbeat_timeout=timedelta(seconds=30)
+    )
+    assert job.slot is None
+
+
 async def test_dequeue_global_concurrency_limit(queries: InMemoryQueries) -> None:
     await queries.enqueue(
         ["ep", "ep", "ep"],
         [None, None, None],
         [0, 0, 0],
     )
-    qm_id = uuid.uuid4()
-    params = {"ep": EntrypointExecutionParameter(0)}
+    qm_id = QueueManagerId(uuid.uuid4())
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     jobs = await queries.dequeue(
         10, params, qm_id, global_concurrency_limit=1, heartbeat_timeout=timedelta(seconds=30)
@@ -264,8 +276,8 @@ async def test_dequeue_global_concurrency_limit(queries: InMemoryQueries) -> Non
 async def test_dequeue_retry_stale_picked(queries: InMemoryQueries) -> None:
     """Picked jobs with expired heartbeat should be retried."""
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
-    params = {"ep": EntrypointExecutionParameter(0)}
+    qm_id = QueueManagerId(uuid.uuid4())
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     jobs = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
     assert len(jobs) == 1
@@ -285,8 +297,8 @@ async def test_dequeue_retry_stale_picked(queries: InMemoryQueries) -> None:
 async def test_dequeue_stale_priority_beats_fresh_work(queries: InMemoryQueries) -> None:
     """A stale high-priority job outranks fresh lower-priority work (#684)."""
     await queries.enqueue("ep", b"stale-hi", priority=10)
-    qm_id = uuid.uuid4()
-    params = {"ep": EntrypointExecutionParameter(0)}
+    qm_id = QueueManagerId(uuid.uuid4())
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     picked = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
     assert len(picked) == 1
@@ -313,8 +325,8 @@ async def test_dequeue_deferred_jobs_delivered_in_priority_order_when_due(
         [1, 10],
         execute_after=[timedelta(hours=1), timedelta(hours=1)],
     )
-    params = {"ep": EntrypointExecutionParameter(0)}
-    qm_id = uuid.uuid4()
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
+    qm_id = QueueManagerId(uuid.uuid4())
 
     assert (
         await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
@@ -336,10 +348,10 @@ async def test_dequeue_redelivers_candidate_bumped_by_higher_priority(
     await queries.enqueue("ep_a", b"lo", priority=0)
     await queries.enqueue("ep_b", b"hi", priority=5)
     params = {
-        "ep_a": EntrypointExecutionParameter(0),
-        "ep_b": EntrypointExecutionParameter(0),
+        QueueEntrypoint("ep_a"): EntrypointExecutionParameter(0),
+        QueueEntrypoint("ep_b"): EntrypointExecutionParameter(0),
     }
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     first = await queries.dequeue(1, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
     assert [j.payload for j in first] == [b"hi"]
@@ -350,8 +362,8 @@ async def test_dequeue_redelivers_candidate_bumped_by_higher_priority(
 
 async def test_retry_job_with_delay_defers_redelivery(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", b"x")
-    params = {"ep": EntrypointExecutionParameter(0)}
-    qm_id = uuid.uuid4()
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
+    qm_id = QueueManagerId(uuid.uuid4())
 
     (job,) = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(hours=1))
     await queries.retry_job(job, timedelta(hours=1), None)
@@ -372,8 +384,8 @@ async def test_cancelled_queued_job_not_delivered(queries: InMemoryQueries) -> N
 
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
+        QueueManagerId(uuid.uuid4()),
         None,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -387,8 +399,8 @@ async def test_cancelled_deferred_job_not_delivered_when_due(queries: InMemoryQu
     with time_machine.travel(datetime.now(timezone.utc) + timedelta(hours=2)):
         jobs = await queries.dequeue(
             10,
-            {"ep": EntrypointExecutionParameter(0)},
-            uuid.uuid4(),
+            {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
+            QueueManagerId(uuid.uuid4()),
             None,
             heartbeat_timeout=timedelta(seconds=30),
         )
@@ -404,8 +416,8 @@ async def test_clear_queue_filtered_then_reenqueue_same_entrypoint(
 
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
+        QueueManagerId(uuid.uuid4()),
         None,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -414,8 +426,8 @@ async def test_clear_queue_filtered_then_reenqueue_same_entrypoint(
 
 async def test_requeue_failed_job_dequeued_again(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", b"x")
-    params = {"ep": EntrypointExecutionParameter(0)}
-    qm_id = uuid.uuid4()
+    params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
+    qm_id = QueueManagerId(uuid.uuid4())
 
     (job,) = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
     await queries.log_jobs([(job, "failed", None)])
@@ -432,14 +444,16 @@ async def test_requeue_failed_job_dequeued_again(queries: InMemoryQueries) -> No
 async def test_dequeue_empty_entrypoints(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     jobs = await queries.dequeue(
-        10, {}, uuid.uuid4(), None, heartbeat_timeout=timedelta(seconds=30)
+        10, {}, QueueManagerId(uuid.uuid4()), None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert len(jobs) == 0
 
 
 async def test_dequeue_batch_size_validation(queries: InMemoryQueries) -> None:
     with pytest.raises(ValueError):
-        await queries.dequeue(0, {}, uuid.uuid4(), None, heartbeat_timeout=timedelta(seconds=30))
+        await queries.dequeue(
+            0, {}, QueueManagerId(uuid.uuid4()), None, heartbeat_timeout=timedelta(seconds=30)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -449,10 +463,10 @@ async def test_dequeue_batch_size_validation(queries: InMemoryQueries) -> None:
 
 async def test_log_jobs_removes_from_queue(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -465,10 +479,10 @@ async def test_log_jobs_removes_from_queue(queries: InMemoryQueries) -> None:
 
 async def test_log_jobs_adds_to_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -538,10 +552,10 @@ async def test_clear_queue_filtered(queries: InMemoryQueries) -> None:
 
 async def test_update_heartbeat(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -560,10 +574,10 @@ async def test_update_heartbeat(queries: InMemoryQueries) -> None:
 
 async def test_queue_log_lifecycle(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -584,10 +598,10 @@ async def test_queue_log_lifecycle(queries: InMemoryQueries) -> None:
 
 async def test_log_statistics(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -606,10 +620,10 @@ async def test_log_statistics(queries: InMemoryQueries) -> None:
 
 async def test_job_status(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -628,15 +642,15 @@ async def test_job_status(queries: InMemoryQueries) -> None:
 
 async def test_queued_work(queries: InMemoryQueries) -> None:
     await queries.enqueue(["ep", "ep", "other"], [None, None, None], [0, 0, 0])
-    count = await queries.queued_work(["ep"])
+    count = await queries.queued_work([QueueEntrypoint("ep")])
     assert count == 2
 
 
 async def test_eligible_queued_work_excludes_deferred(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, 0)
     await queries.enqueue("ep", None, 0, execute_after=timedelta(seconds=30))
-    assert await queries.queued_work(["ep"]) == 2
-    assert await queries.eligible_queued_work(["ep"]) == 1
+    assert await queries.queued_work([QueueEntrypoint("ep")]) == 2
+    assert await queries.eligible_queued_work([QueueEntrypoint("ep")]) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_inmemory_integration.py
+++ b/test/test_inmemory_integration.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.core.applications import PgQueuer
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import QueueExecutionMode
+from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode, QueueManagerId
 
 # ---------------------------------------------------------------------------
 # PgQueuer.in_memory() factory
@@ -79,11 +79,11 @@ async def test_performance_enqueue_dequeue() -> None:
 
     from pgqueuer.ports.repository import EntrypointExecutionParameter
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     t0 = time.perf_counter()
     dequeued = await queries.dequeue(
         n,
-        {"perf_ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("perf_ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),

--- a/test/test_insights_service.py
+++ b/test/test_insights_service.py
@@ -16,14 +16,17 @@ from pgqueuer.core.insights import (
     sparkline_buckets,
 )
 from pgqueuer.domain import models
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
 async def dequeue_all(queries: InMemoryQueries, entrypoint: str) -> list[models.Job]:
     return await queries.dequeue(
         batch_size=100,
-        entrypoints={entrypoint: EntrypointExecutionParameter(concurrency_limit=0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={
+            QueueEntrypoint(entrypoint): EntrypointExecutionParameter(concurrency_limit=0)
+        },
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -82,8 +85,8 @@ class TestInsightsService:
         await queries.enqueue(["ep_a", "ep_a", "ep_b"], [None] * 3, [0] * 3)
         ages = await InsightsService(queries).queue_age()
         by_ep = {a.entrypoint: a for a in ages}
-        assert by_ep["ep_a"].queued_count == 2
-        assert by_ep["ep_b"].queued_count == 1
+        assert by_ep[QueueEntrypoint("ep_a")].queued_count == 2
+        assert by_ep[QueueEntrypoint("ep_b")].queued_count == 1
         assert all(a.oldest_age_seconds >= 0 for a in ages)
 
     async def test_job_durations_from_transitions(self, queries: InMemoryQueries) -> None:

--- a/test/test_listeners.py
+++ b/test/test_listeners.py
@@ -15,6 +15,7 @@ from pgqueuer.core.listeners import (
     initialize_notice_event_listener,
 )
 from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import (
     AnyEvent,
     CancellationEvent,
@@ -155,8 +156,8 @@ async def test_emit_stable_changed_update(apgdriver: db.Driver) -> None:
 
     await Queries(apgdriver).dequeue(
         100,
-        {"test_emit_stable_changed_update": EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        {QueueEntrypoint("test_emit_stable_changed_update"): EntrypointExecutionParameter(0)},
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_qm.py
+++ b/test/test_qm.py
@@ -12,6 +12,7 @@ from pgqueuer import db
 from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core.cache import TTLCache
 from pgqueuer.core.tm import TaskManager
+from pgqueuer.domain.types import QueueEntrypoint
 from pgqueuer.models import Job, Log
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import Queries
@@ -425,7 +426,7 @@ async def test_drain_shutdown_ignores_stale_cached_queued_work(
 
     cached = TTLCache.create(
         ttl=timedelta(hours=1),
-        on_expired=lambda: qm.queries.queued_work(["fetch"]),
+        on_expired=lambda: qm.queries.queued_work([QueueEntrypoint("fetch")]),
     )
     assert await cached() == 0
 
@@ -448,7 +449,7 @@ async def test_drain_shutdown_sets_shutdown_when_queue_confirmed_empty(
 
     cached = TTLCache.create(
         ttl=timedelta(hours=1),
-        on_expired=lambda: qm.queries.queued_work(["fetch"]),
+        on_expired=lambda: qm.queries.queued_work([QueueEntrypoint("fetch")]),
     )
 
     await qm._maybe_drain_shutdown(QueueExecutionMode.drain, TaskManager(), cached)

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -8,6 +8,7 @@ import pytest
 
 from pgqueuer import db, errors, models, queries
 from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 
 
 @pytest.mark.parametrize("N", (1, 2, 64))
@@ -38,8 +39,8 @@ async def test_queries_next_jobs(
     seen = list[int]()
     while jobs := await q.dequeue(
         batch_size=10,
-        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -71,9 +72,9 @@ async def test_queries_next_jobs_concurrent(
 
     async def consumer() -> None:
         while jobs := await q.dequeue(
-            entrypoints={"placeholder": queries.EntrypointExecutionParameter(1)},
+            entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(1)},
             batch_size=10,
-            queue_manager_id=uuid.uuid4(),
+            queue_manager_id=QueueManagerId(uuid.uuid4()),
             global_concurrency_limit=1000,
             heartbeat_timeout=timedelta(seconds=30),
         ):
@@ -118,8 +119,8 @@ async def test_move_job_log(
 
     while jobs := await q.dequeue(
         batch_size=10,
-        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -192,9 +193,9 @@ async def test_queue_priority(
     )
 
     while next_jobs := await q.dequeue(
-        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
+        entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=10,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -226,9 +227,11 @@ async def test_queue_priority_across_entrypoints(
 
     drained = list[models.Job]()
     while next_jobs := await q.dequeue(
-        entrypoints={ep: queries.EntrypointExecutionParameter(0) for ep in entrypoints},
+        entrypoints={
+            QueueEntrypoint(ep): queries.EntrypointExecutionParameter(0) for ep in entrypoints
+        },
         batch_size=batch_size,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -245,14 +248,14 @@ async def test_queue_priority_across_entrypoints(
 async def test_stale_job_priority_beats_fresh_work(apgdriver: db.Driver) -> None:
     """A stale high-priority job outranks fresh lower-priority work (#684)."""
     q = queries.Queries(apgdriver)
-    entrypoints = {"placeholder": queries.EntrypointExecutionParameter(0)}
+    entrypoints = {QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)}
     heartbeat_timeout = timedelta(seconds=0.01)
 
     await q.enqueue("placeholder", b"stale-hi", priority=10)
     picked = await q.dequeue(
         batch_size=10,
         entrypoints=entrypoints,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -265,7 +268,7 @@ async def test_stale_job_priority_beats_fresh_work(apgdriver: db.Driver) -> None
     recovered = await q.dequeue(
         batch_size=1,
         entrypoints=entrypoints,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=heartbeat_timeout,
     )
@@ -289,8 +292,10 @@ async def test_dequeue_caps_at_batch_size_across_entrypoints(
 
     picked = await q.dequeue(
         batch_size=batch_size,
-        entrypoints={ep: queries.EntrypointExecutionParameter(0) for ep in entrypoints},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={
+            QueueEntrypoint(ep): queries.EntrypointExecutionParameter(0) for ep in entrypoints
+        },
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -302,22 +307,22 @@ async def test_has_queued_work_existence_contract(apgdriver: db.Driver) -> None:
     """queued_work reports positive when work exists, zero otherwise, ignoring picked rows."""
     q = queries.Queries(apgdriver)
 
-    assert await q.queued_work(["foo"]) == 0
+    assert await q.queued_work([QueueEntrypoint("foo")]) == 0
 
     await q.enqueue(["foo"] * 3, [None] * 3, [0] * 3)
 
-    assert await q.queued_work(["foo"]) > 0
-    assert await q.queued_work(["bar"]) == 0
+    assert await q.queued_work([QueueEntrypoint("foo")]) > 0
+    assert await q.queued_work([QueueEntrypoint("bar")]) == 0
 
     picked = await q.dequeue(
         batch_size=10,
-        entrypoints={"foo": queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={QueueEntrypoint("foo"): queries.EntrypointExecutionParameter(0)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
     assert len(picked) == 3
-    assert await q.queued_work(["foo"]) == 0
+    assert await q.queued_work([QueueEntrypoint("foo")]) == 0
 
 
 async def test_dequeue_caps_picks_to_entrypoint_remaining_slots(apgdriver: db.Driver) -> None:
@@ -330,10 +335,10 @@ async def test_dequeue_caps_picks_to_entrypoint_remaining_slots(apgdriver: db.Dr
     picked = await q.dequeue(
         batch_size=10,
         entrypoints={
-            "tight": queries.EntrypointExecutionParameter(2),
-            "loose": queries.EntrypointExecutionParameter(0),
+            QueueEntrypoint("tight"): queries.EntrypointExecutionParameter(2),
+            QueueEntrypoint("loose"): queries.EntrypointExecutionParameter(0),
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -346,14 +351,14 @@ async def test_dequeue_caps_picks_to_entrypoint_remaining_slots(apgdriver: db.Dr
 async def test_dequeue_hard_caps_worker_budget(apgdriver: db.Driver) -> None:
     """A worker's picked total never exceeds global_concurrency_limit, even mid-batch."""
     q = queries.Queries(apgdriver)
-    queue_manager_id = uuid.uuid4()
+    queue_manager_id = QueueManagerId(uuid.uuid4())
 
     await q.enqueue(["fetch"] * 10, [None] * 10, [0] * 10)
 
     async def dequeue() -> list[models.Job]:
         return await q.dequeue(
             batch_size=4,
-            entrypoints={"fetch": queries.EntrypointExecutionParameter(0)},
+            entrypoints={QueueEntrypoint("fetch"): queries.EntrypointExecutionParameter(0)},
             queue_manager_id=queue_manager_id,
             global_concurrency_limit=5,
             heartbeat_timeout=timedelta(seconds=30),
@@ -371,21 +376,21 @@ async def test_eligible_queued_work_excludes_deferred(apgdriver: db.Driver) -> N
     await q.enqueue("foo", None, 0)
     await q.enqueue("foo", None, 0, execute_after=timedelta(seconds=30))
 
-    assert await q.queued_work(["foo"]) > 0
-    assert await q.eligible_queued_work(["foo"]) > 0
+    assert await q.queued_work([QueueEntrypoint("foo")]) > 0
+    assert await q.eligible_queued_work([QueueEntrypoint("foo")]) > 0
 
     picked = await q.dequeue(
         batch_size=10,
-        entrypoints={"foo": queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={QueueEntrypoint("foo"): queries.EntrypointExecutionParameter(0)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
     assert len(picked) == 1
 
     # Only the deferred job remains: still queued work, but none eligible.
-    assert await q.queued_work(["foo"]) > 0
-    assert await q.eligible_queued_work(["foo"]) == 0
+    assert await q.queued_work([QueueEntrypoint("foo")]) > 0
+    assert await q.eligible_queued_work([QueueEntrypoint("foo")]) == 0
 
 
 @pytest.mark.parametrize("N", (1, 2, 64))
@@ -406,8 +411,8 @@ async def test_queue_retry_timer(
     # Pick all jobs, and mark then as "in progress"
     while _ := await q.dequeue(
         batch_size=10,
-        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -417,8 +422,10 @@ async def test_queue_retry_timer(
         len(
             await q.dequeue(
                 batch_size=10,
-                entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
-                queue_manager_id=uuid.uuid4(),
+                entrypoints={
+                    QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)
+                },
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             ),
@@ -431,9 +438,9 @@ async def test_queue_retry_timer(
 
     # Re-fetch, should get the same number of jobs as queued (N).
     while next_jobs := await q.dequeue(
-        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
+        entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=10,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=retry_timer,
     ):
@@ -459,11 +466,13 @@ async def test_queue_log_queued_picked_successful(
 
     # Pick all jobs
     picked_jobs = []
-    queue_manager_id = uuid.uuid4()
+    queue_manager_id = QueueManagerId(uuid.uuid4())
     while jobs := await q.dequeue(
         batch_size=10,
         entrypoints={
-            "test_queue_log_queued_picked_successful": queries.EntrypointExecutionParameter(0)
+            QueueEntrypoint(
+                "test_queue_log_queued_picked_successful"
+            ): queries.EntrypointExecutionParameter(0)
         },
         queue_manager_id=queue_manager_id,
         global_concurrency_limit=1000,
@@ -554,11 +563,13 @@ async def test_queue_log_queued_picked_exception(
 
     # Pick all jobs
     picked_jobs = []
-    queue_manager_id = uuid.uuid4()
+    queue_manager_id = QueueManagerId(uuid.uuid4())
     while jobs := await q.dequeue(
         batch_size=10,
         entrypoints={
-            "test_queue_log_queued_picked_exception": queries.EntrypointExecutionParameter(0)
+            QueueEntrypoint(
+                "test_queue_log_queued_picked_exception"
+            ): queries.EntrypointExecutionParameter(0)
         },
         queue_manager_id=queue_manager_id,
         global_concurrency_limit=1000,
@@ -838,9 +849,9 @@ async def test_log_statistics(
 
     # Log jobs
     jobs = await q.dequeue(
-        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
+        entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=N,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -865,9 +876,9 @@ async def _unaggregated_count(q: queries.Queries) -> int:
 async def _log_n_successful(q: queries.Queries, N: int) -> None:
     await q.enqueue(["placeholder"] * N, [None] * N, [0] * N)
     jobs = await q.dequeue(
-        entrypoints={"placeholder": queries.EntrypointExecutionParameter(0)},
+        entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=N,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -968,9 +979,9 @@ async def test_enqueue_with_headers(apgdriver: db.Driver) -> None:
     await q.enqueue("header_task", None, headers=headers)
 
     jobs = await q.dequeue(
-        entrypoints={"header_task": queries.EntrypointExecutionParameter(0)},
+        entrypoints={QueueEntrypoint("header_task"): queries.EntrypointExecutionParameter(0)},
         batch_size=1,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_query_plan_regression.py
+++ b/test/test_query_plan_regression.py
@@ -10,12 +10,14 @@ import pytest
 
 from pgqueuer import db, queries
 from pgqueuer.adapters.persistence import qb
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 
 QUEUE_TABLE = qb.DBSettings().queue_table
 EP_PRIO_ID_IDX = f"{QUEUE_TABLE}_ep_prio_id_idx"
 EP_EA_IDX = f"{QUEUE_TABLE}_ep_ea_idx"
 
-ENTRYPOINTS = ["a", "b", "c", "d"]
+ENTRYPOINT_NAMES = ["a", "b", "c", "d"]
+ENTRYPOINTS = [QueueEntrypoint(name) for name in ENTRYPOINT_NAMES]
 # Large enough that the planner prefers the index over a Seq Scan.
 SEED = 3000
 
@@ -51,7 +53,7 @@ async def _analyze_nodes(driver: db.Driver, sql: str, *args: object) -> list[dic
 
 async def _seed(driver: db.Driver) -> queries.Queries:
     q = queries.Queries(driver)
-    eps = [ENTRYPOINTS[i % len(ENTRYPOINTS)] for i in range(SEED)]
+    eps = [ENTRYPOINT_NAMES[i % len(ENTRYPOINT_NAMES)] for i in range(SEED)]
     await q.enqueue(eps, [None] * SEED, [i % 7 for i in range(SEED)])
     await driver.execute(f"ANALYZE {QUEUE_TABLE};")
     return q
@@ -120,7 +122,7 @@ async def test_dequeue_uses_entrypoint_priority_index(
         batch_size=10,
         entrypoints=ENTRYPOINTS,
         concurrency_limits=[concurrency_limit] * len(ENTRYPOINTS),
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -140,7 +142,7 @@ async def test_next_deferred_eta_uses_execute_after_index(apgdriver: db.Driver) 
     """next_deferred_eta reads the (entrypoint, execute_after) index with a LIMIT (#668)."""
     q = await _seed(apgdriver)
     await q.enqueue(
-        ENTRYPOINTS,
+        ENTRYPOINT_NAMES,
         [None] * len(ENTRYPOINTS),
         [0] * len(ENTRYPOINTS),
         [timedelta(seconds=60)] * len(ENTRYPOINTS),
@@ -177,12 +179,12 @@ async def test_dequeue_plan_scans_proportional_to_batch(
     """
     await _bulk_seed(apgdriver, BULK_ROWS, BULK_EPS)
     q = queries.Queries(apgdriver)
-    eps = [f"ep_{i}" for i in range(BULK_EPS)]
+    eps = [QueueEntrypoint(f"ep_{i}") for i in range(BULK_EPS)]
     query = q.qbq.build_dequeue_query(
         batch_size=BATCH,
         entrypoints=eps,
         concurrency_limits=[concurrency_limit] * BULK_EPS,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -224,12 +226,12 @@ async def test_dequeue_gate_skips_saturated_entrypoints(
     await apgdriver.execute(f"ANALYZE {QUEUE_TABLE};")
 
     q = queries.Queries(apgdriver)
-    eps = [f"ep_{i}" for i in range(BULK_EPS)]
+    eps = [QueueEntrypoint(f"ep_{i}") for i in range(BULK_EPS)]
     query = q.qbq.build_dequeue_query(
         batch_size=BATCH,
         entrypoints=eps,
         concurrency_limits=[1] * BULK_EPS,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -260,12 +262,12 @@ async def test_dequeue_plan_is_independent_of_concurrency_limit(
     """
     await _bulk_seed(apgdriver, BULK_ROWS, BULK_EPS)
     q = queries.Queries(apgdriver)
-    eps = [f"ep_{i}" for i in range(BULK_EPS)]
+    eps = [QueueEntrypoint(f"ep_{i}") for i in range(BULK_EPS)]
     query = q.qbq.build_dequeue_query(
         batch_size=BATCH,
         entrypoints=eps,
         concurrency_limits=[concurrency_limit] * BULK_EPS,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from pgqueuer import db, queries
 from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import QueueEntrypoint
 from pgqueuer.models import Job
 from pgqueuer.qm import QueueManager
 from pgqueuer.types import JobId
@@ -305,7 +306,7 @@ async def test_retry_reclaims_stale_picked_job_after_crash(apgdriver: db.Driver)
     (job_id,) = await crashed_manager.queries.enqueue([entrypoint], [None], [0])
 
     execution_params = {
-        entrypoint: queries.EntrypointExecutionParameter(
+        QueueEntrypoint(entrypoint): queries.EntrypointExecutionParameter(
             concurrency_limit=concurrency_limit,
         )
     }
@@ -351,7 +352,7 @@ async def test_stale_recovery_at_concurrency_limit(apgdriver: db.Driver) -> None
     retry_timer = timedelta(milliseconds=100)
     entrypoint = "stale_at_limit"
     execution_params = {
-        entrypoint: queries.EntrypointExecutionParameter(concurrency_limit=1),
+        QueueEntrypoint(entrypoint): queries.EntrypointExecutionParameter(concurrency_limit=1),
     }
 
     q = queries.Queries(apgdriver)

--- a/test/test_retry_requeue.py
+++ b/test/test_retry_requeue.py
@@ -18,7 +18,7 @@ from pgqueuer.core.qm import QueueManager
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.errors import RetryException, RetryRequested
 from pgqueuer.domain.models import Context, Job, JobId, TracebackRecord
-from pgqueuer.domain.types import QueueExecutionMode
+from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.queries import Queries
 
@@ -58,10 +58,10 @@ def test_retry_requested_is_retry_exception() -> None:
 
 async def test_inmemory_retry_job_updates_state(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", b"payload", priority=5)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -82,7 +82,7 @@ async def test_inmemory_retry_job_updates_state(queries: InMemoryQueries) -> Non
     # Verify via dequeue that the job is eligible again and has attempts=1
     jobs_again = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -95,10 +95,10 @@ async def test_inmemory_retry_job_updates_state(queries: InMemoryQueries) -> Non
 
 async def test_inmemory_retry_job_writes_log_entry(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", b"x", priority=0)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -572,8 +572,8 @@ async def test_retry_with_delay_prevents_immediate_dequeue(
 ) -> None:
     """A retried job with non-zero delay is not dequeued until execute_after passes."""
     await queries.enqueue("ep", b"x", priority=0)
-    qm_id = uuid.uuid4()
-    ep_params = {"ep": EntrypointExecutionParameter(0)}
+    qm_id = QueueManagerId(uuid.uuid4())
+    ep_params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     jobs = await queries.dequeue(
         10, ep_params, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
@@ -656,10 +656,10 @@ async def test_inmemory_retry_job_nonexistent_is_noop(queries: InMemoryQueries) 
 async def test_inmemory_retry_job_stores_traceback(queries: InMemoryQueries) -> None:
     """Traceback record is stored as JSON in the retry log entry."""
     await queries.enqueue("ep", b"x", priority=0)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EntrypointExecutionParameter(0)},
+        {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -410,8 +410,8 @@ async def test_schedule_executor_without_context() -> None:
         received_schedules.append(schedule)
 
     params = ScheduleExecutorFactoryParameters(
-        entrypoint="no_ctx",
-        expression="* * * * *",
+        entrypoint=CronEntrypoint("no_ctx"),
+        expression=CronExpression("* * * * *"),
         func=handler,
         clean_old=False,
         accepts_context=False,
@@ -443,8 +443,8 @@ async def test_schedule_executor_with_context() -> None:
         received.append((schedule, ctx))
 
     params = ScheduleExecutorFactoryParameters(
-        entrypoint="with_ctx",
-        expression="* * * * *",
+        entrypoint=CronEntrypoint("with_ctx"),
+        expression=CronExpression("* * * * *"),
         func=handler,
         clean_old=False,
         accepts_context=True,

--- a/test/test_schema_support.py
+++ b/test/test_schema_support.py
@@ -17,6 +17,7 @@ from async_timeout import timeout
 from pgqueuer import db, queries
 from pgqueuer.core.listeners import initialize_notice_event_listener
 from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import AnyEvent, Channel, CronExpressionEntrypoint
 from pgqueuer.queries import EntrypointExecutionParameter
 from pgqueuer.types import CronEntrypoint, CronExpression
@@ -39,8 +40,8 @@ async def enqueue_dequeue_round_trip(q: queries.Queries) -> None:
     (job_id,) = await q.enqueue("ep", b"x", 0)
     jobs = await q.dequeue(
         batch_size=10,
-        entrypoints={"ep": EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_sigterm_cancellation.py
+++ b/test/test_sigterm_cancellation.py
@@ -14,6 +14,7 @@ from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core import buffers
 from pgqueuer.core.qm import QueueManager
 from pgqueuer.domain import models
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 EP_UNLIMITED = EntrypointExecutionParameter(0)
@@ -23,10 +24,10 @@ EP_SERIAL = EntrypointExecutionParameter(1)
 async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> None:
     """log_jobs('canceled') removes the row and frees the slot."""
     await queries.enqueue("ep", b"x", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
-        {"ep": EP_UNLIMITED},
+        {QueueEntrypoint("ep"): EP_UNLIMITED},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -40,7 +41,7 @@ async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> Non
     assert [e.status for e in log if e.job_id == job.id and e.status == "canceled"] == ["canceled"]
     again = await queries.dequeue(
         10,
-        {"ep": EP_UNLIMITED},
+        {QueueEntrypoint("ep"): EP_UNLIMITED},
         qm_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -63,7 +64,7 @@ async def test_dispatch_cancellation_error_logs_canceled(
     await queries.enqueue("hang", b"payload", priority=1)
     jobs = await queries.dequeue(
         10,
-        {"hang": EP_UNLIMITED},
+        {QueueEntrypoint("hang"): EP_UNLIMITED},
         qm.queue_manager_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -112,7 +113,7 @@ async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
     await queries.enqueue("serial", b"first", priority=1)
     jobs = await queries.dequeue(
         10,
-        {"serial": EP_SERIAL},
+        {QueueEntrypoint("serial"): EP_SERIAL},
         qm.queue_manager_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -137,7 +138,7 @@ async def test_cancel_frees_concurrency_slot(queries: InMemoryQueries) -> None:
     await queries.enqueue("serial", b"second", priority=1)
     next_jobs = await queries.dequeue(
         10,
-        {"serial": EP_SERIAL},
+        {QueueEntrypoint("serial"): EP_SERIAL},
         qm.queue_manager_id,
         None,
         heartbeat_timeout=timedelta(seconds=30),
@@ -153,11 +154,11 @@ async def test_stale_recovery_bypasses_concurrency_limit(
     """Stale rows are recoverable even when picked count == concurrency_limit."""
     heartbeat_timeout = timedelta(milliseconds=20)
 
-    qm_a = uuid.uuid4()
+    qm_a = QueueManagerId(uuid.uuid4())
     await queries.enqueue("ep", b"x", priority=1)
     jobs_a = await queries.dequeue(
         10,
-        {"ep": EP_SERIAL},
+        {QueueEntrypoint("ep"): EP_SERIAL},
         qm_a,
         None,
         heartbeat_timeout=heartbeat_timeout,
@@ -167,10 +168,10 @@ async def test_stale_recovery_bypasses_concurrency_limit(
 
     await asyncio.sleep(heartbeat_timeout.total_seconds() * 3)
 
-    qm_b = uuid.uuid4()
+    qm_b = QueueManagerId(uuid.uuid4())
     jobs_b = await queries.dequeue(
         10,
-        {"ep": EP_SERIAL},
+        {QueueEntrypoint("ep"): EP_SERIAL},
         qm_b,
         None,
         heartbeat_timeout=heartbeat_timeout,

--- a/test/test_strict_serialized.py
+++ b/test/test_strict_serialized.py
@@ -9,6 +9,7 @@ from itertools import chain
 import pytest
 
 from pgqueuer.db import Driver
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import Job
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import EntrypointExecutionParameter, Queries
@@ -140,8 +141,8 @@ async def test_no_jobs_processed_when_locked(
     await enqueue(queries, size=n_tasks)
     picked_job = await queries.dequeue(
         1,
-        {"serialized_dispatch_true": EntrypointExecutionParameter(1)},
-        queue_manager_id=uuid.uuid4(),
+        {QueueEntrypoint("serialized_dispatch_true"): EntrypointExecutionParameter(1)},
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -8,3 +8,14 @@ def test_pgchannel_removed_from_public_api() -> None:
 
     assert not hasattr(m, "PGChannel")
     assert not hasattr(t, "PGChannel")
+
+
+def test_identity_newtypes_reexported_from_shims() -> None:
+    """QueueEntrypoint, QueueManagerId and Slot reach both compatibility shims."""
+    import pgqueuer.models as m
+    import pgqueuer.types as t
+    from pgqueuer.domain import types
+
+    assert m.QueueEntrypoint is t.QueueEntrypoint is types.QueueEntrypoint
+    assert m.QueueManagerId is t.QueueManagerId is types.QueueManagerId
+    assert m.Slot is t.Slot is types.Slot

--- a/test/test_web_integration.py
+++ b/test/test_web_integration.py
@@ -15,6 +15,7 @@ from pgqueuer.adapters.web.routes import create_web_router
 from pgqueuer.adapters.web.sse import Broadcaster
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain import models
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.queries import Queries
 
@@ -44,8 +45,10 @@ async def client(web_app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
 async def dequeue_all(queries: Queries, entrypoint: str) -> list[models.Job]:
     return await queries.dequeue(
         batch_size=100,
-        entrypoints={entrypoint: EntrypointExecutionParameter(concurrency_limit=0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={
+            QueueEntrypoint(entrypoint): EntrypointExecutionParameter(concurrency_limit=0)
+        },
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_web_routes.py
+++ b/test/test_web_routes.py
@@ -27,6 +27,7 @@ from pgqueuer.adapters.web.routes import (
 )
 from pgqueuer.adapters.web.sse import Broadcaster
 from pgqueuer.domain import models
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
@@ -52,8 +53,10 @@ async def client(queries: InMemoryQueries) -> AsyncGenerator[httpx.AsyncClient, 
 async def dequeue_all(queries: InMemoryQueries, entrypoint: str) -> list[models.Job]:
     return await queries.dequeue(
         batch_size=100,
-        entrypoints={entrypoint: EntrypointExecutionParameter(concurrency_limit=0)},
-        queue_manager_id=uuid.uuid4(),
+        entrypoints={
+            QueueEntrypoint(entrypoint): EntrypointExecutionParameter(concurrency_limit=0)
+        },
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )


### PR DESCRIPTION
## Summary

`domain/types.py` had `JobId`/`ScheduleId` but the queue entrypoint name, the worker id and the capacity slot were bare `str` / `uuid.UUID` / not represented at all. This adds:

- `QueueEntrypoint = NewType("QueueEntrypoint", str)` — mirrors `CronEntrypoint`; plain `Entrypoint` clashes with the handler-callable alias in `core/executors.py`.
- `QueueManagerId = NewType("QueueManagerId", uuid.UUID)`
- `Slot = NewType("Slot", int)` and `Job.slot: Slot | None = None` — the dequeue CTE already `RETURNING *`'d the column; `Job` just dropped it.

All three re-exported from `pgqueuer.types` and `pgqueuer.models`.

## Where the types flow

- Models: every `entrypoint`, `entrypoints`, `queue_manager_id` field.
- Core: `QueueManager.entrypoint_registry` keyed by `QueueEntrypoint`; `queue_manager_id: QueueManagerId`; `ScheduleExecutorFactoryParameters` uses `CronEntrypoint`/`CronExpression`.
- Ports/adapters: `dequeue`, `queued_work`, `eligible_queued_work`, `next_deferred_eta`, `qb.build_dequeue_query`; in-memory adapter emits `slot: None`.
- Boundary: user-input APIs stay `str` (`enqueue`, `clear_queue`, `browse_queue`, `@entrypoint(name)`, CLI/web). Once the registry is keyed by the NewType, dict/list invariance forces the port params to follow.

Deliberately not typed: `priority` (a quantity, not an identity).

## Compatibility

Typing-only. Runtime values are unchanged `str`/`UUID`/`int`. Downstream code calling `dequeue`/`queued_work` directly with literals, or indexing `entrypoint_registry` with a `str`, needs `QueueEntrypoint("name")` to pass mypy. Noted in RELEASE.md under v1.4.0. Reviewer call whether that fits a minor release.

## Tests

- New: Postgres dequeue assigns distinct slots in `range(limit)` and `None` for unlimited entrypoints; in-memory slot stays `None`; shim re-exports.
- ~270 existing call sites in 21 test files wrapped mechanically.
- Ran `test_types`, `test_inmemory*`, `test_executors`, `test_concurrency_limit`, `test_queries`, `test_dequeue_shapes`, `test_execute_after`, `test_scheduler`, `test_query_plan_regression`: 258 passed. `ruff`, `lint-imports`, `mypy --no-incremental` clean.

## Docs

RELEASE.md (v1.4.0 Added/Changed), `core-concepts.md` Job table, `design/README.md`, `ports-and-adapters.md`.

> Gotcha found on the way: mypy's incremental cache reported green while `--no-incremental` found 266 errors in tests. CI runs fresh so it is unaffected, but worth knowing locally.
