### PR TITLE
refactor(typing): type the driver boundary with object

### DIFF
--- a/pgqueuer/adapters/drivers/asyncpg.py
+++ b/pgqueuer/adapters/drivers/asyncpg.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable
 
 from typing_extensions import Self
 
@@ -37,15 +37,15 @@ class AsyncpgDriver(Driver):
     async def fetch(
         self,
         query: str,
-        *args: Any,
-    ) -> list[dict]:
+        *args: object,
+    ) -> list[dict[str, object]]:
         async with self._lock:
             return [dict(x) for x in await self._connection.fetch(query, *args)]
 
     async def execute(
         self,
         query: str,
-        *args: Any,
+        *args: object,
     ) -> str:
         async with self._lock:
             return await self._connection.execute(query, *args)
@@ -106,14 +106,14 @@ class AsyncpgPoolDriver(Driver):
     async def fetch(
         self,
         query: str,
-        *args: Any,
-    ) -> list[dict]:
+        *args: object,
+    ) -> list[dict[str, object]]:
         return [dict(x) for x in await self._pool.fetch(query, *args)]
 
     async def execute(
         self,
         query: str,
-        *args: Any,
+        *args: object,
     ) -> str:
         return await self._pool.execute(query, *args)
 

--- a/pgqueuer/adapters/drivers/psycopg.py
+++ b/pgqueuer/adapters/drivers/psycopg.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable
 
 from typing_extensions import Self
 
@@ -59,8 +59,8 @@ class PsycopgDriver(Driver):
     async def fetch(
         self,
         query: str,
-        *args: Any,
-    ) -> list[dict]:
+        *args: object,
+    ) -> list[dict[str, object]]:
         from psycopg import AsyncRawCursor
         from psycopg.rows import dict_row
 
@@ -71,7 +71,7 @@ class PsycopgDriver(Driver):
     async def execute(
         self,
         query: str,
-        *args: Any,
+        *args: object,
     ) -> str:
         from psycopg import AsyncRawCursor
 
@@ -146,8 +146,8 @@ class SyncPsycopgDriver(SyncDriver):
     def fetch(
         self,
         query: str,
-        *args: Any,
-    ) -> list[dict]:
+        *args: object,
+    ) -> list[dict[str, object]]:
         from psycopg import RawCursor
         from psycopg.rows import dict_row
 

--- a/pgqueuer/adapters/inmemory/driver.py
+++ b/pgqueuer/adapters/inmemory/driver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from typing import Any, Callable
+from typing import Callable
 
 from typing_extensions import Self
 
@@ -23,10 +23,10 @@ class InMemoryDriver:
         self._tm = TaskManager()
         self._listeners: dict[str, list[Callable[[str], None]]] = defaultdict(list)
 
-    async def fetch(self, query: str, *args: Any) -> list[dict]:
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
         raise NotImplementedError("InMemoryDriver does not support SQL fetch")
 
-    async def execute(self, query: str, *args: Any) -> str:
+    async def execute(self, query: str, *args: object) -> str:
         raise NotImplementedError("InMemoryDriver does not support SQL execute")
 
     async def add_listener(

--- a/pgqueuer/adapters/persistence/queries.py
+++ b/pgqueuer/adapters/persistence/queries.py
@@ -13,7 +13,7 @@ from pydantic_core import to_json
 from typing_extensions import assert_never
 
 from pgqueuer.adapters.persistence import qb, query_helpers, sqlstate
-from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
+from pgqueuer.adapters.persistence.query_helpers import cell, merge_tracing_headers
 from pgqueuer.domain import errors, models, types
 from pgqueuer.domain.types import CronEntrypoint, HealthCheckId, QueueEntrypoint, QueueManagerId
 from pgqueuer.ports import tracing
@@ -115,7 +115,7 @@ class Queries:
         )
         assert len(rows) == 1
         (row,) = rows
-        return row["exists"]
+        return cell(row, "exists", bool)
 
     async def table_has_index(self, table: str, index: str) -> bool:
         """Return True if *index* exists on *table*."""
@@ -126,7 +126,7 @@ class Queries:
         )
         assert len(rows) == 1
         (row,) = rows
-        return row["exists"]
+        return cell(row, "exists", bool)
 
     async def has_user_defined_enum(self, key: str, enum: str) -> bool:
         """Check if a value exists in a user-defined ENUM type."""
@@ -140,7 +140,7 @@ class Queries:
         )
         assert len(rows) == 1
         (row,) = rows
-        return row["exists"]
+        return cell(row, "exists", bool)
 
     async def has_function(self, function: str) -> bool:
         rows = await self.driver.fetch(
@@ -149,7 +149,7 @@ class Queries:
         )
         assert len(rows) == 1
         (row,) = rows
-        return row["exists"]
+        return cell(row, "exists", bool)
 
     async def has_trigger(self, trigger: str) -> bool:
         rows = await self.driver.fetch(
@@ -158,7 +158,7 @@ class Queries:
         )
         assert len(rows) == 1
         (row,) = rows
-        return row["exists"]
+        return cell(row, "exists", bool)
 
     async def dequeue(
         self,
@@ -298,17 +298,17 @@ class Queries:
         if on_conflict == "skip":
             return query_helpers.scatter_ids_by_ordinal(rows, len(normed_params.entrypoint))
         if on_conflict == "raise":
-            return [types.JobId(row["id"]) for row in rows]
+            return [types.JobId(cell(row, "id", int)) for row in rows]
         assert_never(on_conflict)
 
     async def queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
         rows = await self.driver.fetch(self.qbq.build_has_queued_work(), entrypoints)
-        return rows[0]["queued_work"] if rows else 0
+        return cell(rows[0], "queued_work", int) if rows else 0
 
     async def eligible_queued_work(self, entrypoints: list[QueueEntrypoint]) -> int:
         """Like ``queued_work`` but counting only jobs whose ``execute_after`` has passed."""
         rows = await self.driver.fetch(self.qbq.build_has_eligible_queued_work(), entrypoints)
-        return rows[0]["queued_work"] if rows else 0
+        return cell(rows[0], "queued_work", int) if rows else 0
 
     async def clear_queue(self, entrypoint: str | list[str] | None = None) -> None:
         """Delete jobs; restrict to *entrypoint* when given, else truncate."""
@@ -549,15 +549,18 @@ class Queries:
         self,
         ids: list[types.JobId],
     ) -> list[tuple[types.JobId, types.JOB_STATUS]]:
+        rows = await self.driver.fetch(self.qbq.build_job_status_query(), ids)
         return [
-            (row["job_id"], row["status"])
-            for row in await self.driver.fetch(self.qbq.build_job_status_query(), ids)
+            (row.job_id, row.status)
+            for row in (models.JobStatusRow.model_validate(r) for r in rows)
         ]
 
     async def next_deferred_eta(self, entrypoints: list[QueueEntrypoint]) -> timedelta | None:
         """Return time until the soonest deferred job becomes eligible, or None."""
         rows = await self.driver.fetch(self.qbq.build_next_deferred_eta_query(), entrypoints)
-        return rows[0]["eta"] if rows and rows[0]["eta"] is not None else None
+        if not rows or rows[0]["eta"] is None:
+            return None
+        return cell(rows[0], "eta", timedelta)
 
     async def queue_age(self) -> list[models.QueueAgeStats]:
         """Backlog age of queued jobs per entrypoint, oldest first."""
@@ -674,7 +677,7 @@ class Queries:
 
     async def unaggregated_log_count(self) -> int:
         rows = await self.driver.fetch(self.qbq.build_unaggregated_log_count_query())
-        return rows[0]["unaggregated"] if rows else 0
+        return cell(rows[0], "unaggregated", int) if rows else 0
 
     async def schema_info(self) -> list[models.TableInfo]:
         """Size, row estimate, and persistence mode of each PgQueuer table."""
@@ -801,7 +804,7 @@ class SyncQueries:
         if on_conflict == "skip":
             return query_helpers.scatter_ids_by_ordinal(rows, len(normed_params.entrypoint))
         if on_conflict == "raise":
-            return [types.JobId(row["id"]) for row in rows]
+            return [types.JobId(cell(row, "id", int)) for row in rows]
         assert_never(on_conflict)
 
     def queue_size(self) -> list[models.QueueStatistics]:

--- a/pgqueuer/adapters/persistence/query_helpers.py
+++ b/pgqueuer/adapters/persistence/query_helpers.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Generator, Sequence
+from typing import Generator, Sequence, TypeVar
 
 from pgqueuer.domain.types import JobId
+
+T = TypeVar("T")
 
 
 @dataclass
@@ -56,8 +59,16 @@ def normalize_enqueue_params(
     )
 
 
+def cell(row: Mapping[str, object], key: str, kind: type[T]) -> T:
+    """Return ``row[key]`` checked to be *kind*; driver rows arrive untyped."""
+    value = row[key]
+    if not isinstance(value, kind):
+        raise TypeError(f"column {key!r}: expected {kind.__name__}, got {type(value).__name__}")
+    return value
+
+
 def scatter_ids_by_ordinal(
-    rows: list[dict],
+    rows: list[dict[str, object]],
     count: int,
 ) -> list[JobId | None]:
     """Place each inserted row's id at its 1-based input ordinal.
@@ -67,7 +78,7 @@ def scatter_ids_by_ordinal(
     """
     ids: list[JobId | None] = [None] * count
     for row in rows:
-        ids[row["ord"] - 1] = JobId(row["id"])
+        ids[cell(row, "ord", int) - 1] = JobId(cell(row, "id", int))
     return ids
 
 

--- a/pgqueuer/domain/models.py
+++ b/pgqueuer/domain/models.py
@@ -134,6 +134,13 @@ class Log(BaseModel):
     aggregated: bool
 
 
+class JobStatusRow(BaseModel):
+    """One ``(job_id, status)`` pair from a job-status lookup."""
+
+    job_id: JobId
+    status: JOB_STATUS
+
+
 class QueueStatistics(BaseModel):
     """Per-(entrypoint, priority, status) job count snapshot."""
 

--- a/pgqueuer/ports/driver.py
+++ b/pgqueuer/ports/driver.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Callable, Protocol, runtime_checkable
 
 from typing_extensions import Self
 
@@ -56,14 +56,14 @@ class Driver(Protocol):
     async def fetch(
         self,
         query: str,
-        *args: Any,
-    ) -> list[dict]:
+        *args: object,
+    ) -> list[dict[str, object]]:
         raise NotImplementedError
 
     async def execute(
         self,
         query: str,
-        *args: Any,
+        *args: object,
     ) -> str:
         raise NotImplementedError
 
@@ -102,6 +102,6 @@ class SyncDriver(Protocol):
     def fetch(
         self,
         query: str,
-        *args: Any,
-    ) -> list[dict]:
+        *args: object,
+    ) -> list[dict[str, object]]:
         raise NotImplementedError

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -13,6 +13,7 @@ import async_timeout
 from pgqueuer import db
 from pgqueuer.adapters.persistence import qb
 from pgqueuer.adapters.persistence.queries import Queries
+from pgqueuer.adapters.persistence.query_helpers import cell
 from pgqueuer.models import Job
 from pgqueuer.ports import RepositoryPort
 
@@ -44,7 +45,7 @@ async def id_data_type(driver: db.Driver, table: str, schema: str | None = None)
           AND column_name = 'id';""",
         table,
     )
-    return rows[0]["data_type"]
+    return cell(rows[0], "data_type", str)
 
 
 async def simulate_legacy_serial(driver: db.Driver, table: str, schema: str | None = None) -> None:

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -7,6 +7,7 @@ import psycopg
 import pytest
 
 from pgqueuer import db, errors, models, queries
+from pgqueuer.adapters.persistence.query_helpers import cell
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
 
@@ -872,7 +873,7 @@ async def test_log_statistics(
 
 async def _unaggregated_count(q: queries.Queries) -> int:
     rows = await q.driver.fetch(q.qbq.build_unaggregated_log_count_query())
-    return int(rows[0]["unaggregated"])
+    return cell(rows[0], "unaggregated", int)
 
 
 async def _log_n_successful(q: queries.Queries, N: int) -> None:
@@ -902,7 +903,7 @@ async def test_aggregate_logs_populates_statistics_without_read(apgdriver: db.Dr
     assert await _unaggregated_count(q) == 0
     stats_query = q.qbq.build_log_statistics_query(limit=None, last=None)
     stats = await q.driver.fetch(stats_query.sql, *stats_query.args)
-    assert sum(int(r["count"]) for r in stats) == 3 * N  # queued + picked + successful
+    assert sum(cell(r, "count", int) for r in stats) == 3 * N  # queued + picked + successful
 
 
 async def test_aggregate_logs_advisory_lock_skips_when_held(
@@ -972,7 +973,7 @@ async def test_upgrade_from_legacy_composite_index_still_aggregates(
     assert await _unaggregated_count(q) == 0
     stats_query = q.qbq.build_log_statistics_query(limit=None, last=None)
     stats = await q.driver.fetch(stats_query.sql, *stats_query.args)
-    assert sum(int(r["count"]) for r in stats) == 3 * N  # queued + picked + successful
+    assert sum(cell(r, "count", int) for r in stats) == 3 * N  # queued + picked + successful
 
 
 async def test_enqueue_with_headers(apgdriver: db.Driver) -> None:

--- a/test/test_query_helpers.py
+++ b/test/test_query_helpers.py
@@ -5,8 +5,11 @@ from datetime import timedelta
 from itertools import count
 from typing import Any
 
+import pytest
+
 from pgqueuer.adapters.persistence.query_helpers import (
     NormedEnqueueParam,
+    cell,
     normalize_enqueue_params,
     scatter_ids_by_ordinal,
 )
@@ -257,3 +260,17 @@ def test_scatter_matches_simulated_insert_semantics() -> None:
         active = {key for key in "abc" if rng.random() < 0.4}
         inserted, expected = simulate_enqueue(keys, active)
         assert scatter_ids_by_ordinal(inserted, len(keys)) == expected
+
+
+def test_cell_returns_value_of_expected_type() -> None:
+    row: dict[str, object] = {"exists": True, "queued_work": 3}
+    assert cell(row, "exists", bool) is True
+    assert cell(row, "queued_work", int) == 3
+
+
+def test_cell_rejects_wrong_type_and_missing_key() -> None:
+    row: dict[str, object] = {"eta": "not-a-timedelta"}
+    with pytest.raises(TypeError, match="column 'eta': expected timedelta, got str"):
+        cell(row, "eta", timedelta)
+    with pytest.raises(KeyError):
+        cell(row, "missing", int)

--- a/test/test_query_plan_regression.py
+++ b/test/test_query_plan_regression.py
@@ -32,14 +32,15 @@ def _flatten(node: dict[str, Any]) -> list[dict[str, Any]]:
     return out
 
 
-async def _plan_nodes(driver: db.Driver, sql: str, *args: object) -> list[dict]:
+async def _plan_nodes(driver: db.Driver, sql: str, *args: object) -> list[dict[str, Any]]:
     rows = await driver.fetch("EXPLAIN (FORMAT JSON) " + sql, *args)
     raw = rows[0]["QUERY PLAN"]
-    plan = json.loads(raw) if isinstance(raw, str) else raw
+    assert isinstance(raw, str)
+    plan = json.loads(raw)
     return _flatten(plan[0]["Plan"])
 
 
-async def _analyze_nodes(driver: db.Driver, sql: str, *args: object) -> list[dict]:
+async def _analyze_nodes(driver: db.Driver, sql: str, *args: object) -> list[dict[str, Any]]:
     # EXPLAIN ANALYZE executes the query; dequeue mutates (UPDATE + log INSERT),
     # so run inside a transaction we roll back to keep the guard side-effect-free.
     await driver.execute("BEGIN")
@@ -48,7 +49,8 @@ async def _analyze_nodes(driver: db.Driver, sql: str, *args: object) -> list[dic
     finally:
         await driver.execute("ROLLBACK")
     raw = rows[0]["QUERY PLAN"]
-    plan = json.loads(raw) if isinstance(raw, str) else raw
+    assert isinstance(raw, str)
+    plan = json.loads(raw)
     return _flatten(plan[0]["Plan"])
 
 

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -4,6 +4,7 @@ from collections import Counter, defaultdict
 from datetime import datetime, timedelta
 
 from pgqueuer import db, queries
+from pgqueuer.adapters.persistence.query_helpers import cell
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import QueueEntrypoint
 from pgqueuer.models import Job
@@ -196,7 +197,7 @@ async def test_heartbeat_db_datetime(apgdriver: db.Driver) -> None:
         sql = f"""SELECT NOW() - heartbeat AS dt FROM {DBSettings().queue_table} WHERE id = ANY($1::bigint[])"""  # noqa: E501
         rows = await apgdriver.fetch(sql, [jobid])
         assert len(rows) == 1
-        return rows[0]["dt"]
+        return cell(rows[0], "dt", timedelta)
 
     @qm.entrypoint("fetch")
     async def fetch(context: Job) -> None:

--- a/test/test_schema_support.py
+++ b/test/test_schema_support.py
@@ -15,6 +15,7 @@ import pytest
 from async_timeout import timeout
 
 from pgqueuer import db, queries
+from pgqueuer.adapters.persistence.query_helpers import cell
 from pgqueuer.core.listeners import initialize_notice_event_listener
 from pgqueuer.domain.settings import DBSettings
 from pgqueuer.domain.types import QueueEntrypoint, QueueManagerId
@@ -33,7 +34,7 @@ async def table_schemas(driver: db.Driver, table: str) -> set[str]:
         WHERE c.relname = $1 AND c.relkind = 'r'""",
         table,
     )
-    return {row["nspname"] for row in rows}
+    return {cell(row, "nspname", str) for row in rows}
 
 
 async def enqueue_dequeue_round_trip(q: queries.Queries) -> None:


### PR DESCRIPTION
Part 3/9 of the strict-mypy series. Stacked on #790; merge in order, I rebase the rest after each merge.

Driver.fetch() and execute() take `*args: object` and return rows as
`list[dict[str, object]]`, matching what the drivers actually hand
back. Scalar reads go through `query_helpers.cell(row, key, kind)`,
which checks the value's type and raises TypeError on a mismatch, and
the job-status lookup validates its rows through a small pydantic
model instead of indexing untyped dicts. No runtime change on the
happy path.
