### PR TITLE
refactor(typing): type job headers as dict[str, object]

### DIFF
--- a/pgqueuer/adapters/persistence/query_helpers.py
+++ b/pgqueuer/adapters/persistence/query_helpers.py
@@ -17,7 +17,7 @@ class NormedEnqueueParam:
     payload: list[bytes | None]
     execute_after: list[timedelta]
     dedupe_key: list[str | None]
-    headers: list[dict | None]
+    headers: list[Mapping[str, object] | None]
 
 
 def normalize_enqueue_params(
@@ -26,7 +26,7 @@ def normalize_enqueue_params(
     priority: int | list[int],
     execute_after: timedelta | None | list[timedelta | None] = None,
     dedupe_key: str | list[str | None] | None = None,
-    headers: dict | list[dict | None] | None = None,
+    headers: dict[str, str] | list[dict[str, str] | None] | None = None,
 ) -> NormedEnqueueParam:
     """Normalize parameters for enqueue operations to handle both single and batch inputs."""
     normed_entrypoint = entrypoint if isinstance(entrypoint, list) else [entrypoint]
@@ -46,8 +46,13 @@ def normalize_enqueue_params(
     dedupe_key = [None] * len(normed_entrypoint) if dedupe_key is None else dedupe_key
     normed_dedupe_key = dedupe_key if isinstance(dedupe_key, list) else [dedupe_key]
 
-    headers = [None] * len(normed_entrypoint) if headers is None else headers
-    normed_headers = headers if isinstance(headers, list) else [headers]
+    normed_headers: list[Mapping[str, object] | None] = (
+        [None] * len(normed_entrypoint)
+        if headers is None
+        else list(headers)
+        if isinstance(headers, list)
+        else [headers]
+    )
 
     return NormedEnqueueParam(
         priority=normed_priority,
@@ -83,9 +88,9 @@ def scatter_ids_by_ordinal(
 
 
 def merge_tracing_headers(
-    headers: list[dict | None],
-    trace_headers: Generator[dict | None, None, None],
-) -> list[dict]:
+    headers: list[Mapping[str, object] | None],
+    trace_headers: Generator[Mapping[str, object] | None, None, None],
+) -> list[Mapping[str, object] | None]:
     """Merge tracing headers into the existing headers for each entrypoint."""
     return [
         {**(h or {}), **(t or {})}

--- a/pgqueuer/adapters/tracing/logfire.py
+++ b/pgqueuer/adapters/tracing/logfire.py
@@ -20,7 +20,7 @@ from pgqueuer.ports.tracing import TracingProtocol
 
 
 class LogfireTracing(TracingProtocol):
-    def trace_publish(self, entrypoints: list[str]) -> Generator[dict, None, None]:
+    def trace_publish(self, entrypoints: list[str]) -> Generator[dict[str, object], None, None]:
         if not HAS_LOGFIRE:
             # One header per entrypoint: merge_tracing_headers zips against
             # the entrypoint list with strict=True.

--- a/pgqueuer/adapters/tracing/opentelemetry.py
+++ b/pgqueuer/adapters/tracing/opentelemetry.py
@@ -67,20 +67,20 @@ class OpenTelemetryTracing(TracingProtocol):
 
     def __init__(
         self,
-        tracer: Any = None,
+        tracer: opentelemetry.trace.Tracer | None = None,
         instrumentation_name: str = "pgqueuer",
     ) -> None:
         self._tracer_arg = tracer
         self._instrumentation_name = instrumentation_name
 
-    def _get_tracer(self) -> Any:
+    def _get_tracer(self) -> opentelemetry.trace.Tracer | None:
         if not HAS_OTEL:
             return None
         if self._tracer_arg is not None:
             return self._tracer_arg
         return opentelemetry.trace.get_tracer(self._instrumentation_name)
 
-    def trace_publish(self, entrypoints: list[str]) -> Generator[dict, None, None]:
+    def trace_publish(self, entrypoints: list[str]) -> Generator[dict[str, object], None, None]:
         """Inject W3C trace context into job headers on enqueue.
 
         Single message: one ``PRODUCER`` ``send {destination}`` span whose

--- a/pgqueuer/adapters/tracing/sentry.py
+++ b/pgqueuer/adapters/tracing/sentry.py
@@ -18,7 +18,7 @@ from pgqueuer.ports.tracing import TracingProtocol
 
 
 class SentryTracing(TracingProtocol):
-    def trace_publish(self, entrypoints: list[str]) -> Generator[dict, None, None]:
+    def trace_publish(self, entrypoints: list[str]) -> Generator[dict[str, object], None, None]:
         if not HAS_SENTRY:
             # One header per entrypoint: merge_tracing_headers zips against
             # the entrypoint list with strict=True.

--- a/pgqueuer/domain/models.py
+++ b/pgqueuer/domain/models.py
@@ -4,7 +4,7 @@ import dataclasses
 import traceback
 from collections.abc import MutableMapping
 from datetime import datetime, timedelta, timezone
-from typing import Annotated, Any, Literal, NamedTuple
+from typing import Annotated, Literal, NamedTuple
 
 import anyio
 from pydantic import AwareDatetime, BaseModel, BeforeValidator, Field, RootModel
@@ -102,21 +102,26 @@ class Job(BaseModel):
     queue_manager_id: QueueManagerId | None
     slot: Slot | None = None
     headers: Annotated[
-        dict[str, Any] | None,
-        BeforeValidator(lambda x: None if x is None else from_json(x)),
+        dict[str, object] | None,
+        BeforeValidator(lambda x: x if x is None or isinstance(x, dict) else from_json(x)),
     ]
 
-    def logfire_headers(self) -> dict[str, Any] | None:
+    def header_section(self, key: str) -> dict[str, object] | None:
+        """Return the nested header dict under *key*, or None when absent or not a dict."""
+        section = None if self.headers is None else self.headers.get(key)
+        return section if isinstance(section, dict) else None
+
+    def logfire_headers(self) -> dict[str, object] | None:
         """Return the ``logfire`` sub-dict from job headers, or None."""
-        return None if self.headers is None else self.headers.get("logfire")
+        return self.header_section("logfire")
 
-    def sentry_headers(self) -> dict[str, Any] | None:
+    def sentry_headers(self) -> dict[str, object] | None:
         """Return the ``sentry`` sub-dict from job headers, or None."""
-        return None if self.headers is None else self.headers.get("sentry")
+        return self.header_section("sentry")
 
-    def otel_headers(self) -> dict[str, Any] | None:
+    def otel_headers(self) -> dict[str, object] | None:
         """Return the ``otel`` W3C propagation sub-dict from job headers, or None."""
-        return None if self.headers is None else self.headers.get("otel")
+        return self.header_section("otel")
 
 
 class Log(BaseModel):
@@ -311,14 +316,14 @@ class TracebackRecord(BaseModel):
     exception_type: str
     exception_message: str
     traceback: str
-    additional_context: dict[str, Any] | None
+    additional_context: dict[str, object] | None
 
     @classmethod
     def from_exception(
         cls,
         exc: Exception,
         job_id: JobId,
-        additional_context: dict[str, Any] | None = None,
+        additional_context: dict[str, object] | None = None,
     ) -> TracebackRecord:
         return cls(
             job_id=job_id,

--- a/pgqueuer/ports/tracing.py
+++ b/pgqueuer/ports/tracing.py
@@ -11,7 +11,7 @@ from pgqueuer.domain.models import Job
 class TracingProtocol(Protocol):
     """Tracing operations for queue producer and consumer paths."""
 
-    def trace_publish(self, entrypoints: list[str]) -> Generator[dict, None, None]:
+    def trace_publish(self, entrypoints: list[str]) -> Generator[dict[str, object], None, None]:
         """Yield one tracing-header dict per entrypoint, in input order."""
         ...
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -14,6 +14,7 @@ from pgqueuer import db
 from pgqueuer.adapters.persistence import qb
 from pgqueuer.adapters.persistence.queries import Queries
 from pgqueuer.adapters.persistence.query_helpers import cell
+from pgqueuer.domain.types import JOB_STATUS, JobId, QueueEntrypoint, QueueManagerId
 from pgqueuer.models import Job
 from pgqueuer.ports import RepositoryPort
 
@@ -87,24 +88,24 @@ def mocked_job(
     heartbeat: datetime | None = None,
     execute_after: datetime | None = None,
     updated: datetime | None = None,
-    status: str = "queued",
+    status: JOB_STATUS = "queued",
     entrypoint: str = "test",
     payload: bytes | None = None,
     queue_manager_id: None | uuid.UUID = None,
-    headers: dict | None = None,
+    headers: dict[str, object] | None = None,
 ) -> Job:
     now = datetime.now(timezone.utc)
     return Job(
-        id=id if isinstance(id, int) else next(id),
+        id=JobId(id if isinstance(id, int) else next(id)),
         priority=priority,
         created=created or now,
         heartbeat=heartbeat or now,
         execute_after=execute_after or now,
         updated=updated or now,
         status=status,
-        entrypoint=entrypoint,
+        entrypoint=QueueEntrypoint(entrypoint),
         payload=payload,
-        queue_manager_id=queue_manager_id or uuid.uuid4(),
+        queue_manager_id=QueueManagerId(queue_manager_id or uuid.uuid4()),
         headers=headers,
     )
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 
 import pytest
 
@@ -33,8 +33,8 @@ from pgqueuer.adapters.persistence.query_helpers import merge_tracing_headers
     ],
 )
 def test_merge_tracing_headers(
-    headers: list[dict | None],
-    trace_headers: Generator[dict | None, None, None],
-    expected: list[dict],
+    headers: list[Mapping[str, object] | None],
+    trace_headers: Generator[Mapping[str, object] | None, None, None],
+    expected: list[Mapping[str, object] | None],
 ) -> None:
     assert merge_tracing_headers(headers, trace_headers) == expected

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pgqueuer.domain.models import Job
+from test.helpers import mocked_job
+
+
+def test_job_headers_accept_parsed_dict_and_json() -> None:
+    """Headers validate from an already-parsed dict as well as from JSON text."""
+    headers: dict[str, object] = {"otel": {"traceparent": "00-abc"}}
+    from_dict = mocked_job(headers=headers)
+    from_json = Job.model_validate(
+        {**from_dict.model_dump(), "headers": b'{"otel": {"traceparent": "00-abc"}}'}
+    )
+    assert from_dict.headers == from_json.headers == headers
+
+
+def test_header_section_returns_only_nested_dicts() -> None:
+    job = mocked_job(headers={"otel": {"traceparent": "00-abc"}, "logfire": "not-a-dict"})
+    assert job.otel_headers() == {"traceparent": "00-abc"}
+    assert job.logfire_headers() is None
+    assert job.sentry_headers() is None
+    assert mocked_job(headers=None).otel_headers() is None

--- a/test/test_retry_requeue.py
+++ b/test/test_retry_requeue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import timedelta
+from typing import Any
 
 import anyio
 import async_timeout
@@ -544,7 +545,7 @@ async def test_retry_preserves_priority() -> None:
 async def test_retry_preserves_headers() -> None:
     """Headers survive retry — UPDATE keeps the row intact."""
     pq = PgQueuer.in_memory()
-    seen_headers: list[dict | None] = []
+    seen_headers: list[dict[str, Any] | None] = []
 
     @pq.entrypoint("headers_ep")
     async def handler(job: Job) -> None:
@@ -631,19 +632,21 @@ async def test_multiple_jobs_only_one_retries() -> None:
 
 async def test_inmemory_retry_job_nonexistent_is_noop(queries: InMemoryQueries) -> None:
     """Calling retry_job on a nonexistent job is a silent no-op."""
-    fake_job = Job(
-        id=99999,
-        priority=0,
-        created="2024-01-01T00:00:00Z",
-        updated="2024-01-01T00:00:00Z",
-        heartbeat="2024-01-01T00:00:00Z",
-        execute_after="2024-01-01T00:00:00Z",
-        status="picked",
-        entrypoint="ghost",
-        payload=None,
-        attempts=0,
-        queue_manager_id=None,
-        headers=None,
+    fake_job = Job.model_validate(
+        {
+            "id": JobId(99999),
+            "priority": 0,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2024-01-01T00:00:00Z",
+            "heartbeat": "2024-01-01T00:00:00Z",
+            "execute_after": "2024-01-01T00:00:00Z",
+            "status": "picked",
+            "entrypoint": QueueEntrypoint("ghost"),
+            "payload": None,
+            "attempts": 0,
+            "queue_manager_id": None,
+            "headers": None,
+        }
     )
     # Should not raise
     await queries.retry_job(fake_job, timedelta(0), None)
@@ -745,19 +748,21 @@ async def test_database_retry_executor_chains_cause() -> None:
 
     original = ValueError("the root cause")
 
-    fake_job = Job(
-        id=1,
-        priority=0,
-        created="2024-01-01T00:00:00Z",
-        updated="2024-01-01T00:00:00Z",
-        heartbeat="2024-01-01T00:00:00Z",
-        execute_after="2024-01-01T00:00:00Z",
-        status="picked",
-        entrypoint="cause_ep",
-        payload=None,
-        attempts=0,
-        queue_manager_id=None,
-        headers=None,
+    fake_job = Job.model_validate(
+        {
+            "id": JobId(1),
+            "priority": 0,
+            "created": "2024-01-01T00:00:00Z",
+            "updated": "2024-01-01T00:00:00Z",
+            "heartbeat": "2024-01-01T00:00:00Z",
+            "execute_after": "2024-01-01T00:00:00Z",
+            "status": "picked",
+            "entrypoint": QueueEntrypoint("cause_ep"),
+            "payload": None,
+            "attempts": 0,
+            "queue_manager_id": None,
+            "headers": None,
+        }
     )
 
     # Monkey-patch the executor's func to raise

--- a/test/test_traceback_record.py
+++ b/test/test_traceback_record.py
@@ -8,7 +8,7 @@ from pgqueuer.models import JobId, TracebackRecord
 
 def test_from_exception() -> None:
     job_id: JobId = JobId(123)
-    additional: dict[str, str] = {"detail": "Error occurred"}
+    additional: dict[str, object] = {"detail": "Error occurred"}
 
     try:
         raise ValueError("Testing error")
@@ -40,7 +40,7 @@ def test_timestamp() -> None:
 
 def test_model_dump() -> None:
     job_id: JobId = JobId(789)
-    additional: dict[str, str] = {"key": "value"}
+    additional: dict[str, object] = {"key": "value"}
     try:
         raise KeyError("Missing key")
     except Exception as exc:

--- a/test/test_tracing_graceful_degradation.py
+++ b/test/test_tracing_graceful_degradation.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
-from pydantic_core import to_json
 
 import pgqueuer.adapters.tracing.logfire as logfire_mod
 import pgqueuer.adapters.tracing.sentry as sentry_mod
@@ -14,10 +14,10 @@ from pgqueuer.adapters.inmemory import InMemoryDriver, InMemoryQueries
 from pgqueuer.adapters.tracing.logfire import LogfireTracing
 from pgqueuer.adapters.tracing.sentry import SentryTracing
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import JobId
+from pgqueuer.domain.types import JobId, QueueEntrypoint, QueueManagerId
 
 
-def _make_job(headers: dict) -> Job:
+def _make_job(headers: dict[str, Any]) -> Job:
     now = datetime.now(timezone.utc)
     return Job(
         id=JobId(1),
@@ -27,10 +27,10 @@ def _make_job(headers: dict) -> Job:
         heartbeat=now,
         execute_after=now,
         status="queued",
-        entrypoint="say_hello",
+        entrypoint=QueueEntrypoint("say_hello"),
         payload=b"hello",
-        queue_manager_id=uuid.uuid4(),
-        headers=to_json(headers),
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
+        headers=headers,
     )
 
 

--- a/test/test_tracing_logfire.py
+++ b/test/test_tracing_logfire.py
@@ -10,14 +10,13 @@ import logfire
 import pytest
 from logfire.testing import TestExporter
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from pydantic_core import to_json
 
 from pgqueuer.adapters.tracing.logfire import LogfireTracing
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import JobId
+from pgqueuer.domain.types import JobId, QueueEntrypoint, QueueManagerId
 
 
-def _make_job(headers: dict | None, *, entrypoint: str = "say_hello") -> Job:
+def _make_job(headers: dict[str, Any] | None, *, entrypoint: str = "say_hello") -> Job:
     now = datetime.now(timezone.utc)
     return Job(
         id=JobId(7),
@@ -27,10 +26,10 @@ def _make_job(headers: dict | None, *, entrypoint: str = "say_hello") -> Job:
         heartbeat=now,
         execute_after=now,
         status="queued",
-        entrypoint=entrypoint,
+        entrypoint=QueueEntrypoint(entrypoint),
         payload=b"hello",
-        queue_manager_id=uuid.uuid4(),
-        headers=to_json(headers) if headers is not None else None,
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
+        headers=headers,
     )
 
 
@@ -56,7 +55,9 @@ def _by_name(exporter: TestExporter, needle: str) -> dict[str, Any]:
 
 def test_publish_injects_traceparent(exporter: TestExporter) -> None:
     (headers,) = list(LogfireTracing().trace_publish(["say_hello"]))
-    assert "traceparent" in headers["logfire"]
+    logfire_headers = headers["logfire"]
+    assert isinstance(logfire_headers, dict)
+    assert "traceparent" in logfire_headers
 
 
 def test_publish_emits_span_per_entrypoint(exporter: TestExporter) -> None:

--- a/test/test_tracing_opentelemetry.py
+++ b/test/test_tracing_opentelemetry.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from opentelemetry import trace
@@ -21,18 +22,17 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, StatusCode
-from pydantic_core import to_json
 
 from pgqueuer.adapters.tracing.opentelemetry import OpenTelemetryTracing
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import JobId
+from pgqueuer.domain.types import JobId, QueueEntrypoint, QueueManagerId
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_job(headers: dict | None = None, entrypoint: str = "say_hello") -> Job:
+def _make_job(headers: dict[str, Any] | None = None, entrypoint: str = "say_hello") -> Job:
     """Create a minimal Job for testing.
 
     ``Job.headers`` has a ``BeforeValidator`` that expects JSON-encoded
@@ -48,10 +48,10 @@ def _make_job(headers: dict | None = None, entrypoint: str = "say_hello") -> Job
         heartbeat=now,
         execute_after=now,
         status="queued",
-        entrypoint=entrypoint,
+        entrypoint=QueueEntrypoint(entrypoint),
         payload=b"hello",
-        queue_manager_id=uuid.uuid4(),
-        headers=to_json(headers) if headers is not None else None,
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
+        headers=headers,
     )
 
 
@@ -87,8 +87,9 @@ def test_single_publish_yields_otel_header(
     tracing: OpenTelemetryTracing,
 ) -> None:
     (headers,) = tracing.trace_publish(["fetch"])
-    assert "otel" in headers
-    assert "traceparent" in headers["otel"]
+    otel = headers["otel"]
+    assert isinstance(otel, dict)
+    assert "traceparent" in otel
 
 
 def test_single_publish_span_name(
@@ -134,8 +135,9 @@ def test_batch_publish_yields_otel_headers_for_each(
     headers = list(tracing.trace_publish(["a", "b", "c"]))
     assert len(headers) == 3
     for h in headers:
-        assert "otel" in h
-        assert "traceparent" in h["otel"]
+        otel = h["otel"]
+        assert isinstance(otel, dict)
+        assert "traceparent" in otel
 
 
 def test_batch_publish_span_names(

--- a/test/test_tracing_sentry.py
+++ b/test/test_tracing_sentry.py
@@ -8,15 +8,14 @@ from typing import Any, Iterator
 
 import pytest
 import sentry_sdk
-from pydantic_core import to_json
 from sentry_sdk.transport import Transport
 
 from pgqueuer.adapters.tracing.sentry import SentryTracing
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import JobId
+from pgqueuer.domain.types import JobId, QueueEntrypoint, QueueManagerId
 
 
-def _make_job(headers: dict | None, *, entrypoint: str = "say_hello") -> Job:
+def _make_job(headers: dict[str, Any] | None, *, entrypoint: str = "say_hello") -> Job:
     now = datetime.now(timezone.utc)
     return Job(
         id=JobId(1),
@@ -26,10 +25,10 @@ def _make_job(headers: dict | None, *, entrypoint: str = "say_hello") -> Job:
         heartbeat=now,
         execute_after=now,
         status="queued",
-        entrypoint=entrypoint,
+        entrypoint=QueueEntrypoint(entrypoint),
         payload=b"hello",
-        queue_manager_id=uuid.uuid4(),
-        headers=to_json(headers) if headers is not None else None,
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
+        headers=headers,
     )
 
 
@@ -66,9 +65,11 @@ def _consumer(transactions: list[dict[str, Any]]) -> dict[str, Any]:
 
 def test_publish_injects_sentry_headers(transactions: list[dict[str, Any]]) -> None:
     (headers,) = list(SentryTracing().trace_publish(["say_hello"]))
-    assert set(headers["sentry"]) == {"sentry-trace", "baggage"}
+    sentry = headers["sentry"]
+    assert isinstance(sentry, dict)
+    assert set(sentry) == {"sentry-trace", "baggage"}
     # sentry-trace = "{trace_id}-{span_id}-{sampled}"; trace_id is 16 bytes hex.
-    assert len(headers["sentry"]["sentry-trace"].split("-")[0]) == 32
+    assert len(sentry["sentry-trace"].split("-")[0]) == 32
 
 
 def test_publish_emits_one_span_per_entrypoint(transactions: list[dict[str, Any]]) -> None:
@@ -82,7 +83,9 @@ def test_publish_emits_one_span_per_entrypoint(transactions: list[dict[str, Any]
 async def test_consumer_continues_producer_trace(transactions: list[dict[str, Any]]) -> None:
     tracing = SentryTracing()
     (headers,) = list(tracing.trace_publish(["say_hello"]))
-    publish_trace_id = headers["sentry"]["sentry-trace"].split("-")[0]
+    sentry = headers["sentry"]
+    assert isinstance(sentry, dict)
+    publish_trace_id = sentry["sentry-trace"].split("-")[0]
 
     async with tracing.trace_process(_make_job(headers)):
         pass

--- a/test/test_tracing_sentry_status.py
+++ b/test/test_tracing_sentry_status.py
@@ -8,15 +8,14 @@ from typing import Any, Iterator
 
 import pytest
 import sentry_sdk
-from pydantic_core import to_json
 from sentry_sdk.transport import Transport
 
 from pgqueuer.adapters.tracing.sentry import SentryTracing
 from pgqueuer.domain.models import Job
-from pgqueuer.domain.types import JobId
+from pgqueuer.domain.types import JobId, QueueEntrypoint, QueueManagerId
 
 
-def _make_job(headers: dict | None) -> Job:
+def _make_job(headers: dict[str, Any] | None) -> Job:
     now = datetime.now(timezone.utc)
     return Job(
         id=JobId(1),
@@ -26,10 +25,10 @@ def _make_job(headers: dict | None) -> Job:
         heartbeat=now,
         execute_after=now,
         status="queued",
-        entrypoint="say_hello",
+        entrypoint=QueueEntrypoint("say_hello"),
         payload=b"hello",
-        queue_manager_id=uuid.uuid4(),
-        headers=to_json(headers) if headers is not None else None,
+        queue_manager_id=QueueManagerId(uuid.uuid4()),
+        headers=headers,
     )
 
 


### PR DESCRIPTION
Part 5/9 of the strict-mypy series. Stacked on #792; merge in order, I rebase the rest after each merge.

Job.headers and TracebackRecord.additional_context are
dict[str, object]; the tracing adapters yield the same shape for
their carriers and merge_tracing_headers accepts any Mapping. The
nested sections come out through Job.header_section(), which returns
the sub-dict or None when the key is missing or not a dict, and the
headers validator now also accepts an already-parsed dict so a Job can
be built in Python without round-tripping JSON.
