### PR TITLE
refactor(inmemory): keep rows in TypedDicts

### DIFF
--- a/pgqueuer/adapters/inmemory/queries.py
+++ b/pgqueuer/adapters/inmemory/queries.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import heapq
-import uuid
 from datetime import datetime, timedelta
-from typing import Any, Literal, overload
+from typing import Literal, TypedDict, overload
 
 from pydantic_core import to_json
 from typing_extensions import assert_never
@@ -21,18 +20,69 @@ from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
 from pgqueuer.domain import errors, models, types
 from pgqueuer.domain.models import utc_now
 from pgqueuer.domain.types import (
+    JOB_STATUS,
     CronEntrypoint,
+    CronExpression,
     HealthCheckId,
     JobId,
     OnConflict,
     QueueEntrypoint,
     QueueManagerId,
     ScheduleId,
+    Slot,
     SortOrder,
 )
 from pgqueuer.ports import tracing
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 from pgqueuer.ports.tracing import TracingProtocol
+
+
+class JobRow(TypedDict):
+    id: int
+    priority: int
+    created: datetime
+    updated: datetime
+    heartbeat: datetime
+    execute_after: datetime
+    status: JOB_STATUS
+    entrypoint: QueueEntrypoint
+    payload: bytes | None
+    attempts: int
+    queue_manager_id: QueueManagerId | None
+    slot: Slot | None
+    headers: str
+
+
+class LogRow(TypedDict):
+    id: int
+    created: datetime
+    job_id: int
+    status: JOB_STATUS
+    priority: int
+    entrypoint: QueueEntrypoint
+    traceback: str | None
+    aggregated: bool
+
+
+class StatisticsRow(TypedDict):
+    id: int
+    created: datetime
+    count: int
+    entrypoint: QueueEntrypoint
+    priority: int
+    status: JOB_STATUS
+
+
+class ScheduleRow(TypedDict):
+    id: int
+    expression: CronExpression
+    entrypoint: CronEntrypoint
+    heartbeat: datetime
+    created: datetime
+    updated: datetime
+    next_run: datetime
+    last_run: datetime | None
+    status: JOB_STATUS
 
 
 def percentile_cont(values: list[float], fraction: float) -> float:
@@ -64,10 +114,10 @@ class InMemoryQueries:
 
     tracer: TracingProtocol | None = None
 
-    _jobs: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
-    _log: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
-    _statistics: list[dict[str, Any]] = dataclasses.field(default_factory=list, init=False)
-    _schedules: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict, init=False)
+    _jobs: dict[int, JobRow] = dataclasses.field(default_factory=dict, init=False)
+    _log: list[LogRow] = dataclasses.field(default_factory=list, init=False)
+    _statistics: list[StatisticsRow] = dataclasses.field(default_factory=list, init=False)
+    _schedules: dict[int, ScheduleRow] = dataclasses.field(default_factory=dict, init=False)
     _dedupe_index: dict[str, int] = dataclasses.field(default_factory=dict, init=False)
     _dedupe_key_by_job: dict[int, str] = dataclasses.field(default_factory=dict, init=False)
 
@@ -226,7 +276,7 @@ class InMemoryQueries:
             ea = now + normed.execute_after[i]
             hdr = to_json(normed.headers[i]).decode()
 
-            job_dict: dict[str, Any] = {
+            job_dict: JobRow = {
                 "id": job_id,
                 "priority": normed.priority[i],
                 "created": now,
@@ -234,7 +284,7 @@ class InMemoryQueries:
                 "heartbeat": now,
                 "execute_after": ea,
                 "status": "queued",
-                "entrypoint": normed.entrypoint[i],
+                "entrypoint": QueueEntrypoint(normed.entrypoint[i]),
                 "payload": normed.payload[i],
                 "attempts": 0,
                 "queue_manager_id": None,
@@ -257,7 +307,7 @@ class InMemoryQueries:
                     "job_id": job_id,
                     "status": "queued",
                     "priority": normed.priority[i],
-                    "entrypoint": normed.entrypoint[i],
+                    "entrypoint": QueueEntrypoint(normed.entrypoint[i]),
                     "traceback": None,
                     "aggregated": False,
                 }
@@ -267,7 +317,7 @@ class InMemoryQueries:
         await self.emit_table_changed("insert")
         return ids
 
-    def _push_queued_job(self, job: dict[str, Any], now: datetime) -> None:
+    def _push_queued_job(self, job: JobRow, now: datetime) -> None:
         if job["execute_after"] <= now:
             heapq.heappush(
                 self._ready_heaps.setdefault(job["entrypoint"], []),
@@ -301,8 +351,8 @@ class InMemoryQueries:
         limit: int,
         now: datetime,
         seen: set[int],
-    ) -> list[dict[str, Any]]:
-        popped: list[dict[str, Any]] = []
+    ) -> list[JobRow]:
+        popped: list[JobRow] = []
         heap = self._ready_heaps.get(entrypoint)
         if heap is None:
             return popped
@@ -339,7 +389,7 @@ class InMemoryQueries:
         now: datetime,
         entrypoints: dict[QueueEntrypoint, EntrypointExecutionParameter],
         heartbeat_timeout: timedelta,
-    ) -> list[dict[str, Any]]:
+    ) -> list[JobRow]:
         candidates = [
             j
             for j in (self._jobs[job_id] for job_id in self._picked_ids)
@@ -350,7 +400,7 @@ class InMemoryQueries:
 
     def _write_picked_logs(
         self,
-        jobs: list[dict[str, Any]],
+        jobs: list[JobRow],
         now: datetime,
     ) -> None:
         for j in jobs:
@@ -396,7 +446,7 @@ class InMemoryQueries:
         self._promote_due_deferred(now)
 
         seen = set[int]()
-        queued_candidates: list[dict[str, Any]] = []
+        queued_candidates: list[JobRow] = []
         for ep, params in entrypoints.items():
             cap = remaining
             if params.concurrency_limit > 0:
@@ -604,7 +654,7 @@ class InMemoryQueries:
             self._picked_ids.clear()
 
     async def queue_size(self) -> list[models.QueueStatistics]:
-        counts: dict[tuple[str, int, str], int] = {}
+        counts: dict[tuple[QueueEntrypoint, int, JOB_STATUS], int] = {}
         for j in self._jobs.values():
             key = (j["entrypoint"], j["priority"], j["status"])
             counts[key] = counts.get(key, 0) + 1
@@ -658,7 +708,7 @@ class InMemoryQueries:
 
     def aggregate_log_to_statistics(self) -> None:
         """Roll un-aggregated log rows into per-second statistics buckets."""
-        to_agg: dict[tuple[str, int, str, datetime], int] = {}
+        to_agg: dict[tuple[QueueEntrypoint, int, JOB_STATUS, datetime], int] = {}
         for entry in self._log:
             if entry["aggregated"]:
                 continue
@@ -762,7 +812,7 @@ class InMemoryQueries:
         entrypoints: dict[models.CronExpressionEntrypoint, timedelta],
     ) -> list[models.Schedule]:
         now = utc_now()
-        selected: list[dict[str, Any]] = []
+        selected: list[ScheduleRow] = []
 
         ep_set = {(k.expression, k.entrypoint): v for k, v in entrypoints.items()}
 
@@ -841,7 +891,7 @@ class InMemoryQueries:
         """Return time until the soonest deferred job becomes eligible, or None."""
         now = utc_now()
         ep_set = set(entrypoints)
-        candidates = [
+        candidates: list[datetime] = [
             j["execute_after"]
             for j in self._jobs.values()
             if j["status"] == "queued" and j["entrypoint"] in ep_set and j["execute_after"] > now
@@ -852,7 +902,7 @@ class InMemoryQueries:
 
     async def queue_age(self) -> list[models.QueueAgeStats]:
         now = utc_now()
-        grouped: dict[str, list[datetime]] = {}
+        grouped: dict[QueueEntrypoint, list[datetime]] = {}
         for j in self._jobs.values():
             if j["status"] == "queued":
                 grouped.setdefault(j["entrypoint"], []).append(j["created"])
@@ -879,8 +929,8 @@ class InMemoryQueries:
             key=lambda e: (e["job_id"], e["created"], e["id"]),
         )
         terminal = {"successful", "exception", "canceled", "failed"}
-        durations: dict[str, list[float]] = {}
-        prev: dict[str, Any] | None = None
+        durations: dict[QueueEntrypoint, list[float]] = {}
+        prev: LogRow | None = None
         for entry in ordered:
             if (
                 prev is not None
@@ -912,7 +962,7 @@ class InMemoryQueries:
     ) -> list[models.ThroughputStats]:
         self.aggregate_log_to_statistics()
         cutoff = utc_now() - last if last is not None else None
-        totals: dict[tuple[str, str], int] = {}
+        totals: dict[tuple[QueueEntrypoint, JOB_STATUS], int] = {}
         for r in self._statistics:
             if cutoff is not None and r["created"] <= cutoff:
                 continue
@@ -929,7 +979,7 @@ class InMemoryQueries:
     ) -> list[models.ThroughputBucket]:
         self.aggregate_log_to_statistics()
         cutoff = utc_now() - last
-        buckets: dict[tuple[datetime, str, str], int] = {}
+        buckets: dict[tuple[datetime, QueueEntrypoint, JOB_STATUS], int] = {}
         for r in self._statistics:
             if r["created"] <= cutoff:
                 continue
@@ -942,7 +992,7 @@ class InMemoryQueries:
         ]
 
     async def active_workers(self) -> list[models.ActiveWorker]:
-        grouped: dict[uuid.UUID, list[dict[str, Any]]] = {}
+        grouped: dict[QueueManagerId, list[JobRow]] = {}
         for j in self._jobs.values():
             if j["status"] == "picked" and j["queue_manager_id"] is not None:
                 grouped.setdefault(j["queue_manager_id"], []).append(j)


### PR DESCRIPTION
Part 4/9 of the strict-mypy series. Stacked on #791; merge in order, I rebase the rest after each merge.

The in-memory adapter stored jobs, log entries, statistics and
schedules as dict[str, Any]. Declare a TypedDict per row shape so
every key access is checked and the entrypoint/status fields carry
QueueEntrypoint and JOB_STATUS like the Postgres-backed models. No
runtime change.
