### PR TITLE
refactor(typing): import domain types from pgqueuer.domain.types

### DIFF
--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -219,7 +219,7 @@ async def display_stats(log_stats: list[models.LogStatistics]) -> None:
 
 async def display_pg_channel(
     connection: Driver,
-    channel: models.Channel,
+    channel: types.Channel,
 ) -> None:
     queue = asyncio.Queue[models.AnyEvent]()
     await listeners.initialize_notice_event_listener(
@@ -463,7 +463,7 @@ def listen(
 ) -> None:
     async def run() -> None:
         async with yield_queries(ctx, qb.DBSettings()) as q:
-            await display_pg_channel(q.driver, models.Channel(channel))
+            await display_pg_channel(q.driver, types.Channel(channel))
 
     asyncio_run(run())
 
@@ -565,7 +565,7 @@ def schedules(
     async def run_async() -> None:
         async with yield_queries(ctx, qb.DBSettings()) as q:
             if remove:
-                schedule_ids = {models.ScheduleId(int(x)) for x in remove if x.isdigit()}
+                schedule_ids = {types.ScheduleId(int(x)) for x in remove if x.isdigit()}
                 schedule_names = {types.CronEntrypoint(x) for x in remove if not x.isdigit()}
                 await q.delete_schedule(schedule_ids, schedule_names)
             await display_schedule(await q.peek_schedule())

--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -18,7 +18,7 @@ from typing_extensions import assert_never
 from pgqueuer.adapters.inmemory.driver import InMemoryDriver
 from pgqueuer.adapters.persistence import qb, query_helpers
 from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
-from pgqueuer.domain import errors, models
+from pgqueuer.domain import errors, models, types
 from pgqueuer.domain.models import utc_now
 from pgqueuer.domain.types import (
     CronEntrypoint,
@@ -449,7 +449,7 @@ class InMemoryQueries:
         job_status: list[
             tuple[
                 models.Job,
-                models.JOB_STATUS,
+                types.JOB_STATUS,
                 models.TracebackRecord | None,
             ]
         ],
@@ -647,9 +647,9 @@ class InMemoryQueries:
     async def job_status(
         self,
         ids: list[JobId],
-    ) -> list[tuple[JobId, models.JOB_STATUS]]:
+    ) -> list[tuple[JobId, types.JOB_STATUS]]:
         id_set = {int(jid) for jid in ids}
-        latest: dict[int, models.JOB_STATUS] = {}
+        latest: dict[int, types.JOB_STATUS] = {}
         for entry in reversed(self._log):
             jid = entry["job_id"]
             if jid in id_set and jid not in latest:
@@ -993,7 +993,7 @@ class InMemoryQueries:
         self,
         limit: int = 50,
         offset: int = 0,
-        statuses: list[models.JOB_STATUS] | None = None,
+        statuses: list[types.JOB_STATUS] | None = None,
         entrypoints: list[str] | None = None,
     ) -> list[models.Job]:
         rows = [
@@ -1044,7 +1044,7 @@ class InMemoryQueries:
         if dk is not None:
             self._dedupe_index.pop(dk, None)
 
-    async def emit_table_changed(self, operation: models.OPERATIONS) -> None:
+    async def emit_table_changed(self, operation: types.OPERATIONS) -> None:
         event = models.TableChangedEvent(
             channel=self.qbq.settings.channel,
             sent_at=utc_now(),

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -211,7 +211,7 @@ class Queries:
         headers: dict[str, str] | None = None,
         *,
         on_conflict: Literal["raise"] = "raise",
-    ) -> list[models.JobId]: ...
+    ) -> list[types.JobId]: ...
 
     @overload
     async def enqueue(
@@ -224,7 +224,7 @@ class Queries:
         headers: dict[str, str] | None = None,
         *,
         on_conflict: Literal["skip"],
-    ) -> list[models.JobId | None]: ...
+    ) -> list[types.JobId | None]: ...
 
     @overload
     async def enqueue(
@@ -237,7 +237,7 @@ class Queries:
         headers: list[dict[str, str] | None] | None = None,
         *,
         on_conflict: Literal["raise"] = "raise",
-    ) -> list[models.JobId]: ...
+    ) -> list[types.JobId]: ...
 
     @overload
     async def enqueue(
@@ -250,7 +250,7 @@ class Queries:
         headers: list[dict[str, str] | None] | None = None,
         *,
         on_conflict: Literal["skip"],
-    ) -> list[models.JobId | None]: ...
+    ) -> list[types.JobId | None]: ...
 
     async def enqueue(
         self,
@@ -262,7 +262,7 @@ class Queries:
         headers: dict[str, str] | list[dict[str, str] | None] | None = None,
         *,
         on_conflict: types.OnConflict = "raise",
-    ) -> list[models.JobId] | list[models.JobId | None]:
+    ) -> list[types.JobId] | list[types.JobId | None]:
         """Insert one or many jobs. Scalar args = single insert; lists = batch insert.
 
         With ``on_conflict="skip"``, dedupe-key duplicates are skipped instead of
@@ -298,7 +298,7 @@ class Queries:
         if on_conflict == "skip":
             return query_helpers.scatter_ids_by_ordinal(rows, len(normed_params.entrypoint))
         if on_conflict == "raise":
-            return [models.JobId(row["id"]) for row in rows]
+            return [types.JobId(row["id"]) for row in rows]
         assert_never(on_conflict)
 
     async def queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
@@ -320,7 +320,7 @@ class Queries:
         else:
             await self.driver.execute(self.qbq.build_truncate_queue_query())
 
-    async def mark_job_as_cancelled(self, ids: list[models.JobId]) -> None:
+    async def mark_job_as_cancelled(self, ids: list[types.JobId]) -> None:
         """Log *ids* as 'canceled' and emit a cancellation NOTIFY."""
         await asyncio.gather(
             self.driver.execute(
@@ -344,7 +344,7 @@ class Queries:
         job_status: list[
             tuple[
                 models.Job,
-                models.JOB_STATUS,
+                types.JOB_STATUS,
                 models.TracebackRecord | None,
             ]
         ],
@@ -382,7 +382,7 @@ class Queries:
             traceback_record.model_dump_json() if traceback_record else None,
         )
 
-    async def requeue_jobs(self, ids: list[models.JobId]) -> None:
+    async def requeue_jobs(self, ids: list[types.JobId]) -> None:
         """Move failed jobs back to queued status for reprocessing.
 
         Resets attempts to 0 and sets execute_after to NOW().
@@ -448,7 +448,7 @@ class Queries:
         rows = await self.driver.fetch(query.sql, *query.args)
         return [models.LogStatistics.model_validate(row) for row in rows]
 
-    async def notify_job_cancellation(self, ids: list[models.JobId]) -> None:
+    async def notify_job_cancellation(self, ids: list[types.JobId]) -> None:
         """Emit a ``cancellation_event`` NOTIFY carrying *ids*."""
         await self.driver.notify(
             self.qbq.settings.channel,
@@ -472,7 +472,7 @@ class Queries:
             ).model_dump_json(),
         )
 
-    async def update_heartbeat(self, job_ids: list[models.JobId]) -> None:
+    async def update_heartbeat(self, job_ids: list[types.JobId]) -> None:
         await self.driver.execute(
             self.qbq.build_update_heartbeat_query(),
             list(set(job_ids)),
@@ -503,13 +503,13 @@ class Queries:
             )
         ]
 
-    async def set_schedule_queued(self, ids: set[models.ScheduleId]) -> None:
+    async def set_schedule_queued(self, ids: set[types.ScheduleId]) -> None:
         await self.driver.execute(
             self.qbs.build_set_schedule_queued_query(),
             list(ids),
         )
 
-    async def update_schedule_heartbeat(self, ids: set[models.ScheduleId]) -> None:
+    async def update_schedule_heartbeat(self, ids: set[types.ScheduleId]) -> None:
         await self.driver.execute(
             self.qbs.build_update_schedule_heartbeat(),
             list(ids),
@@ -525,7 +525,7 @@ class Queries:
 
     async def delete_schedule(
         self,
-        ids: set[models.ScheduleId],
+        ids: set[types.ScheduleId],
         entrypoints: set[CronEntrypoint],
     ) -> None:
         await self.driver.execute(
@@ -547,8 +547,8 @@ class Queries:
 
     async def job_status(
         self,
-        ids: list[models.JobId],
-    ) -> list[tuple[models.JobId, models.JOB_STATUS]]:
+        ids: list[types.JobId],
+    ) -> list[tuple[types.JobId, types.JOB_STATUS]]:
         return [
             (row["job_id"], row["status"])
             for row in await self.driver.fetch(self.qbq.build_job_status_query(), ids)
@@ -640,7 +640,7 @@ class Queries:
         self,
         limit: int = 50,
         offset: int = 0,
-        statuses: list[models.JOB_STATUS] | None = None,
+        statuses: list[types.JOB_STATUS] | None = None,
         entrypoints: list[str] | None = None,
     ) -> list[models.Job]:
         """Paginated queue rows, optionally filtered by status and entrypoint."""
@@ -653,13 +653,13 @@ class Queries:
         )
         return [models.Job.model_validate(row) for row in rows]
 
-    async def queue_job_by_id(self, id: models.JobId) -> models.Job | None:
+    async def queue_job_by_id(self, id: types.JobId) -> models.Job | None:
         rows = await self.driver.fetch(self.qbq.build_queue_job_by_id_query(), id)
         return models.Job.model_validate(rows[0]) if rows else None
 
     async def job_log_history(
         self,
-        id: models.JobId,
+        id: types.JobId,
         limit: int = 100,
     ) -> list[models.Log]:
         """State transitions of one job, oldest first."""
@@ -708,7 +708,7 @@ class SyncQueries:
         headers: dict[str, str] | None = None,
         *,
         on_conflict: Literal["raise"] = "raise",
-    ) -> list[models.JobId]: ...
+    ) -> list[types.JobId]: ...
 
     @overload
     def enqueue(
@@ -721,7 +721,7 @@ class SyncQueries:
         headers: dict[str, str] | None = None,
         *,
         on_conflict: Literal["skip"],
-    ) -> list[models.JobId | None]: ...
+    ) -> list[types.JobId | None]: ...
 
     @overload
     def enqueue(
@@ -734,7 +734,7 @@ class SyncQueries:
         headers: list[dict[str, str] | None] | None = None,
         *,
         on_conflict: Literal["raise"] = "raise",
-    ) -> list[models.JobId]: ...
+    ) -> list[types.JobId]: ...
 
     @overload
     def enqueue(
@@ -747,7 +747,7 @@ class SyncQueries:
         headers: list[dict[str, str] | None] | None = None,
         *,
         on_conflict: Literal["skip"],
-    ) -> list[models.JobId | None]: ...
+    ) -> list[types.JobId | None]: ...
 
     def enqueue(
         self,
@@ -759,7 +759,7 @@ class SyncQueries:
         headers: dict[str, str] | list[dict[str, str] | None] | None = None,
         *,
         on_conflict: types.OnConflict = "raise",
-    ) -> list[models.JobId] | list[models.JobId | None]:
+    ) -> list[types.JobId] | list[types.JobId | None]:
         """Insert one or many jobs. Scalar args = single insert; lists = batch insert.
 
         With ``on_conflict="skip"``, dedupe-key duplicates are skipped instead of
@@ -801,7 +801,7 @@ class SyncQueries:
         if on_conflict == "skip":
             return query_helpers.scatter_ids_by_ordinal(rows, len(normed_params.entrypoint))
         if on_conflict == "raise":
-            return [models.JobId(row["id"]) for row in rows]
+            return [types.JobId(row["id"]) for row in rows]
         assert_never(on_conflict)
 
     def queue_size(self) -> list[models.QueueStatistics]:

--- a/pgqueuer/adapters/web/routes.py
+++ b/pgqueuer/adapters/web/routes.py
@@ -27,7 +27,7 @@ from pgqueuer.core.insights import (
     InsightsService,
     QueueManagementService,
 )
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 
 WEB_DIR = Path(__file__).parent
 STATIC_DIR = WEB_DIR / "static"
@@ -46,7 +46,7 @@ WINDOWS = {
     "24h": timedelta(hours=24),
 }
 
-ACTIVE_STATUSES: tuple[models.JOB_STATUS, ...] = ("queued", "picked")
+ACTIVE_STATUSES: tuple[types.JOB_STATUS, ...] = ("queued", "picked")
 
 PAGE_SIZE = 50
 
@@ -220,7 +220,7 @@ def parse_window(name: str) -> timedelta:
     return WINDOWS.get(name, WINDOWS["1h"])
 
 
-def parse_statuses(status: str) -> list[models.JOB_STATUS]:
+def parse_statuses(status: str) -> list[types.JOB_STATUS]:
     """Held-failed jobs are owned by the failures page; the browser only shows active rows."""
     return [s for s in ACTIVE_STATUSES if s == status] or list(ACTIVE_STATUSES)
 
@@ -428,8 +428,8 @@ def create_web_router(  # noqa: C901
         job_id: int,
         insights: InsightsService = Depends(get_insights),
     ) -> HTMLResponse:
-        job = await insights.job(models.JobId(job_id))
-        history = await insights.job_history(models.JobId(job_id))
+        job = await insights.job(types.JobId(job_id))
+        history = await insights.job_history(types.JobId(job_id))
         if job is None and not history:
             raise HTTPException(status_code=404, detail=f"job {job_id} not found")
         return render(
@@ -528,7 +528,7 @@ def create_web_router(  # noqa: C901
         job_id: int,
         management: QueueManagementService = Depends(get_management),
     ) -> Response:
-        await management.cancel([models.JobId(job_id)])
+        await management.cancel([types.JobId(job_id)])
         return Response(status_code=204, headers={"HX-Refresh": "true"})
 
     @router.post(
@@ -541,7 +541,7 @@ def create_web_router(  # noqa: C901
         management: QueueManagementService = Depends(get_management),
     ) -> Response:
         form = await request.form()
-        ids = [models.JobId(int(raw)) for raw in form.getlist("ids") if isinstance(raw, str)]
+        ids = [types.JobId(int(raw)) for raw in form.getlist("ids") if isinstance(raw, str)]
         if ids:
             await management.requeue(ids)
         return Response(status_code=204, headers={"HX-Refresh": "true"})

--- a/pgqueuer/adapters/web/sse.py
+++ b/pgqueuer/adapters/web/sse.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator
 from datetime import timedelta
 
 from pgqueuer.core.listeners import initialize_notice_event_listener
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 from pgqueuer.ports.driver import Driver
 
 KEEPALIVE_SECONDS = 15.0
@@ -24,7 +24,7 @@ class Broadcaster:
     """
 
     driver: Driver
-    channel: models.Channel
+    channel: types.Channel
     debounce: timedelta = dataclasses.field(default=timedelta(milliseconds=250))
 
     subscribers: set[asyncio.Queue[str]] = dataclasses.field(default_factory=set, init=False)

--- a/pgqueuer/core/applications.py
+++ b/pgqueuer/core/applications.py
@@ -19,9 +19,8 @@ from pgqueuer.core.executors import (
 )
 from pgqueuer.core.qm import QueueManager
 from pgqueuer.core.sm import SchedulerManager
-from pgqueuer.domain.models import Channel
 from pgqueuer.domain.settings import DBSettings
-from pgqueuer.domain.types import OnFailure, QueueExecutionMode
+from pgqueuer.domain.types import Channel, OnFailure, QueueExecutionMode
 from pgqueuer.ports import RepositoryPort
 from pgqueuer.ports.driver import Driver
 

--- a/pgqueuer/core/buffers.py
+++ b/pgqueuer/core/buffers.py
@@ -12,7 +12,7 @@ from typing import Generic, Protocol, TypeVar
 from typing_extensions import Self
 
 from pgqueuer.core import logconfig
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 
 T = TypeVar("T")
 
@@ -129,7 +129,7 @@ class JobLogSink(Protocol):
         job_status: list[
             tuple[
                 models.Job,
-                models.JOB_STATUS,
+                types.JOB_STATUS,
                 models.TracebackRecord | None,
             ]
         ],
@@ -139,7 +139,7 @@ class JobLogSink(Protocol):
 class HeartbeatSink(Protocol):
     """Narrow port: accepts batched heartbeat updates."""
 
-    async def update_heartbeat(self, job_ids: list[models.JobId]) -> None: ...
+    async def update_heartbeat(self, job_ids: list[types.JobId]) -> None: ...
 
 
 @dataclasses.dataclass
@@ -147,7 +147,7 @@ class JobStatusLogBuffer(
     TimedOverflowBuffer[
         tuple[
             models.Job,
-            models.JOB_STATUS,
+            types.JOB_STATUS,
             models.TracebackRecord | None,
         ]
     ]
@@ -161,7 +161,7 @@ class JobStatusLogBuffer(
         items: list[
             tuple[
                 models.Job,
-                models.JOB_STATUS,
+                types.JOB_STATUS,
                 models.TracebackRecord | None,
             ]
         ],
@@ -170,10 +170,10 @@ class JobStatusLogBuffer(
 
 
 @dataclasses.dataclass
-class HeartbeatBuffer(TimedOverflowBuffer[models.JobId]):
+class HeartbeatBuffer(TimedOverflowBuffer[types.JobId]):
     """Batched buffer for heartbeat updates."""
 
     repository: HeartbeatSink
 
-    async def flush_items(self, items: list[models.JobId]) -> None:
+    async def flush_items(self, items: list[types.JobId]) -> None:
         await self.repository.update_heartbeat(items)

--- a/pgqueuer/core/completion.py
+++ b/pgqueuer/core/completion.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from itertools import chain
 
 from pgqueuer.core import tm
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.ports.driver import Driver
 from pgqueuer.ports.repository import QueueRepositoryPort
@@ -42,7 +42,7 @@ class CompletionWatcher:
         default_factory=lambda: timedelta(milliseconds=50),
         repr=False,
     )
-    waiters: defaultdict[models.JobId, list[asyncio.Future[models.JOB_STATUS]]] = field(
+    waiters: defaultdict[types.JobId, list[asyncio.Future[types.JOB_STATUS]]] = field(
         default_factory=lambda: defaultdict(list),
         init=False,
         repr=False,
@@ -81,9 +81,9 @@ class CompletionWatcher:
         await self.task_manager.gather_tasks()
         return False
 
-    def wait_for(self, jid: models.JobId) -> asyncio.Future[models.JOB_STATUS]:
+    def wait_for(self, jid: types.JobId) -> asyncio.Future[types.JOB_STATUS]:
         """Return a Future that resolves when *jid* reaches a terminal state."""
-        fut: asyncio.Future[models.JOB_STATUS] = asyncio.get_running_loop().create_future()
+        fut: asyncio.Future[types.JOB_STATUS] = asyncio.get_running_loop().create_future()
         self.waiters[jid].append(fut)
         self._schedule_refresh_waiters()
         return fut
@@ -138,6 +138,6 @@ class CompletionWatcher:
                         if not waiter.done():
                             waiter.set_result(status)
 
-    def _is_terminal(self, status: models.JOB_STATUS) -> bool:
+    def _is_terminal(self, status: types.JOB_STATUS) -> bool:
         """Return ``True`` if *status* is terminal."""
         return status in ("canceled", "deleted", "exception", "successful")

--- a/pgqueuer/core/heartbeat.py
+++ b/pgqueuer/core/heartbeat.py
@@ -8,14 +8,14 @@ from datetime import timedelta
 from typing_extensions import Self
 
 from pgqueuer.core import buffers, logconfig
-from pgqueuer.domain import models
+from pgqueuer.domain import types
 
 
 @dataclass
 class Heartbeat:
     """Async context manager that sends periodic heartbeats to a buffer."""
 
-    job_id: models.JobId
+    job_id: types.JobId
     interval: timedelta
     buffer: buffers.HeartbeatBuffer
     shutdown: asyncio.Event = field(

--- a/pgqueuer/core/insights.py
+++ b/pgqueuer/core/insights.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import dataclasses
 from datetime import timedelta
 
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 from pgqueuer.ports.repository import InsightsRepositoryPort, QueueRepositoryPort
 
 DEFAULT_WINDOW = timedelta(hours=1)
@@ -75,15 +75,15 @@ class InsightsService:
         self,
         limit: int = 50,
         offset: int = 0,
-        statuses: list[models.JOB_STATUS] | None = None,
+        statuses: list[types.JOB_STATUS] | None = None,
         entrypoints: list[str] | None = None,
     ) -> list[models.Job]:
         return await self.repository.browse_queue(limit, offset, statuses, entrypoints)
 
-    async def job(self, id: models.JobId) -> models.Job | None:
+    async def job(self, id: types.JobId) -> models.Job | None:
         return await self.repository.queue_job_by_id(id)
 
-    async def job_history(self, id: models.JobId) -> list[models.Log]:
+    async def job_history(self, id: types.JobId) -> list[models.Log]:
         return await self.repository.job_log_history(id)
 
     async def schedules(self) -> list[models.Schedule]:
@@ -202,10 +202,10 @@ class QueueManagementService:
 
     repository: QueueRepositoryPort
 
-    async def requeue(self, ids: list[models.JobId]) -> None:
+    async def requeue(self, ids: list[types.JobId]) -> None:
         """Move held ``'failed'`` jobs back to queued; other statuses are unaffected."""
         await self.repository.requeue_jobs(ids)
 
-    async def cancel(self, ids: list[models.JobId]) -> None:
+    async def cancel(self, ids: list[types.JobId]) -> None:
         """Cancel jobs: logs ``'canceled'`` and notifies in-flight workers."""
         await self.repository.mark_job_as_cancelled(ids)

--- a/pgqueuer/core/listeners.py
+++ b/pgqueuer/core/listeners.py
@@ -49,7 +49,7 @@ class EventRouter:
 def default_event_router(
     *,
     notice_event_queue: PGNoticeEventListener,
-    canceled: MutableMapping[models.JobId, models.Context],
+    canceled: MutableMapping[types.JobId, models.Context],
     pending_health_check: MutableMapping[
         types.HealthCheckId, asyncio.Future[models.HealthCheckEvent]
     ],
@@ -78,7 +78,7 @@ def default_event_router(
 
 async def initialize_notice_event_listener(
     connection: Driver,
-    channel: models.Channel,
+    channel: types.Channel,
     event_handler: Callable[[models.AnyEvent], None],
 ) -> None:
     """Add a listener on *channel* and funnel parsed events to *event_handler*."""

--- a/pgqueuer/core/qm.py
+++ b/pgqueuer/core/qm.py
@@ -37,8 +37,8 @@ class QueueManager:
     """
 
     queries: RepositoryPort
-    channel: models.Channel = dataclasses.field(
-        default=models.Channel(DBSettings().channel),
+    channel: types.Channel = dataclasses.field(
+        default=types.Channel(DBSettings().channel),
     )
 
     shutdown: asyncio.Event = dataclasses.field(
@@ -66,7 +66,7 @@ class QueueManager:
     tracer: tracing.TracingProtocol | None = None
 
     # Per job.
-    job_context: dict[models.JobId, models.Context] = dataclasses.field(
+    job_context: dict[types.JobId, models.Context] = dataclasses.field(
         init=False,
         default_factory=dict,
     )
@@ -143,7 +143,7 @@ class QueueManager:
                     timeout=interval.total_seconds() * random.uniform(0.8, 1.2),
                 )
 
-    def get_context(self, job_id: models.JobId) -> models.Context:
+    def get_context(self, job_id: types.JobId) -> models.Context:
         return self.job_context[job_id]
 
     def register_executor(

--- a/pgqueuer/core/sm.py
+++ b/pgqueuer/core/sm.py
@@ -10,7 +10,7 @@ from typing import Callable
 import croniter
 
 from pgqueuer.core import executors, logconfig, tm
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 from pgqueuer.domain.types import ScheduleId
 from pgqueuer.ports import RepositoryPort
 
@@ -56,8 +56,8 @@ class SchedulerManager:
         if not croniter.croniter.is_valid(expression):
             raise ValueError(f"Invalid cron expression: {expression}")
 
-        expression = models.CronExpression(" ".join(croniter.croniter(expression).expressions))
-        entrypoint = models.CronEntrypoint(entrypoint)
+        expression = types.CronExpression(" ".join(croniter.croniter(expression).expressions))
+        entrypoint = types.CronEntrypoint(entrypoint)
 
         key = models.CronExpressionEntrypoint(
             entrypoint=entrypoint,

--- a/pgqueuer/domain/settings.py
+++ b/pgqueuer/domain/settings.py
@@ -13,7 +13,7 @@ from typing import Callable, Literal
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from pgqueuer.domain.models import Channel
+from pgqueuer.domain.types import Channel
 
 IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 

--- a/pgqueuer/ports/repository.py
+++ b/pgqueuer/ports/repository.py
@@ -6,7 +6,7 @@ import dataclasses
 from datetime import timedelta
 from typing import Literal, Protocol, overload
 
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import (
     CronEntrypoint,
@@ -55,7 +55,7 @@ class QueueRepositoryPort(Protocol):
         headers: dict[str, str] | None = None,
         *,
         on_conflict: Literal["raise"] = "raise",
-    ) -> list[models.JobId]: ...
+    ) -> list[types.JobId]: ...
 
     @overload
     async def enqueue(
@@ -68,7 +68,7 @@ class QueueRepositoryPort(Protocol):
         headers: dict[str, str] | None = None,
         *,
         on_conflict: Literal["skip"],
-    ) -> list[models.JobId | None]: ...
+    ) -> list[types.JobId | None]: ...
 
     @overload
     async def enqueue(
@@ -81,7 +81,7 @@ class QueueRepositoryPort(Protocol):
         headers: list[dict[str, str] | None] | None = None,
         *,
         on_conflict: Literal["raise"] = "raise",
-    ) -> list[models.JobId]: ...
+    ) -> list[types.JobId]: ...
 
     @overload
     async def enqueue(
@@ -94,7 +94,7 @@ class QueueRepositoryPort(Protocol):
         headers: list[dict[str, str] | None] | None = None,
         *,
         on_conflict: Literal["skip"],
-    ) -> list[models.JobId | None]: ...
+    ) -> list[types.JobId | None]: ...
 
     async def enqueue(
         self,
@@ -106,14 +106,14 @@ class QueueRepositoryPort(Protocol):
         headers: dict[str, str] | list[dict[str, str] | None] | None = None,
         *,
         on_conflict: OnConflict = "raise",
-    ) -> list[models.JobId] | list[models.JobId | None]: ...
+    ) -> list[types.JobId] | list[types.JobId | None]: ...
 
     async def log_jobs(
         self,
         job_status: list[
             tuple[
                 models.Job,
-                models.JOB_STATUS,
+                types.JOB_STATUS,
                 models.TracebackRecord | None,
             ]
         ],
@@ -126,7 +126,7 @@ class QueueRepositoryPort(Protocol):
         traceback_record: models.TracebackRecord | None,
     ) -> None: ...
 
-    async def requeue_jobs(self, ids: list[models.JobId]) -> None: ...
+    async def requeue_jobs(self, ids: list[types.JobId]) -> None: ...
 
     async def list_failed_jobs(
         self, limit: int = 100, order: SortOrder = "DESC"
@@ -136,9 +136,9 @@ class QueueRepositoryPort(Protocol):
 
     async def queue_size(self) -> list[models.QueueStatistics]: ...
 
-    async def mark_job_as_cancelled(self, ids: list[models.JobId]) -> None: ...
+    async def mark_job_as_cancelled(self, ids: list[types.JobId]) -> None: ...
 
-    async def update_heartbeat(self, job_ids: list[models.JobId]) -> None: ...
+    async def update_heartbeat(self, job_ids: list[types.JobId]) -> None: ...
 
     async def queued_work(self, entrypoints: list[QueueEntrypoint]) -> int: ...
 
@@ -160,8 +160,8 @@ class QueueRepositoryPort(Protocol):
 
     async def job_status(
         self,
-        ids: list[models.JobId],
-    ) -> list[tuple[models.JobId, models.JOB_STATUS]]: ...
+        ids: list[types.JobId],
+    ) -> list[tuple[types.JobId, types.JOB_STATUS]]: ...
 
     @property
     def driver(self) -> Driver: ...
@@ -219,15 +219,15 @@ class InsightsRepositoryPort(Protocol):
         self,
         limit: int = 50,
         offset: int = 0,
-        statuses: list[models.JOB_STATUS] | None = None,
+        statuses: list[types.JOB_STATUS] | None = None,
         entrypoints: list[str] | None = None,
     ) -> list[models.Job]: ...
 
-    async def queue_job_by_id(self, id: models.JobId) -> models.Job | None: ...
+    async def queue_job_by_id(self, id: types.JobId) -> models.Job | None: ...
 
     async def job_log_history(
         self,
-        id: models.JobId,
+        id: types.JobId,
         limit: int = 100,
     ) -> list[models.Log]: ...
 
@@ -251,15 +251,15 @@ class ScheduleRepositoryPort(Protocol):
         entrypoints: dict[models.CronExpressionEntrypoint, timedelta],
     ) -> list[models.Schedule]: ...
 
-    async def set_schedule_queued(self, ids: set[models.ScheduleId]) -> None: ...
+    async def set_schedule_queued(self, ids: set[types.ScheduleId]) -> None: ...
 
-    async def update_schedule_heartbeat(self, ids: set[models.ScheduleId]) -> None: ...
+    async def update_schedule_heartbeat(self, ids: set[types.ScheduleId]) -> None: ...
 
     async def peek_schedule(self) -> list[models.Schedule]: ...
 
     async def delete_schedule(
         self,
-        ids: set[models.ScheduleId],
+        ids: set[types.ScheduleId],
         entrypoints: set[CronEntrypoint],
     ) -> None: ...
 
@@ -269,7 +269,7 @@ class ScheduleRepositoryPort(Protocol):
 class NotificationPort(Protocol):
     """Abstraction over PostgreSQL NOTIFY for inter-process signalling."""
 
-    async def notify_job_cancellation(self, ids: list[models.JobId]) -> None: ...
+    async def notify_job_cancellation(self, ids: list[types.JobId]) -> None: ...
 
     async def notify_health_check(self, health_check_event_id: HealthCheckId) -> None: ...
 

--- a/test/test_insights_service.py
+++ b/test/test_insights_service.py
@@ -15,7 +15,7 @@ from pgqueuer.core.insights import (
     clamp_window,
     sparkline_buckets,
 )
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
@@ -128,7 +128,7 @@ class TestInsightsService:
         assert job is not None and job.payload == b"payload"
         history = await service.job_history(job_id)
         assert [h.status for h in history] == ["queued"]
-        assert await service.job(models.JobId(999_999)) is None
+        assert await service.job(types.JobId(999_999)) is None
 
     async def test_browse_queue_filters(self, queries: InMemoryQueries) -> None:
         await queries.enqueue(["ep_a", "ep_b"], [None, None], [0, 0])

--- a/test/test_retry_requeue.py
+++ b/test/test_retry_requeue.py
@@ -17,8 +17,8 @@ from pgqueuer.core.executors import (
 from pgqueuer.core.qm import QueueManager
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.errors import RetryException, RetryRequested
-from pgqueuer.domain.models import Context, Job, JobId, TracebackRecord
-from pgqueuer.domain.types import QueueEntrypoint, QueueExecutionMode, QueueManagerId
+from pgqueuer.domain.models import Context, Job, TracebackRecord
+from pgqueuer.domain.types import JobId, QueueEntrypoint, QueueExecutionMode, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.queries import Queries
 

--- a/test/test_web_routes.py
+++ b/test/test_web_routes.py
@@ -26,7 +26,7 @@ from pgqueuer.adapters.web.routes import (
     throughput_chart_svg,
 )
 from pgqueuer.adapters.web.sse import Broadcaster
-from pgqueuer.domain import models
+from pgqueuer.domain import models, types
 from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
@@ -395,7 +395,7 @@ class TestChartSlots:
         return datetime(2026, 7, 19, 12, 0, tzinfo=timezone.utc)
 
     def bucket(
-        self, minutes_ago: int, status: models.JOB_STATUS, count: int
+        self, minutes_ago: int, status: types.JOB_STATUS, count: int
     ) -> models.ThroughputBucket:
         return models.ThroughputBucket(
             bucket=self.now() - timedelta(minutes=minutes_ago),

--- a/test/windows/test_cli_event_loop_policy.py
+++ b/test/windows/test_cli_event_loop_policy.py
@@ -10,7 +10,7 @@ from pgqueuer.adapters.cli import cli
 
 
 def test_off_windows_delegates_to_asyncio_run(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cli.sys, "platform", "linux")
+    monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(cli, "HAS_UVLOOP", False)
 
     calls: list[Coroutine[object, object, None]] = []
@@ -19,7 +19,7 @@ def test_off_windows_delegates_to_asyncio_run(monkeypatch: pytest.MonkeyPatch) -
         calls.append(coro)
         coro.close()
 
-    monkeypatch.setattr(cli.asyncio, "run", fake_run)
+    monkeypatch.setattr(asyncio, "run", fake_run)
 
     async def noop() -> None:
         return None
@@ -32,7 +32,7 @@ def test_off_windows_delegates_to_asyncio_run(monkeypatch: pytest.MonkeyPatch) -
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="asyncio.Runner is 3.11+")
 def test_windows_path_runs_under_selector_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(sys, "platform", "win32")
 
     captured: list[type[asyncio.AbstractEventLoop]] = []
 
@@ -51,8 +51,8 @@ def test_windows_path_runs_under_selector_event_loop(monkeypatch: pytest.MonkeyP
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_python_310_path_installs_selector_policy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cli.sys, "platform", "win32")
-    monkeypatch.setattr(cli.sys, "version_info", (3, 10, 0))
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0))
 
     seen: list[asyncio.AbstractEventLoopPolicy] = []
 
@@ -60,7 +60,7 @@ def test_python_310_path_installs_selector_policy(monkeypatch: pytest.MonkeyPatc
         seen.append(asyncio.get_event_loop_policy())
         coro.close()
 
-    monkeypatch.setattr(cli.asyncio, "run", fake_run)
+    monkeypatch.setattr(asyncio, "run", fake_run)
 
     original_policy = asyncio.get_event_loop_policy()
     asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())


### PR DESCRIPTION
Part 1/9 of the strict-mypy series. First in the stack; the series ends with the strict config PR so CI stays green throughout.

Reference JobId, JOB_STATUS, ScheduleId, Channel and the cron types
through pgqueuer.domain.types instead of pgqueuer.domain.models, which
only imported them. This is what mypy's no_implicit_reexport requires
and keeps domain/types.py the single home for the domain primitives.
No runtime change.
