### PR TITLE
feat(domain): add Slot identity type and Job.slot

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,6 +50,13 @@ wins; nothing validates or rejects the mismatch.
   failure now restart in place. Review any external restart or alerting that
   relied on the process dying.
 
+### Added
+
+- `Job.slot` exposes the capacity seat a picked job holds under a
+  `concurrency_limit`; `None` for unlimited entrypoints and unpicked rows.
+  Typed as the new `Slot` identity in `pgqueuer.domain.types` (re-exported
+  from `pgqueuer.types` and `pgqueuer.models`); a plain `int` at runtime.
+
 ### Changed
 
 - `QueryQueueBuilder.build_dequeue_query()` and `build_log_statistics_query()`

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -190,7 +190,7 @@ Arrows denote dependency, not communication flow.
 
 | Component        | Type         | Description                                    |
 |------------------|--------------|------------------------------------------------|
-| JobId, ScheduleId| Value Object | `NewType` identities (`domain/types.py`)       |
+| JobId, ScheduleId, Slot | Value Object | `NewType` identities (`domain/types.py`) |
 | Entrypoint       | Value Object | Name binding a job to its registered handler; schedules use the `CronEntrypoint` variant |
 | Payload          | Value Object | Opaque `bytes`; the library ships no serializer (ADR-0009) |
 | Headers          | Value Object | Side-channel dict for tracing propagation      |

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -16,6 +16,7 @@ A **job** is a unit of work stored as a row in the `pgqueuer` table. Each job ha
 | `execute_after` | `timestamp` | Earliest time the job can be picked up |
 | `attempts` | `int` | Number of previous retry attempts (starts at 0) |
 | `heartbeat` | `timestamp` | Last time the worker confirmed it is alive |
+| `slot` | `int \| None` | Capacity seat held while picked under a `concurrency_limit`; `None` otherwise |
 | `dedupe_key` | `str \| None` | Optional unique key to prevent duplicate enqueuing |
 
 Jobs are created by calling `Queries.enqueue()` and processed by functions registered

--- a/docs/reference/ports-and-adapters.md
+++ b/docs/reference/ports-and-adapters.md
@@ -144,7 +144,7 @@ pgqueuer/
 
   domain/
     models.py                 # Job, Schedule, Event, Context, statistics
-    types.py                  # JobId, JOB_STATUS, Channel, etc.
+    types.py                  # JobId, Slot, JOB_STATUS, Channel, etc.
     errors.py                 # Exception hierarchy
     settings.py               # DBSettings, Durability, DurabilityPolicy
 

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -229,6 +229,7 @@ class InMemoryQueries:
                 "payload": normed.payload[i],
                 "attempts": 0,
                 "queue_manager_id": None,
+                "slot": None,
                 "headers": hdr,
             }
 

--- a/pgqueuer/domain/models.py
+++ b/pgqueuer/domain/models.py
@@ -20,6 +20,7 @@ from pgqueuer.domain.types import (
     CronExpression,
     JobId,
     ScheduleId,
+    Slot,
 )
 
 
@@ -80,7 +81,11 @@ class AnyEvent(
 
 
 class Job(BaseModel):
-    """A queued or in-flight job row."""
+    """A queued or in-flight job row.
+
+    ``slot`` is the capacity seat held while picked under a ``concurrency_limit``;
+    None for unlimited entrypoints and for rows not currently picked.
+    """
 
     id: JobId
     priority: int
@@ -93,6 +98,7 @@ class Job(BaseModel):
     payload: bytes | None
     attempts: int = 0
     queue_manager_id: uuid.UUID | None
+    slot: Slot | None = None
     headers: Annotated[
         dict[str, Any] | None,
         BeforeValidator(lambda x: None if x is None else from_json(x)),

--- a/pgqueuer/domain/types.py
+++ b/pgqueuer/domain/types.py
@@ -19,6 +19,7 @@ EVENT_TYPES = Literal[
 
 
 JobId = NewType("JobId", int)
+Slot = NewType("Slot", int)
 JOB_STATUS = Literal[
     "queued",
     "picked",

--- a/pgqueuer/models.py
+++ b/pgqueuer/models.py
@@ -27,6 +27,7 @@ from pgqueuer.domain.types import (
     CronExpression,
     JobId,
     ScheduleId,
+    Slot,
 )
 
 __all__ = [
@@ -50,6 +51,7 @@ __all__ = [
     "Schedule",
     "ScheduleContext",
     "ScheduleId",
+    "Slot",
     "TableChangedEvent",
     "TracebackRecord",
 ]

--- a/pgqueuer/types.py
+++ b/pgqueuer/types.py
@@ -14,6 +14,7 @@ from pgqueuer.domain.types import (
     OnFailure,
     QueueExecutionMode,
     ScheduleId,
+    Slot,
 )
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     "OnFailure",
     "QueueExecutionMode",
     "ScheduleId",
+    "Slot",
 ]

--- a/test/test_concurrency_limit.py
+++ b/test/test_concurrency_limit.py
@@ -410,3 +410,31 @@ async def test_slot_race_does_not_lose_unlimited_jobs_in_the_same_batch(
     loose_ids.update(job.id for job in remaining if job.entrypoint == "loose")
     assert len(loose_ids) == n_loose
     assert all(job.entrypoint != "tight" for job in remaining)
+
+
+async def test_dequeue_assigns_capacity_slots(apgdriver: Driver) -> None:
+    """A limited entrypoint gets a distinct seat in ``Job.slot``; an unlimited one gets none."""
+    limit = 3
+    n_fetch = 2 * limit
+    n_loose = 2
+    q = Queries(apgdriver)
+    await q.enqueue(["fetch"] * n_fetch, [None] * n_fetch, [0] * n_fetch)
+    await q.enqueue(["loose"] * n_loose, [None] * n_loose, [0] * n_loose)
+
+    picked = await q.dequeue(
+        batch_size=10,
+        entrypoints={
+            "fetch": EntrypointExecutionParameter(limit),
+            "loose": EntrypointExecutionParameter(0),
+        },
+        queue_manager_id=uuid.uuid4(),
+        global_concurrency_limit=None,
+        heartbeat_timeout=timedelta(minutes=10),
+    )
+
+    fetch = [job for job in picked if job.entrypoint == "fetch"]
+    loose = [job for job in picked if job.entrypoint == "loose"]
+    assert len(fetch) == limit
+    assert {job.slot for job in fetch} == set(range(limit))
+    assert len(loose) == n_loose
+    assert all(job.slot is None for job in loose)

--- a/test/test_inmemory.py
+++ b/test/test_inmemory.py
@@ -241,6 +241,17 @@ async def test_dequeue_concurrency_limit(queries: InMemoryQueries) -> None:
     assert len(jobs2) == 0
 
 
+async def test_dequeue_leaves_capacity_slot_unset(queries: InMemoryQueries) -> None:
+    """The in-memory adapter enforces limits by counting, so ``Job.slot`` stays None."""
+    await queries.enqueue("ep", None)
+    params = {"ep": EntrypointExecutionParameter(1)}
+
+    (job,) = await queries.dequeue(
+        10, params, uuid.uuid4(), None, heartbeat_timeout=timedelta(seconds=30)
+    )
+    assert job.slot is None
+
+
 async def test_dequeue_global_concurrency_limit(queries: InMemoryQueries) -> None:
     await queries.enqueue(
         ["ep", "ep", "ep"],

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -8,3 +8,12 @@ def test_pgchannel_removed_from_public_api() -> None:
 
     assert not hasattr(m, "PGChannel")
     assert not hasattr(t, "PGChannel")
+
+
+def test_slot_reexported_from_shims() -> None:
+    """Slot reaches both compatibility shims."""
+    import pgqueuer.models as m
+    import pgqueuer.types as t
+    from pgqueuer.domain import types
+
+    assert m.Slot is t.Slot is types.Slot


### PR DESCRIPTION
Split from #783 (one PR per new type).

## Summary

The dequeue CTE already returns the capacity seat a picked job holds (`RETURNING *`), but `Job` dropped the column. This exposes it as `Job.slot`, typed with a new `Slot = NewType("Slot", int)` next to `JobId` in `pgqueuer/domain/types.py`, re-exported from `pgqueuer.types` and `pgqueuer.models`.

`slot` is `None` for unlimited entrypoints and for rows not currently picked. The in-memory adapter enforces limits by counting, so it reports `None`.

## Compatibility

Additive. New optional field with a default; runtime value is a plain `int`.

## Tests

- Postgres: dequeue with `concurrency_limit=3` yields slots `{0, 1, 2}`, unlimited entrypoint yields `None` (`test_concurrency_limit.py`).
- In-memory: slot stays `None` (`test_inmemory.py`).
- Shim re-export (`test_types.py`).
- Ran `test_types`, `test_inmemory`, `test_concurrency_limit`: 73 passed. `ruff`, `lint-imports`, `mypy --no-incremental` clean.

## Docs

RELEASE.md (v1.4.0 Added), `core-concepts.md` Job table, `design/README.md`, `ports-and-adapters.md`.
