### PR TITLE
refactor(adapters): remove Any from the CLI, web, MCP and tracing adapters

### DIFF
--- a/examples/fastapi_usage.py
+++ b/examples/fastapi_usage.py
@@ -11,7 +11,9 @@ from pgqueuer.queries import Queries
 
 def get_pgq_queries(request: Request) -> Queries:
     """Retrieve Queries instance from FastAPI app context."""
-    return request.app.extra["pgq_queries"]
+    pgq_queries = request.app.extra["pgq_queries"]
+    assert isinstance(pgq_queries, Queries)
+    return pgq_queries
 
 
 def create_app() -> FastAPI:
@@ -47,14 +49,14 @@ def create_app() -> FastAPI:
         payload: str,
         priority: int = 0,
         queries: Queries = Depends(get_pgq_queries),
-    ) -> dict:
+    ) -> dict[str, object]:
         ids = await queries.enqueue(entrypoint, payload.encode(), priority)
         return {"job_ids": ids}
 
     @app.get("/queue-size")
     async def get_queue_size(
         queries: Queries = Depends(get_pgq_queries),
-    ) -> list:
+    ) -> list[dict[str, object]]:
         stats = await queries.queue_size()
         return [
             {

--- a/pgqueuer/adapters/cli/cli.py
+++ b/pgqueuer/adapters/cli/cli.py
@@ -34,25 +34,22 @@ except ImportError:
 
 def asyncio_run(coro: Coroutine[object, object, object]) -> None:
     """Run *coro* on the best event loop for this platform."""
-    if sys.platform != "win32":
-        if HAS_UVLOOP:
-            uvloop.run(coro)
+    if sys.platform == "win32":
+        # psycopg async rejects ProactorEventLoop (Windows default); force the
+        # selector loop on every supported Windows + Python combination.
+        if sys.version_info >= (3, 12):
+            asyncio.run(coro, loop_factory=asyncio.SelectorEventLoop)
+        elif sys.version_info >= (3, 11):
+            with asyncio.Runner(loop_factory=asyncio.SelectorEventLoop) as runner:
+                runner.run(coro)
         else:
+            # Python 3.10: no Runner, no loop_factory; mutate policy.
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
             asyncio.run(coro)
-        return
-
-    # psycopg async rejects ProactorEventLoop (Windows default); force the
-    # selector loop on every supported Windows + Python combination.
-    if sys.version_info >= (3, 12):
-        asyncio.run(coro, loop_factory=asyncio.SelectorEventLoop)
-        return
-    if sys.version_info >= (3, 11):
-        with asyncio.Runner(loop_factory=asyncio.SelectorEventLoop) as runner:
-            runner.run(coro)
-        return
-    # Python 3.10: no Runner, no loop_factory; mutate policy.
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    asyncio.run(coro)
+    elif HAS_UVLOOP:
+        uvloop.run(coro)
+    else:
+        asyncio.run(coro)
 
 
 app = typer.Typer(
@@ -144,7 +141,7 @@ def main(
 def create_default_queries_factory(
     config: AppConfig,
     settings: qb.DBSettings,
-) -> Callable[..., contextlib.AbstractAsyncContextManager[queries.Queries]]:
+) -> Callable[[], contextlib.AbstractAsyncContextManager[queries.Queries]]:
     """Default Queries factory: try asyncpg, fall back to psycopg."""
 
     @contextlib.asynccontextmanager
@@ -185,12 +182,15 @@ async def yield_queries(
 ) -> AsyncGenerator[queries.Queries, None]:
     """Yield Queries from the user-supplied factory or the built-in default."""
     config: AppConfig = ctx.obj
+    factory_fn: Callable[[], object]
     if config.factory_fn_ref:
         factory_fn = factories.load_factory(config.factory_fn_ref)
     else:
         factory_fn = create_default_queries_factory(config, settings)
-    async with factories.validate_factory_result(factory_fn()) as q:
-        yield q
+    async with factories.validate_factory_result(factory_fn()) as entered:
+        if not isinstance(entered, queries.Queries):
+            raise TypeError(f"Factory must yield Queries, got {type(entered).__name__}")
+        yield entered
 
 
 def tablefmt() -> str:

--- a/pgqueuer/adapters/cli/factories.py
+++ b/pgqueuer/adapters/cli/factories.py
@@ -5,10 +5,16 @@ import inspect
 import os
 import sys
 from contextlib import AbstractAsyncContextManager
-from typing import Any, Callable
+from typing import Protocol
 
 
-def load_factory(factory: str | Callable[..., Any]) -> Callable[..., Any]:
+class Factory(Protocol):
+    """User factory callable; CLI extra arguments are forwarded positionally."""
+
+    def __call__(self, *args: object) -> object: ...
+
+
+def load_factory(factory: str | Factory) -> Factory:
     """Resolve a factory: a ``module:attr`` import path, or pass-through if already callable."""
     sys.path.insert(0, os.getcwd())
 
@@ -17,10 +23,13 @@ def load_factory(factory: str | Callable[..., Any]) -> Callable[..., Any]:
 
     module_name, factory_name = factory.split(":", 1)
     module = importlib.import_module(module_name)
-    return getattr(module, factory_name)
+    loaded: object = getattr(module, factory_name)
+    if not callable(loaded):
+        raise TypeError(f"{factory!r} does not resolve to a callable, got {type(loaded).__name__}")
+    return loaded
 
 
-def validate_factory_result(result: object) -> AbstractAsyncContextManager[Any]:
+def validate_factory_result(result: object) -> AbstractAsyncContextManager[object]:
     """Validate that a factory produced an async context manager.
 
     Raises TypeError with actionable migration instructions when the result

--- a/pgqueuer/adapters/cli/supervisor.py
+++ b/pgqueuer/adapters/cli/supervisor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import signal
-from contextlib import AbstractAsyncContextManager, suppress
+from contextlib import suppress
 from datetime import timedelta
 from typing import Callable, TypeAlias
 
@@ -11,10 +11,10 @@ from pgqueuer.core import applications, logconfig, qm, sm
 from pgqueuer.domain import types
 
 Manager: TypeAlias = qm.QueueManager | sm.SchedulerManager | applications.PgQueuer
-ManagerFactory: TypeAlias = Callable[[], AbstractAsyncContextManager[Manager]]
+ManagerFactory: TypeAlias = Callable[[], object]
 
 
-def setup_shutdown_handlers(manager: Manager, shutdown: asyncio.Event) -> Manager:
+def setup_shutdown_handlers(manager: object, shutdown: asyncio.Event) -> Manager:
     """Wire *shutdown* into *manager* so cancellation propagates to inner managers."""
 
     if isinstance(manager, qm.QueueManager | sm.SchedulerManager):
@@ -86,8 +86,8 @@ async def runit(
         forward_task = asyncio.create_task(forward_shutdown(shutdown, cycle_shutdown))
         failed = False
         try:
-            async with factories.validate_factory_result(factory()) as manager:
-                setup_shutdown_handlers(manager, cycle_shutdown)
+            async with factories.validate_factory_result(factory()) as entered:
+                manager = setup_shutdown_handlers(entered, cycle_shutdown)
                 await run_manager(
                     manager,
                     dequeue_timeout,

--- a/pgqueuer/adapters/mcp/server.py
+++ b/pgqueuer/adapters/mcp/server.py
@@ -86,7 +86,7 @@ def _db(ctx: Ctx) -> PgQueuerDatabase:
     return ctx.request_context.lifespan_context
 
 
-def _register_tools(mcp: FastMCP) -> None:  # noqa: C901
+def _register_tools(mcp: FastMCP[PgQueuerDatabase]) -> None:  # noqa: C901
     """Register all read-only insight tools onto the given FastMCP instance."""
 
     @mcp.tool()
@@ -462,7 +462,7 @@ def create_mcp_server(
     dsn: str | None = None,
     settings: DBSettings = DBSettings(),
     connection_settings: ConnectionSettings | None = None,
-) -> FastMCP:
+) -> FastMCP[PgQueuerDatabase]:
     """Factory that builds a fully-configured PgQueuer MCP server.
 
     Args:
@@ -478,7 +478,7 @@ def create_mcp_server(
     """
 
     @asynccontextmanager
-    async def app_lifespan(server: FastMCP) -> AsyncIterator[PgQueuerDatabase]:
+    async def app_lifespan(server: FastMCP[PgQueuerDatabase]) -> AsyncIterator[PgQueuerDatabase]:
         async with create_asyncpg_pool(dsn=dsn, settings=connection_settings) as pool:
             yield PgQueuerDatabase(pool, settings)
 

--- a/pgqueuer/adapters/tracing/opentelemetry.py
+++ b/pgqueuer/adapters/tracing/opentelemetry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, AsyncIterator, Generator
 
 if TYPE_CHECKING:
     import opentelemetry
@@ -152,7 +152,7 @@ class OpenTelemetryTracing(TracingProtocol):
                         yield {"otel": carrier}
 
     @asynccontextmanager
-    async def trace_process(self, job: Job) -> Any:
+    async def trace_process(self, job: Job) -> AsyncIterator[None]:
         """Extract W3C trace context from job headers and wrap execution in a
         ``CONSUMER`` ``process {destination}`` span.
 

--- a/pgqueuer/adapters/web/auth.py
+++ b/pgqueuer/adapters/web/auth.py
@@ -16,7 +16,7 @@ USER_ENV = "PGQUEUER_WEB_USER"
 PASSWORD_ENV = "PGQUEUER_WEB_PASSWORD"
 
 
-def create_basic_auth_dependency() -> Callable[..., None] | None:
+def create_basic_auth_dependency() -> Callable[[HTTPBasicCredentials], None] | None:
     """HTTP Basic auth dependency from env vars, or None when auth is not configured."""
     user = os.environ.get(USER_ENV)
     password = os.environ.get(PASSWORD_ENV)

--- a/pgqueuer/adapters/web/deps.py
+++ b/pgqueuer/adapters/web/deps.py
@@ -22,4 +22,7 @@ def get_management(request: Request) -> QueueManagementService:
 
 
 def get_broadcaster(request: Request) -> Broadcaster:
-    return request.app.state.pgq_broadcaster
+    broadcaster: object = request.app.state.pgq_broadcaster
+    if not isinstance(broadcaster, Broadcaster):
+        raise RuntimeError("app.state.pgq_broadcaster is not a Broadcaster")
+    return broadcaster

--- a/pgqueuer/core/executors.py
+++ b/pgqueuer/core/executors.py
@@ -25,7 +25,7 @@ AsyncContextCrontab: TypeAlias = Callable[
 ScheduleCrontab: TypeAlias = AsyncCrontab | AsyncContextCrontab
 
 
-def is_async_callable(obj: Callable[..., object] | object) -> bool:
+def is_async_callable(obj: object) -> bool:
     """Return True if *obj* is an async function or async-callable instance."""
     while isinstance(obj, functools.partial):
         obj = obj.func
@@ -35,8 +35,10 @@ def is_async_callable(obj: Callable[..., object] | object) -> bool:
     )
 
 
-def wants_context(func: Callable[..., object], context_type: type) -> bool:
+def wants_context(func: object, context_type: type) -> bool:
     """Return True if func declares a positionally-bindable parameter annotated context_type."""
+    if not callable(func):
+        return False
     # eval_str resolves string/forward-ref annotations (PEP 563) to real types.
     try:
         signature = inspect.signature(func, eval_str=True)
@@ -78,7 +80,7 @@ class EntrypointExecutor(AbstractEntrypointExecutor):
     """Default executor: invokes the registered async entrypoint."""
 
     def __post_init__(self) -> None:
-        if not is_async_callable(cast(Callable[..., object], self.parameters.func)):
+        if not is_async_callable(self.parameters.func):
             raise TypeError(
                 "Entrypoint function must be async (defined with 'async def'). "
                 "Sync entrypoints are no longer supported. "

--- a/test/test_factories.py
+++ b/test/test_factories.py
@@ -131,3 +131,16 @@ def test_validate_rejects_arbitrary_type_with_migration_message() -> None:
 
     msg = str(exc_info.value)
     assert "@asynccontextmanager" in msg
+
+
+def test_load_factory_rejects_non_callable_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_module: Mock = Mock(spec_set=["not_callable"])
+    mock_module.not_callable = 42
+
+    def mock_import_module(module_name: str) -> Any:
+        return mock_module
+
+    monkeypatch.setattr("importlib.import_module", mock_import_module)
+
+    with pytest.raises(TypeError, match="does not resolve to a callable, got int"):
+        load_factory("test_module:not_callable")

--- a/test/test_factory_supervisor_chain.py
+++ b/test/test_factory_supervisor_chain.py
@@ -154,7 +154,7 @@ async def test_coroutine_factory_rejected_with_migration() -> None:
 
     with pytest.raises(TypeError, match="AsyncContextManager") as exc_info:
         await supervisor.runit(
-            factory=factory,  # type: ignore[arg-type]
+            factory=factory,
             dequeue_timeout=timedelta(seconds=1),
             batch_size=10,
             restart_delay=timedelta(seconds=0),
@@ -176,7 +176,7 @@ async def test_sync_cm_factory_rejected_with_migration() -> None:
 
     with pytest.raises(TypeError, match="AsyncContextManager") as exc_info:
         await supervisor.runit(
-            factory=factory,  # type: ignore[arg-type]
+            factory=factory,
             dequeue_timeout=timedelta(seconds=1),
             batch_size=10,
             restart_delay=timedelta(seconds=0),
@@ -196,7 +196,7 @@ async def test_arbitrary_return_rejected_with_migration() -> None:
 
     with pytest.raises(TypeError, match="AsyncContextManager") as exc_info:
         await supervisor.runit(
-            factory=factory,  # type: ignore[arg-type]
+            factory=factory,
             dequeue_timeout=timedelta(seconds=1),
             batch_size=10,
             restart_delay=timedelta(seconds=0),

--- a/test/test_superviser.py
+++ b/test/test_superviser.py
@@ -76,7 +76,7 @@ async def test_setup_shutdown_handlers_invalid_manager(
         pass
 
     with pytest.raises(NotImplementedError, match="Unsupported instance type: .*InvalidManager.*"):
-        supervisor.setup_shutdown_handlers(InvalidManager(), shutdown_event)  # type: ignore[arg-type]
+        supervisor.setup_shutdown_handlers(InvalidManager(), shutdown_event)
 
 
 async def test_setup_signal_handlers(

--- a/tools/prometheus/prometheus.py
+++ b/tools/prometheus/prometheus.py
@@ -19,7 +19,9 @@ ReduceFn: TypeAlias = Callable[[Iterable[float]], float]
 
 def get_queries(request: Request) -> Queries:
     """Retrieve the Queries object from the FastAPI application state."""
-    return request.app.extra["pgq_queries"]
+    pgq_queries = request.app.extra["pgq_queries"]
+    assert isinstance(pgq_queries, Queries)
+    return pgq_queries
 
 
 @asynccontextmanager


### PR DESCRIPTION
Part 6/9 of the strict-mypy series. Stacked on #793; merge in order, I rebase the rest after each merge.

The CLI factory loader returns a Factory protocol (a callable taking
`*args: object`) and raises TypeError when a `module:attr` path does
not resolve to a callable; validate_factory_result() yields `object`
and the supervisor and `pgq` commands narrow with isinstance, so a
factory yielding the wrong type fails with a clear TypeError instead
of an AttributeError later. The web broadcaster dependency, the basic
auth dependency, the MCP server's FastMCP generic and the
OpenTelemetry tracer field get their real types, and the executor
callable probes take `object` and guard with callable().
