### PR TITLE
feat(domain): add QueueManagerId identity type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,6 +60,10 @@ wins; nothing validates or rejects the mismatch.
   `pgqueuer.types` and `pgqueuer.models`) for the queue entrypoint name on
   `Job`, `Log`, the statistics models and `QueueManager.entrypoint_registry`;
   a plain `str` at runtime. Schedules keep the existing `CronEntrypoint`.
+- `QueueManagerId` identity type in `pgqueuer.domain.types` (re-exported from
+  `pgqueuer.types` and `pgqueuer.models`) for the worker id on `Job`,
+  `StaleJob`, `ActiveWorker` and `QueueManager.queue_manager_id`; a plain
+  `uuid.UUID` at runtime.
 
 ### Changed
 
@@ -70,6 +74,10 @@ wins; nothing validates or rejects the mismatch.
   Code that calls these directly with literals needs `QueueEntrypoint("name")`
   to pass mypy. `enqueue()`, `clear_queue()` and the `@entrypoint` decorator
   still take `str`.
+- Type annotations only, no runtime change: `dequeue()` and
+  `QueryQueueBuilder.build_dequeue_query()` take `queue_manager_id:
+  QueueManagerId` instead of `uuid.UUID`. Code calling them directly with a
+  bare `uuid.uuid4()` needs `QueueManagerId(uuid.uuid4())` to pass mypy.
 - `QueryQueueBuilder.build_dequeue_query()` and `build_log_statistics_query()`
   take keyword-only arguments and return a `ComposedQuery` (`.sql`, `.args`)
   instead of a SQL string. Both are internal but reachable via `Queries.qbq`.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -190,7 +190,7 @@ Arrows denote dependency, not communication flow.
 
 | Component        | Type         | Description                                    |
 |------------------|--------------|------------------------------------------------|
-| JobId, ScheduleId, Slot | Value Object | `NewType` identities (`domain/types.py`) |
+| JobId, ScheduleId, QueueManagerId, Slot | Value Object | `NewType` identities (`domain/types.py`) |
 | Entrypoint       | Value Object | Name binding a job to its registered handler (`QueueEntrypoint`); schedules use the `CronEntrypoint` variant |
 | Payload          | Value Object | Opaque `bytes`; the library ships no serializer (ADR-0009) |
 | Headers          | Value Object | Side-channel dict for tracing propagation      |

--- a/docs/reference/ports-and-adapters.md
+++ b/docs/reference/ports-and-adapters.md
@@ -144,7 +144,7 @@ pgqueuer/
 
   domain/
     models.py                 # Job, Schedule, Event, Context, statistics
-    types.py                  # JobId, QueueEntrypoint, Slot, JOB_STATUS, etc.
+    types.py                  # JobId, QueueEntrypoint, QueueManagerId, Slot, JOB_STATUS, etc.
     errors.py                 # Exception hierarchy
     settings.py               # DBSettings, Durability, DurabilityPolicy
 

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -25,6 +25,7 @@ from pgqueuer.domain.types import (
     JobId,
     OnConflict,
     QueueEntrypoint,
+    QueueManagerId,
     ScheduleId,
     SortOrder,
 )
@@ -318,7 +319,7 @@ class InMemoryQueries:
 
     def _count_picked_jobs(
         self,
-        queue_manager_id: uuid.UUID,
+        queue_manager_id: QueueManagerId,
         entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
     ) -> tuple[dict[QueueEntrypoint, int], int]:
         picked_per_ep: dict[QueueEntrypoint, int] = {}
@@ -370,7 +371,7 @@ class InMemoryQueries:
         self,
         batch_size: int,
         entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
-        queue_manager_id: uuid.UUID,
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> list[models.Job]:

--- a/pgqueuer/adapters/persistence/qb.py
+++ b/pgqueuer/adapters/persistence/qb.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import uuid
 from datetime import timedelta
 from typing import Generator
 
@@ -14,7 +13,7 @@ from pgqueuer.domain.settings import (
     DurabilityPolicy,
     QualifiedNames,
 )
-from pgqueuer.domain.types import OnConflict, QueueEntrypoint, SortOrder
+from pgqueuer.domain.types import OnConflict, QueueEntrypoint, QueueManagerId, SortOrder
 
 # Re-export for backward compatibility within the adapter layer
 __all__ = [
@@ -484,7 +483,7 @@ class QueryQueueBuilder:
         batch_size: int,
         entrypoints: list[QueueEntrypoint],
         concurrency_limits: list[int],
-        queue_manager_id: uuid.UUID,
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> ComposedQuery:

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -16,7 +16,7 @@ from typing_extensions import assert_never
 from pgqueuer.adapters.persistence import qb, query_helpers, sqlstate
 from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
 from pgqueuer.domain import errors, models, types
-from pgqueuer.domain.types import CronEntrypoint, QueueEntrypoint
+from pgqueuer.domain.types import CronEntrypoint, QueueEntrypoint, QueueManagerId
 from pgqueuer.ports import tracing
 from pgqueuer.ports.driver import Driver, SyncDriver
 from pgqueuer.ports.repository import EntrypointExecutionParameter
@@ -162,7 +162,7 @@ class Queries:
         self,
         batch_size: int,
         entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
-        queue_manager_id: uuid.UUID,
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> list[models.Job]:

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -53,9 +53,9 @@ class QueueManager:
             default_factory=dict,
         )
     )
-    queue_manager_id: uuid.UUID = dataclasses.field(
+    queue_manager_id: types.QueueManagerId = dataclasses.field(
         init=False,
-        default_factory=uuid.uuid4,
+        default_factory=lambda: types.QueueManagerId(uuid.uuid4()),
     )
     # Shared resources mapping propagated into each job Context.
     resources: MutableMapping = dataclasses.field(

--- a/pgqueuer/domain/models.py
+++ b/pgqueuer/domain/models.py
@@ -20,6 +20,7 @@ from pgqueuer.domain.types import (
     CronExpression,
     JobId,
     QueueEntrypoint,
+    QueueManagerId,
     ScheduleId,
     Slot,
 )
@@ -98,7 +99,7 @@ class Job(BaseModel):
     entrypoint: QueueEntrypoint
     payload: bytes | None
     attempts: int = 0
-    queue_manager_id: uuid.UUID | None
+    queue_manager_id: QueueManagerId | None
     slot: Slot | None = None
     headers: Annotated[
         dict[str, Any] | None,
@@ -240,7 +241,7 @@ class ThroughputBucket(BaseModel):
 class ActiveWorker(BaseModel):
     """A queue manager currently holding picked jobs."""
 
-    queue_manager_id: uuid.UUID
+    queue_manager_id: QueueManagerId
     active_jobs: int
     oldest_heartbeat: AwareDatetime
     newest_heartbeat: AwareDatetime
@@ -252,7 +253,7 @@ class StaleJob(BaseModel):
 
     id: JobId
     priority: int
-    queue_manager_id: uuid.UUID | None
+    queue_manager_id: QueueManagerId | None
     created: AwareDatetime
     updated: AwareDatetime
     heartbeat: AwareDatetime

--- a/pgqueuer/domain/types.py
+++ b/pgqueuer/domain/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from enum import Enum
 from typing import Literal, NewType
 
@@ -20,6 +21,7 @@ EVENT_TYPES = Literal[
 
 JobId = NewType("JobId", int)
 QueueEntrypoint = NewType("QueueEntrypoint", str)
+QueueManagerId = NewType("QueueManagerId", uuid.UUID)
 Slot = NewType("Slot", int)
 JOB_STATUS = Literal[
     "queued",

--- a/pgqueuer/models.py
+++ b/pgqueuer/models.py
@@ -27,6 +27,7 @@ from pgqueuer.domain.types import (
     CronExpression,
     JobId,
     QueueEntrypoint,
+    QueueManagerId,
     ScheduleId,
     Slot,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "LogStatistics",
     "OPERATIONS",
     "QueueEntrypoint",
+    "QueueManagerId",
     "QueueStatistics",
     "Schedule",
     "ScheduleContext",

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -13,6 +13,7 @@ from pgqueuer.domain.types import (
     CronEntrypoint,
     OnConflict,
     QueueEntrypoint,
+    QueueManagerId,
     SortOrder,
 )
 from pgqueuer.ports.driver import Driver
@@ -38,7 +39,7 @@ class QueueRepositoryPort(Protocol):
         self,
         batch_size: int,
         entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
-        queue_manager_id: uuid.UUID,
+        queue_manager_id: QueueManagerId,
         global_concurrency_limit: int | None,
         heartbeat_timeout: timedelta,
     ) -> list[models.Job]: ...

--- a/pgqueuer/types.py
+++ b/pgqueuer/types.py
@@ -14,6 +14,7 @@ from pgqueuer.domain.types import (
     OnFailure,
     QueueEntrypoint,
     QueueExecutionMode,
+    QueueManagerId,
     ScheduleId,
     Slot,
 )
@@ -30,6 +31,7 @@ __all__ = [
     "OnFailure",
     "QueueEntrypoint",
     "QueueExecutionMode",
+    "QueueManagerId",
     "ScheduleId",
     "Slot",
 ]

--- a/test/integration/test_persistence_queries_sql.py
+++ b/test/integration/test_persistence_queries_sql.py
@@ -18,7 +18,7 @@ import pytest
 from pgqueuer.adapters.persistence.queries import Queries
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.models import CronExpressionEntrypoint, TracebackRecord
-from pgqueuer.domain.types import CronEntrypoint, CronExpression, QueueEntrypoint
+from pgqueuer.domain.types import CronEntrypoint, CronExpression, QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
@@ -29,8 +29,8 @@ async def test_dequeue_locking_race_single_job_one_picker(
     q = Queries(apgdriver)
 
     await q.enqueue(["ep"], [None], [0])
-    qm1_id = uuid.uuid4()
-    qm2_id = uuid.uuid4()
+    qm1_id = QueueManagerId(uuid.uuid4())
+    qm2_id = QueueManagerId(uuid.uuid4())
 
     async def dequeue_1() -> list:
         return await q.dequeue(
@@ -66,7 +66,7 @@ async def test_atomicity_dequeue_log_entry_created(
     q = Queries(apgdriver)
 
     jids = await q.enqueue(["ep"], [None], [0])
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     jobs = await q.dequeue(
         batch_size=1,
@@ -96,7 +96,7 @@ async def test_dedupe_constraint_partial_index(
     with pytest.raises(Exception):
         await q.enqueue(["ep"], [None], [0], dedupe_key=["k"], on_conflict="raise")
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await q.dequeue(
         batch_size=1,
         entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
@@ -147,7 +147,7 @@ async def test_stale_job_recovery_heartbeat_timeout(
 
     await q.enqueue(["ep"], [None], [0])
 
-    qm1_id = uuid.uuid4()
+    qm1_id = QueueManagerId(uuid.uuid4())
     jobs = await q.dequeue(
         batch_size=1,
         entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
@@ -161,7 +161,7 @@ async def test_stale_job_recovery_heartbeat_timeout(
 
     await asyncio.sleep(1.2)
 
-    qm2_id = uuid.uuid4()
+    qm2_id = QueueManagerId(uuid.uuid4())
     jobs2 = await q.dequeue(
         batch_size=1,
         entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(concurrency_limit=1)},
@@ -233,7 +233,7 @@ async def test_mark_job_cancellation(
     q = Queries(apgdriver)
 
     jids = await q.enqueue(["ep"], [None], [0])
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     jobs = await q.dequeue(
         batch_size=1,
@@ -260,7 +260,7 @@ async def test_traceback_jsonb_roundtrip(
     q = Queries(apgdriver)
 
     jids = await q.enqueue(["ep"], [None], [0])
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     jobs = await q.dequeue(
         batch_size=1,

--- a/test/test_concurrency_limit.py
+++ b/test/test_concurrency_limit.py
@@ -13,7 +13,7 @@ import pytest
 import pytest_asyncio
 
 from pgqueuer.db import AsyncpgDriver, Driver
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import Job
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import EntrypointExecutionParameter, Queries
@@ -232,7 +232,7 @@ async def test_concurrency_limit_holds_across_concurrent_dequeues(
             q.dequeue(
                 batch_size=concurrency_limit,
                 entrypoints={FETCH: EntrypointExecutionParameter(concurrency_limit)},
-                queue_manager_id=uuid.uuid4(),
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -282,7 +282,7 @@ async def test_concurrency_limit_holds_when_priority_arrives_mid_claim(
             q.dequeue(
                 batch_size=limit,
                 entrypoints={FETCH: EntrypointExecutionParameter(limit)},
-                queue_manager_id=uuid.uuid4(),
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -329,7 +329,7 @@ async def test_concurrency_limit_rollback_releases_capacity_for_the_other_worker
             q.dequeue(
                 batch_size=concurrency_limit,
                 entrypoints={FETCH: EntrypointExecutionParameter(concurrency_limit)},
-                queue_manager_id=uuid.uuid4(),
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -384,7 +384,7 @@ async def test_slot_race_does_not_lose_unlimited_jobs_in_the_same_batch(
             q.dequeue(
                 batch_size=10,
                 entrypoints=entrypoints,
-                queue_manager_id=uuid.uuid4(),
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=None,
                 heartbeat_timeout=timedelta(minutes=10),
             )
@@ -430,7 +430,7 @@ async def test_dequeue_assigns_capacity_slots(apgdriver: Driver) -> None:
             FETCH: EntrypointExecutionParameter(limit),
             QueueEntrypoint("loose"): EntrypointExecutionParameter(0),
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(minutes=10),
     )

--- a/test/test_dequeue_shapes.py
+++ b/test/test_dequeue_shapes.py
@@ -22,7 +22,7 @@ from pgqueuer import db, queries
 from pgqueuer.adapters.persistence import qb
 from pgqueuer.adapters.persistence.composer import ComposedQuery
 from pgqueuer.domain.settings import DBSettings
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 
 SNAPSHOT_DIR = Path(__file__).parent / "query_shapes"
 
@@ -44,7 +44,7 @@ def compose(
         batch_size=10,
         entrypoints=[QueueEntrypoint("fetch")],
         concurrency_limits=[concurrency_limit],
-        queue_manager_id=uuid.UUID(int=0),
+        queue_manager_id=QueueManagerId(uuid.UUID(int=0)),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -117,7 +117,7 @@ def test_dequeue_rejects_mismatched_concurrency_limits() -> None:
             batch_size=10,
             entrypoints=[QueueEntrypoint("a"), QueueEntrypoint("b")],
             concurrency_limits=[0],
-            queue_manager_id=uuid.UUID(int=0),
+            queue_manager_id=QueueManagerId(uuid.UUID(int=0)),
             global_concurrency_limit=None,
             heartbeat_timeout=timedelta(seconds=30),
         )
@@ -147,7 +147,7 @@ async def test_dequeue_shapes_respect_gates(
         entrypoints={
             QueueEntrypoint("fetch"): queries.EntrypointExecutionParameter(concurrency_limit)
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -171,12 +171,12 @@ async def test_minimal_shape_recovers_stale_jobs(apgdriver: db.Driver) -> None:
         heartbeat_timeout=timedelta(seconds=30),
     )
 
-    picked = await dequeue(queue_manager_id=uuid.uuid4())
+    picked = await dequeue(queue_manager_id=QueueManagerId(uuid.uuid4()))
     assert len(picked) == 2
 
     await apgdriver.execute(
         f"UPDATE {DBSettings().queue_table} SET heartbeat = NOW() - interval '1 hour'"
     )
 
-    recovered = await dequeue(queue_manager_id=uuid.uuid4())
+    recovered = await dequeue(queue_manager_id=QueueManagerId(uuid.uuid4()))
     assert sorted(j.id for j in recovered) == sorted(j.id for j in picked)

--- a/test/test_execute_after.py
+++ b/test/test_execute_after.py
@@ -9,7 +9,7 @@ from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core.applications import PgQueuer
 from pgqueuer.db import Driver
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.queries import EntrypointExecutionParameter, Queries
 
 
@@ -20,7 +20,7 @@ async def test_execute_after_default_is_now(apgdriver: Driver) -> None:
             await Queries(apgdriver).dequeue(
                 10,
                 {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -34,7 +34,7 @@ async def test_execute_after_default_is_now(apgdriver: Driver) -> None:
             await Queries(apgdriver).dequeue(
                 10,
                 {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -51,7 +51,7 @@ async def test_execute_after_zero(apgdriver: Driver) -> None:
             await Queries(apgdriver).dequeue(
                 10,
                 {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -68,7 +68,7 @@ async def test_execute_after_negative(apgdriver: Driver) -> None:
             await Queries(apgdriver).dequeue(
                 10,
                 {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
-                uuid.uuid4(),
+                QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             )
@@ -83,7 +83,7 @@ async def test_execute_after_1_second(apgdriver: Driver) -> None:
     before = await Queries(apgdriver).dequeue(
         10,
         {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -93,7 +93,7 @@ async def test_execute_after_1_second(apgdriver: Driver) -> None:
     after = await Queries(apgdriver).dequeue(
         10,
         {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -107,7 +107,7 @@ async def test_execute_after_updated_gt_execute_after(apgdriver: Driver) -> None
     after = await Queries(apgdriver).dequeue(
         10,
         {QueueEntrypoint("foo"): EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_hold_failed.py
+++ b/test/test_hold_failed.py
@@ -13,7 +13,7 @@ from pgqueuer.core.applications import PgQueuer
 from pgqueuer.core.executors import DatabaseRetryEntrypointExecutor
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode
+from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.queries import Queries
 
@@ -28,7 +28,7 @@ EP = EntrypointExecutionParameter(0)
 async def test_inmemory_hold_keeps_job(queries: InMemoryQueries) -> None:
     """on_failure='hold' keeps the job in the queue with status='failed'."""
     await queries.enqueue("ep", b"important-payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -49,7 +49,7 @@ async def test_inmemory_hold_keeps_job(queries: InMemoryQueries) -> None:
 async def test_inmemory_delete_removes_job(queries: InMemoryQueries) -> None:
     """Default on_failure='delete' removes the job from the queue."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -68,7 +68,7 @@ async def test_inmemory_mixed_batch(queries: InMemoryQueries) -> None:
         [b"hold-me", b"delete-me"],
         [1, 1],
     )
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -89,7 +89,7 @@ async def test_inmemory_mixed_batch(queries: InMemoryQueries) -> None:
 async def test_inmemory_failed_not_dequeued(queries: InMemoryQueries) -> None:
     """Failed jobs are not returned by dequeue."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -104,7 +104,7 @@ async def test_inmemory_failed_not_dequeued(queries: InMemoryQueries) -> None:
 async def test_inmemory_requeue_moves_to_queued(queries: InMemoryQueries) -> None:
     """requeue_jobs moves failed jobs back to queued."""
     await queries.enqueue("ep", b"payload", priority=5)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -125,7 +125,7 @@ async def test_inmemory_requeue_moves_to_queued(queries: InMemoryQueries) -> Non
 async def test_inmemory_requeue_resets_attempts(queries: InMemoryQueries) -> None:
     """Re-queued jobs have attempts reset to 0."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -151,7 +151,7 @@ async def test_inmemory_requeue_resets_attempts(queries: InMemoryQueries) -> Non
 async def test_inmemory_requeue_ignores_non_failed(queries: InMemoryQueries) -> None:
     """requeue_jobs only affects jobs with status='failed'."""
     await queries.enqueue("ep", b"payload", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -165,7 +165,7 @@ async def test_inmemory_list_failed_ordered_by_created(queries: InMemoryQueries)
     for i in range(3):
         await queries.enqueue("ep", f"job-{i}".encode(), priority=1)
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -183,7 +183,7 @@ async def test_inmemory_list_failed_respects_limit(queries: InMemoryQueries) -> 
     for i in range(5):
         await queries.enqueue("ep", f"job-{i}".encode(), priority=1)
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )
@@ -197,7 +197,7 @@ async def test_inmemory_list_failed_respects_limit(queries: InMemoryQueries) -> 
 async def test_inmemory_failed_releases_dedupe_key(queries: InMemoryQueries) -> None:
     """A held/failed job must release its dedupe_key so a new job can be enqueued."""
     await queries.enqueue("ep", b"first", priority=1, dedupe_key="unique-key")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10, {QueueEntrypoint("ep"): EP}, qm_id, None, heartbeat_timeout=timedelta(seconds=30)
     )

--- a/test/test_inmemory.py
+++ b/test/test_inmemory.py
@@ -11,7 +11,7 @@ import time_machine
 
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.domain.errors import DuplicateJobError
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 # ---------------------------------------------------------------------------
@@ -59,7 +59,7 @@ async def test_dedupe_key_rejects_duplicate(queries: InMemoryQueries) -> None:
 
 async def test_dedupe_key_freed_after_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, dedupe_key="dk1")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -140,7 +140,7 @@ async def test_dedupe_key_on_conflict_skip_no_log_for_skipped(
 
 async def test_dedupe_key_on_conflict_skip_freed_after_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, dedupe_key="dk1")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -161,7 +161,7 @@ async def test_dedupe_key_on_conflict_skip_freed_after_log(queries: InMemoryQuer
 
 async def test_dequeue_basic(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", b"data")
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -181,7 +181,7 @@ async def test_dequeue_priority_ordering(queries: InMemoryQueries) -> None:
         [b"lo", b"hi", b"med"],
         [1, 10, 5],
     )
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -196,7 +196,7 @@ async def test_dequeue_priority_ordering(queries: InMemoryQueries) -> None:
 
 async def test_dequeue_execute_after(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None, execute_after=timedelta(hours=1))
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -214,7 +214,7 @@ async def test_dequeue_serialized_dispatch(queries: InMemoryQueries) -> None:
         [None, None],
         [0, 0],
     )
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(1)}
 
     # First dequeue should get 1 job (concurrency_limit=1 = only one at a time)
@@ -232,7 +232,7 @@ async def test_dequeue_concurrency_limit(queries: InMemoryQueries) -> None:
         [None, None, None],
         [0, 0, 0],
     )
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(2)}
 
     jobs = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
@@ -248,7 +248,7 @@ async def test_dequeue_leaves_capacity_slot_unset(queries: InMemoryQueries) -> N
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(1)}
 
     (job,) = await queries.dequeue(
-        10, params, uuid.uuid4(), None, heartbeat_timeout=timedelta(seconds=30)
+        10, params, QueueManagerId(uuid.uuid4()), None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert job.slot is None
 
@@ -259,7 +259,7 @@ async def test_dequeue_global_concurrency_limit(queries: InMemoryQueries) -> Non
         [None, None, None],
         [0, 0, 0],
     )
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     jobs = await queries.dequeue(
@@ -276,7 +276,7 @@ async def test_dequeue_global_concurrency_limit(queries: InMemoryQueries) -> Non
 async def test_dequeue_retry_stale_picked(queries: InMemoryQueries) -> None:
     """Picked jobs with expired heartbeat should be retried."""
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     jobs = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
@@ -297,7 +297,7 @@ async def test_dequeue_retry_stale_picked(queries: InMemoryQueries) -> None:
 async def test_dequeue_stale_priority_beats_fresh_work(queries: InMemoryQueries) -> None:
     """A stale high-priority job outranks fresh lower-priority work (#684)."""
     await queries.enqueue("ep", b"stale-hi", priority=10)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     picked = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
@@ -326,7 +326,7 @@ async def test_dequeue_deferred_jobs_delivered_in_priority_order_when_due(
         execute_after=[timedelta(hours=1), timedelta(hours=1)],
     )
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     assert (
         await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
@@ -351,7 +351,7 @@ async def test_dequeue_redelivers_candidate_bumped_by_higher_priority(
         QueueEntrypoint("ep_a"): EntrypointExecutionParameter(0),
         QueueEntrypoint("ep_b"): EntrypointExecutionParameter(0),
     }
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     first = await queries.dequeue(1, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
     assert [j.payload for j in first] == [b"hi"]
@@ -363,7 +363,7 @@ async def test_dequeue_redelivers_candidate_bumped_by_higher_priority(
 async def test_retry_job_with_delay_defers_redelivery(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", b"x")
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     (job,) = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(hours=1))
     await queries.retry_job(job, timedelta(hours=1), None)
@@ -385,7 +385,7 @@ async def test_cancelled_queued_job_not_delivered(queries: InMemoryQueries) -> N
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        QueueManagerId(uuid.uuid4()),
         None,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -400,7 +400,7 @@ async def test_cancelled_deferred_job_not_delivered_when_due(queries: InMemoryQu
         jobs = await queries.dequeue(
             10,
             {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
-            uuid.uuid4(),
+            QueueManagerId(uuid.uuid4()),
             None,
             heartbeat_timeout=timedelta(seconds=30),
         )
@@ -417,7 +417,7 @@ async def test_clear_queue_filtered_then_reenqueue_same_entrypoint(
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        QueueManagerId(uuid.uuid4()),
         None,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -427,7 +427,7 @@ async def test_clear_queue_filtered_then_reenqueue_same_entrypoint(
 async def test_requeue_failed_job_dequeued_again(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", b"x")
     params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
 
     (job,) = await queries.dequeue(10, params, qm_id, None, heartbeat_timeout=timedelta(seconds=30))
     await queries.log_jobs([(job, "failed", None)])
@@ -444,14 +444,16 @@ async def test_requeue_failed_job_dequeued_again(queries: InMemoryQueries) -> No
 async def test_dequeue_empty_entrypoints(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
     jobs = await queries.dequeue(
-        10, {}, uuid.uuid4(), None, heartbeat_timeout=timedelta(seconds=30)
+        10, {}, QueueManagerId(uuid.uuid4()), None, heartbeat_timeout=timedelta(seconds=30)
     )
     assert len(jobs) == 0
 
 
 async def test_dequeue_batch_size_validation(queries: InMemoryQueries) -> None:
     with pytest.raises(ValueError):
-        await queries.dequeue(0, {}, uuid.uuid4(), None, heartbeat_timeout=timedelta(seconds=30))
+        await queries.dequeue(
+            0, {}, QueueManagerId(uuid.uuid4()), None, heartbeat_timeout=timedelta(seconds=30)
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -461,7 +463,7 @@ async def test_dequeue_batch_size_validation(queries: InMemoryQueries) -> None:
 
 async def test_log_jobs_removes_from_queue(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -477,7 +479,7 @@ async def test_log_jobs_removes_from_queue(queries: InMemoryQueries) -> None:
 
 async def test_log_jobs_adds_to_log(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -550,7 +552,7 @@ async def test_clear_queue_filtered(queries: InMemoryQueries) -> None:
 
 async def test_update_heartbeat(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -572,7 +574,7 @@ async def test_update_heartbeat(queries: InMemoryQueries) -> None:
 
 async def test_queue_log_lifecycle(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -596,7 +598,7 @@ async def test_queue_log_lifecycle(queries: InMemoryQueries) -> None:
 
 async def test_log_statistics(queries: InMemoryQueries) -> None:
     await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -618,7 +620,7 @@ async def test_log_statistics(queries: InMemoryQueries) -> None:
 
 async def test_job_status(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", None)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},

--- a/test/test_inmemory_integration.py
+++ b/test/test_inmemory_integration.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.core.applications import PgQueuer
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode
+from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode, QueueManagerId
 
 # ---------------------------------------------------------------------------
 # PgQueuer.in_memory() factory
@@ -79,7 +79,7 @@ async def test_performance_enqueue_dequeue() -> None:
 
     from pgqueuer.ports.repository import EntrypointExecutionParameter
 
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     t0 = time.perf_counter()
     dequeued = await queries.dequeue(
         n,

--- a/test/test_insights_service.py
+++ b/test/test_insights_service.py
@@ -16,7 +16,7 @@ from pgqueuer.core.insights import (
     sparkline_buckets,
 )
 from pgqueuer.domain import models
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
@@ -26,7 +26,7 @@ async def dequeue_all(queries: InMemoryQueries, entrypoint: str) -> list[models.
         entrypoints={
             QueueEntrypoint(entrypoint): EntrypointExecutionParameter(concurrency_limit=0)
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_listeners.py
+++ b/test/test_listeners.py
@@ -15,7 +15,7 @@ from pgqueuer.core.listeners import (
     initialize_notice_event_listener,
 )
 from pgqueuer.domain.settings import DBSettings
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import (
     AnyEvent,
     CancellationEvent,
@@ -157,7 +157,7 @@ async def test_emit_stable_changed_update(apgdriver: db.Driver) -> None:
     await Queries(apgdriver).dequeue(
         100,
         {QueueEntrypoint("test_emit_stable_changed_update"): EntrypointExecutionParameter(0)},
-        uuid.uuid4(),
+        QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -8,7 +8,7 @@ import pytest
 
 from pgqueuer import db, errors, models, queries
 from pgqueuer.domain.settings import DBSettings
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 
 
 @pytest.mark.parametrize("N", (1, 2, 64))
@@ -40,7 +40,7 @@ async def test_queries_next_jobs(
     while jobs := await q.dequeue(
         batch_size=10,
         entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -74,7 +74,7 @@ async def test_queries_next_jobs_concurrent(
         while jobs := await q.dequeue(
             entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(1)},
             batch_size=10,
-            queue_manager_id=uuid.uuid4(),
+            queue_manager_id=QueueManagerId(uuid.uuid4()),
             global_concurrency_limit=1000,
             heartbeat_timeout=timedelta(seconds=30),
         ):
@@ -120,7 +120,7 @@ async def test_move_job_log(
     while jobs := await q.dequeue(
         batch_size=10,
         entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -195,7 +195,7 @@ async def test_queue_priority(
     while next_jobs := await q.dequeue(
         entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=10,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -231,7 +231,7 @@ async def test_queue_priority_across_entrypoints(
             QueueEntrypoint(ep): queries.EntrypointExecutionParameter(0) for ep in entrypoints
         },
         batch_size=batch_size,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -255,7 +255,7 @@ async def test_stale_job_priority_beats_fresh_work(apgdriver: db.Driver) -> None
     picked = await q.dequeue(
         batch_size=10,
         entrypoints=entrypoints,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -268,7 +268,7 @@ async def test_stale_job_priority_beats_fresh_work(apgdriver: db.Driver) -> None
     recovered = await q.dequeue(
         batch_size=1,
         entrypoints=entrypoints,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=heartbeat_timeout,
     )
@@ -295,7 +295,7 @@ async def test_dequeue_caps_at_batch_size_across_entrypoints(
         entrypoints={
             QueueEntrypoint(ep): queries.EntrypointExecutionParameter(0) for ep in entrypoints
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -317,7 +317,7 @@ async def test_has_queued_work_existence_contract(apgdriver: db.Driver) -> None:
     picked = await q.dequeue(
         batch_size=10,
         entrypoints={QueueEntrypoint("foo"): queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -338,7 +338,7 @@ async def test_dequeue_caps_picks_to_entrypoint_remaining_slots(apgdriver: db.Dr
             QueueEntrypoint("tight"): queries.EntrypointExecutionParameter(2),
             QueueEntrypoint("loose"): queries.EntrypointExecutionParameter(0),
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -351,7 +351,7 @@ async def test_dequeue_caps_picks_to_entrypoint_remaining_slots(apgdriver: db.Dr
 async def test_dequeue_hard_caps_worker_budget(apgdriver: db.Driver) -> None:
     """A worker's picked total never exceeds global_concurrency_limit, even mid-batch."""
     q = queries.Queries(apgdriver)
-    queue_manager_id = uuid.uuid4()
+    queue_manager_id = QueueManagerId(uuid.uuid4())
 
     await q.enqueue(["fetch"] * 10, [None] * 10, [0] * 10)
 
@@ -382,7 +382,7 @@ async def test_eligible_queued_work_excludes_deferred(apgdriver: db.Driver) -> N
     picked = await q.dequeue(
         batch_size=10,
         entrypoints={QueueEntrypoint("foo"): queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -412,7 +412,7 @@ async def test_queue_retry_timer(
     while _ := await q.dequeue(
         batch_size=10,
         entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     ):
@@ -425,7 +425,7 @@ async def test_queue_retry_timer(
                 entrypoints={
                     QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)
                 },
-                queue_manager_id=uuid.uuid4(),
+                queue_manager_id=QueueManagerId(uuid.uuid4()),
                 global_concurrency_limit=1000,
                 heartbeat_timeout=timedelta(seconds=30),
             ),
@@ -440,7 +440,7 @@ async def test_queue_retry_timer(
     while next_jobs := await q.dequeue(
         entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=10,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=retry_timer,
     ):
@@ -466,7 +466,7 @@ async def test_queue_log_queued_picked_successful(
 
     # Pick all jobs
     picked_jobs = []
-    queue_manager_id = uuid.uuid4()
+    queue_manager_id = QueueManagerId(uuid.uuid4())
     while jobs := await q.dequeue(
         batch_size=10,
         entrypoints={
@@ -563,7 +563,7 @@ async def test_queue_log_queued_picked_exception(
 
     # Pick all jobs
     picked_jobs = []
-    queue_manager_id = uuid.uuid4()
+    queue_manager_id = QueueManagerId(uuid.uuid4())
     while jobs := await q.dequeue(
         batch_size=10,
         entrypoints={
@@ -851,7 +851,7 @@ async def test_log_statistics(
     jobs = await q.dequeue(
         entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=N,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -878,7 +878,7 @@ async def _log_n_successful(q: queries.Queries, N: int) -> None:
     jobs = await q.dequeue(
         entrypoints={QueueEntrypoint("placeholder"): queries.EntrypointExecutionParameter(0)},
         batch_size=N,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -981,7 +981,7 @@ async def test_enqueue_with_headers(apgdriver: db.Driver) -> None:
     jobs = await q.dequeue(
         entrypoints={QueueEntrypoint("header_task"): queries.EntrypointExecutionParameter(0)},
         batch_size=1,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_query_plan_regression.py
+++ b/test/test_query_plan_regression.py
@@ -10,7 +10,7 @@ import pytest
 
 from pgqueuer import db, queries
 from pgqueuer.adapters.persistence import qb
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 
 QUEUE_TABLE = qb.DBSettings().queue_table
 EP_PRIO_ID_IDX = f"{QUEUE_TABLE}_ep_prio_id_idx"
@@ -122,7 +122,7 @@ async def test_dequeue_uses_entrypoint_priority_index(
         batch_size=10,
         entrypoints=ENTRYPOINTS,
         concurrency_limits=[concurrency_limit] * len(ENTRYPOINTS),
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -184,7 +184,7 @@ async def test_dequeue_plan_scans_proportional_to_batch(
         batch_size=BATCH,
         entrypoints=eps,
         concurrency_limits=[concurrency_limit] * BULK_EPS,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -231,7 +231,7 @@ async def test_dequeue_gate_skips_saturated_entrypoints(
         batch_size=BATCH,
         entrypoints=eps,
         concurrency_limits=[1] * BULK_EPS,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=global_limit,
         heartbeat_timeout=timedelta(seconds=30),
     )
@@ -267,7 +267,7 @@ async def test_dequeue_plan_is_independent_of_concurrency_limit(
         batch_size=BATCH,
         entrypoints=eps,
         concurrency_limits=[concurrency_limit] * BULK_EPS,
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_retry_requeue.py
+++ b/test/test_retry_requeue.py
@@ -18,7 +18,7 @@ from pgqueuer.core.qm import QueueManager
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.errors import RetryException, RetryRequested
 from pgqueuer.domain.models import Context, Job, JobId, TracebackRecord
-from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode
+from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.queries import Queries
 
@@ -58,7 +58,7 @@ def test_retry_requested_is_retry_exception() -> None:
 
 async def test_inmemory_retry_job_updates_state(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", b"payload", priority=5)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -95,7 +95,7 @@ async def test_inmemory_retry_job_updates_state(queries: InMemoryQueries) -> Non
 
 async def test_inmemory_retry_job_writes_log_entry(queries: InMemoryQueries) -> None:
     ids = await queries.enqueue("ep", b"x", priority=0)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
@@ -572,7 +572,7 @@ async def test_retry_with_delay_prevents_immediate_dequeue(
 ) -> None:
     """A retried job with non-zero delay is not dequeued until execute_after passes."""
     await queries.enqueue("ep", b"x", priority=0)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     ep_params = {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)}
 
     jobs = await queries.dequeue(
@@ -656,7 +656,7 @@ async def test_inmemory_retry_job_nonexistent_is_noop(queries: InMemoryQueries) 
 async def test_inmemory_retry_job_stores_traceback(queries: InMemoryQueries) -> None:
     """Traceback record is stored as JSON in the retry log entry."""
     await queries.enqueue("ep", b"x", priority=0)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},

--- a/test/test_schema_support.py
+++ b/test/test_schema_support.py
@@ -17,7 +17,7 @@ from async_timeout import timeout
 from pgqueuer import db, queries
 from pgqueuer.core.listeners import initialize_notice_event_listener
 from pgqueuer.domain.settings import DBSettings
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import AnyEvent, Channel, CronExpressionEntrypoint
 from pgqueuer.queries import EntrypointExecutionParameter
 from pgqueuer.types import CronEntrypoint, CronExpression
@@ -41,7 +41,7 @@ async def enqueue_dequeue_round_trip(q: queries.Queries) -> None:
     jobs = await q.dequeue(
         batch_size=10,
         entrypoints={QueueEntrypoint("ep"): EntrypointExecutionParameter(0)},
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_sigterm_cancellation.py
+++ b/test/test_sigterm_cancellation.py
@@ -14,7 +14,7 @@ from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.core import buffers
 from pgqueuer.core.qm import QueueManager
 from pgqueuer.domain import models
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 EP_UNLIMITED = EntrypointExecutionParameter(0)
@@ -24,7 +24,7 @@ EP_SERIAL = EntrypointExecutionParameter(1)
 async def test_log_canceled_releases_picked_row(queries: InMemoryQueries) -> None:
     """log_jobs('canceled') removes the row and frees the slot."""
     await queries.enqueue("ep", b"x", priority=1)
-    qm_id = uuid.uuid4()
+    qm_id = QueueManagerId(uuid.uuid4())
     jobs = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EP_UNLIMITED},
@@ -154,7 +154,7 @@ async def test_stale_recovery_bypasses_concurrency_limit(
     """Stale rows are recoverable even when picked count == concurrency_limit."""
     heartbeat_timeout = timedelta(milliseconds=20)
 
-    qm_a = uuid.uuid4()
+    qm_a = QueueManagerId(uuid.uuid4())
     await queries.enqueue("ep", b"x", priority=1)
     jobs_a = await queries.dequeue(
         10,
@@ -168,7 +168,7 @@ async def test_stale_recovery_bypasses_concurrency_limit(
 
     await asyncio.sleep(heartbeat_timeout.total_seconds() * 3)
 
-    qm_b = uuid.uuid4()
+    qm_b = QueueManagerId(uuid.uuid4())
     jobs_b = await queries.dequeue(
         10,
         {QueueEntrypoint("ep"): EP_SERIAL},

--- a/test/test_strict_serialized.py
+++ b/test/test_strict_serialized.py
@@ -9,7 +9,7 @@ from itertools import chain
 import pytest
 
 from pgqueuer.db import Driver
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.models import Job
 from pgqueuer.qm import QueueManager
 from pgqueuer.queries import EntrypointExecutionParameter, Queries
@@ -142,7 +142,7 @@ async def test_no_jobs_processed_when_locked(
     picked_job = await queries.dequeue(
         1,
         {QueueEntrypoint("serialized_dispatch_true"): EntrypointExecutionParameter(1)},
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=1000,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -26,3 +26,12 @@ def test_queue_entrypoint_reexported_from_shims() -> None:
     from pgqueuer.domain import types
 
     assert m.QueueEntrypoint is t.QueueEntrypoint is types.QueueEntrypoint
+
+
+def test_queue_manager_id_reexported_from_shims() -> None:
+    """QueueManagerId reaches both compatibility shims."""
+    import pgqueuer.models as m
+    import pgqueuer.types as t
+    from pgqueuer.domain import types
+
+    assert m.QueueManagerId is t.QueueManagerId is types.QueueManagerId

--- a/test/test_web_integration.py
+++ b/test/test_web_integration.py
@@ -15,7 +15,7 @@ from pgqueuer.adapters.web.routes import create_web_router
 from pgqueuer.adapters.web.sse import Broadcaster
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain import models
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.queries import Queries
 
@@ -48,7 +48,7 @@ async def dequeue_all(queries: Queries, entrypoint: str) -> list[models.Job]:
         entrypoints={
             QueueEntrypoint(entrypoint): EntrypointExecutionParameter(concurrency_limit=0)
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )

--- a/test/test_web_routes.py
+++ b/test/test_web_routes.py
@@ -27,7 +27,7 @@ from pgqueuer.adapters.web.routes import (
 )
 from pgqueuer.adapters.web.sse import Broadcaster
 from pgqueuer.domain import models
-from pgqueuer.domain.types import QueueEntrypoint
+from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
@@ -56,7 +56,7 @@ async def dequeue_all(queries: InMemoryQueries, entrypoint: str) -> list[models.
         entrypoints={
             QueueEntrypoint(entrypoint): EntrypointExecutionParameter(concurrency_limit=0)
         },
-        queue_manager_id=uuid.uuid4(),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
         global_concurrency_limit=None,
         heartbeat_timeout=timedelta(seconds=30),
     )


### PR DESCRIPTION
Split from #783 (one PR per new type).

## Summary

`QueueManagerId = NewType("QueueManagerId", uuid.UUID)` in `pgqueuer/domain/types.py`, re-exported from `pgqueuer.types` and `pgqueuer.models`. Applied to `Job.queue_manager_id`, `StaleJob`, `ActiveWorker`, `QueueManager.queue_manager_id`, the `dequeue` port and `QueryQueueBuilder.build_dequeue_query()`, so a worker id cannot be confused with the health-check event id or any other UUID in the same code.

## Compatibility

Typing-only; runtime value is still a `uuid.UUID`. Code calling `dequeue()` or `build_dequeue_query()` directly with a bare `uuid.uuid4()` needs `QueueManagerId(uuid.uuid4())` to pass mypy. Noted in RELEASE.md.

## Tests

- Existing call sites in 17 test files wrapped mechanically; shim re-export test added.
- Ran `test_types`, `test_inmemory`, `test_queries`, `test_dequeue_shapes`, `test_execute_after`: 157 passed. `ruff`, `lint-imports`, `mypy --no-incremental` clean.

## Docs

RELEASE.md (v1.4.0 Added/Changed), `design/README.md`, `ports-and-adapters.md`.
