### PR TITLE
test: reuse one maintenance connection for per-test databases

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import os
 import uuid
 from typing import Any, AsyncGenerator, Generator
@@ -10,9 +11,10 @@ import asyncpg
 import psycopg
 import pytest
 import pytest_asyncio
+from psycopg import sql
 
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
-from pgqueuer.db import AsyncpgDriver, AsyncpgPoolDriver
+from pgqueuer.db import AsyncpgDriver
 from pgqueuer.queries import Queries
 
 try:  # pragma: no cover - uvloop not installed on Windows
@@ -189,39 +191,73 @@ async def postgres_container() -> AsyncGenerator[str, None]:
         yield running.get_connection_url()
 
 
-@pytest.fixture(scope="session")
-async def migrated_db(postgres_container: str) -> AsyncGenerator[str, None]:
-    """Ensure the database is migrated before running tests."""
-
-    parent = f"parent_{uuid.uuid4().hex}"
-
-    async with asyncpg.create_pool(dsn=build_dsn_for(postgres_container, "/postgres")) as pool:
-        await pool.execute(f"CREATE DATABASE {parent}")
-
-    async with asyncpg.create_pool(dsn=build_dsn_for(postgres_container, f"/{parent}")) as pool:
-        await Queries(AsyncpgPoolDriver(pool)).install()
-
-    yield build_dsn_for(postgres_container, f"/{parent}")
-
-
 def build_dsn_for(base_url: str, path: str) -> str:
     """Build a DSN for the specified path."""
     return urlunparse(urlparse(base_url)._replace(path=path))
 
 
-@pytest_asyncio.fixture(scope="function")
-async def dsn(migrated_db: str) -> AsyncGenerator[str, None]:
-    parent = urlparse(migrated_db).path.strip("/")
+@dataclasses.dataclass(frozen=True)
+class MaintenanceDb:
+    """One long-lived connection to the ``postgres`` maintenance database.
+
+    Only CREATE DATABASE / DROP DATABASE run here. Sync psycopg on purpose:
+    a sync connection is not tied to any asyncio loop, so a single
+    session-scoped connection can serve every test's function-scoped loop.
+    Before this, each test opened a 10-connection asyncpg pool just to run
+    these two statements (~190ms per test, ~45s of CI wall time).
+    """
+
+    conn: psycopg.Connection[Any]
+
+    def create_database(self, name: str, *, template: str | None = None) -> None:
+        stmt = sql.SQL("CREATE DATABASE {}").format(sql.Identifier(name))
+        if template is not None:
+            stmt += sql.SQL(" TEMPLATE {}").format(sql.Identifier(template))
+        self.conn.execute(stmt)
+
+    def drop_database(self, name: str) -> None:
+        # FORCE terminates backends a test may have left open. The drop itself
+        # keeps the 1 GB tmpfs data dir bounded: every clone copies the
+        # template (~8 MiB), so a worker would run out of space mid-suite.
+        stmt = sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(sql.Identifier(name))
+        self.conn.execute(stmt)
+
+
+@pytest.fixture(scope="session")
+def maintenance_db(postgres_container: str) -> Generator[MaintenanceDb, None, None]:
+    dsn = build_dsn_for(postgres_container, "/postgres")
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        yield MaintenanceDb(conn)
+
+
+@pytest.fixture(scope="session")
+async def migrated_db(
+    postgres_container: str,
+    maintenance_db: MaintenanceDb,
+) -> AsyncGenerator[str, None]:
+    """Create the template database and install the pgqueuer schema into it once."""
+    template = f"parent_{uuid.uuid4().hex}"
+    maintenance_db.create_database(template)
+
+    dsn = build_dsn_for(postgres_container, f"/{template}")
+    conn = await asyncpg.connect(dsn=dsn)
+    try:
+        await Queries(AsyncpgDriver(conn)).install()
+    finally:
+        await conn.close()
+
+    yield dsn
+
+
+@pytest.fixture
+def dsn(migrated_db: str, maintenance_db: MaintenanceDb) -> Generator[str, None, None]:
+    """A fresh database per test, cloned from the migrated template."""
+    template = urlparse(migrated_db).path.strip("/")
     child = f"test_{uuid.uuid4().hex}"
 
-    async with asyncpg.create_pool(dsn=build_dsn_for(migrated_db, path="/postgres")) as pool:
-        # Create a short-lived test db from the template dbname on the container
-        await pool.execute(f"CREATE DATABASE {child} TEMPLATE {parent}")
-
-        yield build_dsn_for(migrated_db, path=f"/{child}")
-
-        # Clean up the test db
-        await pool.execute(f'DROP DATABASE IF EXISTS "{child}" WITH (FORCE)')
+    maintenance_db.create_database(child, template=template)
+    yield build_dsn_for(migrated_db, f"/{child}")
+    maintenance_db.drop_database(child)
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,9 +11,9 @@ import asyncpg
 import psycopg
 import pytest
 import pytest_asyncio
-from psycopg import sql
 
 from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
+from pgqueuer.core.tm import TaskManager
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.queries import Queries
 
@@ -198,46 +198,55 @@ def build_dsn_for(base_url: str, path: str) -> str:
 
 @dataclasses.dataclass(frozen=True)
 class MaintenanceDb:
-    """One long-lived connection to the ``postgres`` maintenance database.
+    """CREATE / DROP DATABASE against the ``postgres`` maintenance database.
 
-    Only CREATE DATABASE / DROP DATABASE run here. Sync psycopg on purpose:
-    a sync connection is not tied to any asyncio loop, so a single
-    session-scoped connection can serve every test's function-scoped loop.
-    Before this, each test opened a 10-connection asyncpg pool just to run
+    Opened once per xdist worker and lives on pytest-asyncio's session loop.
+    Tests never touch it: the fixtures below run on the session loop too and
+    hand each test a plain DSN string, so nothing crosses between event loops.
+
+    Before this, every test opened a 10-connection asyncpg pool just to run
     these two statements (~190ms per test, ~45s of CI wall time).
     """
 
-    conn: psycopg.Connection[Any]
+    pool: asyncpg.Pool
+    background: TaskManager
 
-    def create_database(self, name: str, *, template: str | None = None) -> None:
-        stmt = sql.SQL("CREATE DATABASE {}").format(sql.Identifier(name))
+    async def create_database(self, name: str, *, template: str | None = None) -> None:
+        stmt = f'CREATE DATABASE "{name}"'
         if template is not None:
-            stmt += sql.SQL(" TEMPLATE {}").format(sql.Identifier(template))
-        self.conn.execute(stmt)
+            stmt += f' TEMPLATE "{template}"'
+        await self.pool.execute(stmt)
 
-    def drop_database(self, name: str) -> None:
-        # FORCE terminates backends a test may have left open. The drop itself
-        # keeps the 1 GB tmpfs data dir bounded: every clone copies the
-        # template (~8 MiB), so a worker would run out of space mid-suite.
-        stmt = sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(sql.Identifier(name))
-        self.conn.execute(stmt)
+    def drop_database_in_background(self, name: str) -> None:
+        # Not awaited: the task runs while the next test sets up, and the
+        # session fixture gathers whatever is left at exit.
+        # FORCE terminates backends a test may have left open. Dropping at all
+        # keeps the 1 GB tmpfs data dir bounded: each clone copies the ~8 MiB
+        # template, so a worker would run out of space mid-suite.
+        stmt = f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)'
+        self.background.add(asyncio.create_task(self.pool.execute(stmt)))
 
 
-@pytest.fixture(scope="session")
-def maintenance_db(postgres_container: str) -> Generator[MaintenanceDb, None, None]:
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def maintenance_db(postgres_container: str) -> AsyncGenerator[MaintenanceDb, None]:
     dsn = build_dsn_for(postgres_container, "/postgres")
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        yield MaintenanceDb(conn)
+    # Two connections: one creates the next test's database while the other
+    # drops the previous one. asyncpg rejects concurrent work on one connection.
+    async with (
+        asyncpg.create_pool(dsn, min_size=2, max_size=2) as pool,
+        TaskManager() as background,
+    ):
+        yield MaintenanceDb(pool, background)
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
 async def migrated_db(
     postgres_container: str,
     maintenance_db: MaintenanceDb,
 ) -> AsyncGenerator[str, None]:
     """Create the template database and install the pgqueuer schema into it once."""
     template = f"parent_{uuid.uuid4().hex}"
-    maintenance_db.create_database(template)
+    await maintenance_db.create_database(template)
 
     dsn = build_dsn_for(postgres_container, f"/{template}")
     conn = await asyncpg.connect(dsn=dsn)
@@ -249,15 +258,19 @@ async def migrated_db(
     yield dsn
 
 
-@pytest.fixture
-def dsn(migrated_db: str, maintenance_db: MaintenanceDb) -> Generator[str, None, None]:
-    """A fresh database per test, cloned from the migrated template."""
+@pytest_asyncio.fixture(loop_scope="session")
+async def dsn(migrated_db: str, maintenance_db: MaintenanceDb) -> AsyncGenerator[str, None]:
+    """A fresh database per test, cloned from the migrated template.
+
+    Runs on the session loop so it can share the maintenance connections.
+    The test itself runs on its own function loop and only sees the DSN.
+    """
     template = urlparse(migrated_db).path.strip("/")
     child = f"test_{uuid.uuid4().hex}"
 
-    maintenance_db.create_database(child, template=template)
+    await maintenance_db.create_database(child, template=template)
     yield build_dsn_for(migrated_db, f"/{child}")
-    maintenance_db.drop_database(child)
+    maintenance_db.drop_database_in_background(child)
 
 
 @pytest_asyncio.fixture(scope="function")


### PR DESCRIPTION
## Problem

The `dsn` fixture created an asyncpg pool per test (default `min_size=10`) to run two statements, `CREATE DATABASE ... TEMPLATE` and `DROP DATABASE`. Ten connection handshakes at ~20ms each cost ~190ms per test. 506 tests use the fixture, so that is roughly 45s of the 217s CI pytest wall on 2 xdist workers.

## Fix

- `MaintenanceDb`: frozen dataclass holding a two-connection asyncpg pool to the `postgres` maintenance database plus a `TaskManager`. `create_database` is awaited. `drop_database_in_background` queues `DROP DATABASE ... WITH (FORCE)` as a task and returns.
- `maintenance_db` session fixture, `loop_scope="session"`, one pool per xdist worker. The `TaskManager` gathers any leftover drops at session exit, then the pool closes.
- `migrated_db` creates the template through it and installs the schema over a single `asyncpg.connect` instead of a pool.
- `dsn` stays async but runs with `loop_scope="session"`: await create, yield the DSN string, queue the drop.

Why the loop scoping: pytest-asyncio 1.2.0 runs session fixtures on a session loop and tests on function loops, and asyncpg connections are bound to the loop that created them. Everything that touches the pool runs on the session loop. Tests run on their own loop and only ever see a DSN string, so nothing crosses loops.

Two pool connections because asyncpg rejects concurrent work on one connection: one creates the next test's database while the other drops the previous one.

Drop kept on evidence: template database is 7.7 MiB, and 253 clones per worker would overflow the 1 GiB tmpfs data dir around clone 132. `FORCE` also terminates backends a test may have left open.

## Evidence

Measured locally with a `pytest_fixture_setup` hookwrapper plugin under `--setup-only`, then normal runs of the same files.

| measure | before | after |
|---|---|---|
| `dsn` fixture mean | 177ms | 9ms |
| `apgdriver` fixture mean | 21ms | 16ms |
| setup total, 7 sample files | 32.4s | 6.7s |

Background drops keep up: a throwaway test that counted `test_*` databases across 8 consecutive `dsn` tests saw exactly 1 at every point.

Remaining setup cost is the 2.4s container start per worker plus the real asyncpg handshake in `apgdriver`.

## Verification

- 435 passed, 15 skipped on `test_queries`, `test_completion`, `test_retry`, `test_hold_failed`, `test_execute_after`, `test_qm`, `test_inmemory`, `test_connections`, `test_sync_queries`, `test_drivers`, `test_pgqueuer`
- No "attached to a different loop" or "Task exception was never retrieved" warnings
- `ruff check`, `ruff format --check`, `mypy` strict clean
- No test files changed. Isolation unchanged: one fresh database per test cloned from the migrated template.
