### PR TITLE
refactor(core): give EventRouter typed handlers

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -24,9 +24,11 @@ Producer ──enqueue──▶ PostgreSQL ──NOTIFY──▶ EventRouter
 4. The **QueueManager** waits for events, fetches ready jobs with `FOR UPDATE SKIP LOCKED` (see [Row Locking & SKIP LOCKED](skip-locked.md) for the mechanics), and dispatches them to registered entrypoints.
 5. After execution, the **Consumer** updates job status back in PostgreSQL.
 
-`EventRouter` maps notification types to the functions registered via
-`@pgq.entrypoint`. Because the notification arrives over `LISTEN/NOTIFY`, a
-consumer picks up new work without waiting for its next poll.
+`EventRouter` dispatches each notification type to its typed handler: table
+changes feed the listener queue, cancellations cancel the job's scope, and
+health-check echoes resolve the pending probe. Because the notification arrives
+over `LISTEN/NOTIFY`, a consumer picks up new work without waiting for its next
+poll.
 
 ## QueueManager processing loop
 

--- a/pgqueuer/core/listeners.py
+++ b/pgqueuer/core/listeners.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import MutableMapping, TypeAlias, TypeVar
+from typing import MutableMapping
+
+from typing_extensions import assert_never
 
 from pgqueuer.core import logconfig
 from pgqueuer.domain import models, types
 from pgqueuer.ports.driver import Driver
-
-EventHandler: TypeAlias = Callable[[models.Event], None]
-HandlerTypeVar = TypeVar("HandlerTypeVar", bound=Callable[..., None])
 
 
 class PGNoticeEventListener(asyncio.Queue[models.TableChangedEvent]):
@@ -23,27 +22,22 @@ class PGNoticeEventListener(asyncio.Queue[models.TableChangedEvent]):
 
 @dataclass
 class EventRouter:
-    """Dispatch parsed NOTIFY events to exactly one handler per `type`."""
+    """Dispatch a parsed NOTIFY envelope to the handler for its event type."""
 
-    handlers: dict[types.EVENT_TYPES, EventHandler] = field(default_factory=dict, init=False)
-
-    def register(self, event_type: types.EVENT_TYPES) -> Callable[[HandlerTypeVar], HandlerTypeVar]:
-        """Decorator that wires *func* to *event_type*. The function must return `None`."""
-
-        def decorator(func: HandlerTypeVar) -> HandlerTypeVar:
-            if event_type in self.handlers:
-                raise ValueError(f"duplicate handler for {event_type!r}")
-            self.handlers[event_type] = func
-            return func
-
-        return decorator
+    on_table_changed: Callable[[models.TableChangedEvent], None]
+    on_cancellation: Callable[[models.CancellationEvent], None]
+    on_health_check: Callable[[models.HealthCheckEvent], None]
 
     def __call__(self, envelope: models.AnyEvent) -> None:
         event = envelope.root
-        try:
-            self.handlers[event.type](event)
-        except KeyError as exc:
-            raise NotImplementedError(event) from exc
+        if isinstance(event, models.TableChangedEvent):
+            self.on_table_changed(event)
+        elif isinstance(event, models.CancellationEvent):
+            self.on_cancellation(event)
+        elif isinstance(event, models.HealthCheckEvent):
+            self.on_health_check(event)
+        else:
+            assert_never(event)
 
 
 def default_event_router(
@@ -56,24 +50,23 @@ def default_event_router(
 ) -> EventRouter:
     """Return an `EventRouter` wired with handlers for all known event types."""
 
-    router = EventRouter()
-
-    @router.register("table_changed_event")
-    def _table_changed(evt: models.TableChangedEvent) -> None:
+    def on_table_changed(evt: models.TableChangedEvent) -> None:
         notice_event_queue.put_nowait(evt)
 
-    @router.register("cancellation_event")
-    def _cancellation(evt: models.CancellationEvent) -> None:
+    def on_cancellation(evt: models.CancellationEvent) -> None:
         for jid in evt.ids:
             if ctx := canceled.get(jid):
                 ctx.cancellation.cancel()
 
-    @router.register("health_check_event")
-    def _health_check_event(evt: models.HealthCheckEvent) -> None:
+    def on_health_check(evt: models.HealthCheckEvent) -> None:
         if (fut := pending_health_check.get(evt.id)) and not fut.done():
             fut.set_result(evt)
 
-    return router
+    return EventRouter(
+        on_table_changed=on_table_changed,
+        on_cancellation=on_cancellation,
+        on_health_check=on_health_check,
+    )
 
 
 async def initialize_notice_event_listener(

--- a/test/test_listeners.py
+++ b/test/test_listeners.py
@@ -225,17 +225,10 @@ async def test_pgqueuer_heartbeat_event_trigger(apgdriver: db.Driver) -> None:
     assert len(evnets) == 0
 
 
-def test_event_router_dispatches_correct_handler() -> None:
-    router = EventRouter()
-    called = {"flag": False}
-
-    @router.register("table_changed_event")
-    def _handle(evt: TableChangedEvent) -> None:
-        called["flag"] = evt.table == "jobs_table"
-
-    event = AnyEvent(
+def _table_changed_event() -> AnyEvent:
+    return AnyEvent(
         root=TableChangedEvent(
-            channel="chan",
+            channel=Channel("chan"),
             sent_at=datetime.now(tz=timezone.utc),
             type="table_changed_event",
             operation="insert",
@@ -243,36 +236,46 @@ def test_event_router_dispatches_correct_handler() -> None:
         )
     )
 
-    router(event)
-    assert called["flag"] is True
+
+def test_event_router_dispatches_table_changed_to_its_handler() -> None:
+    seen: list[TableChangedEvent] = []
+    router = EventRouter(
+        on_table_changed=seen.append,
+        on_cancellation=lambda evt: pytest.fail(f"unexpected {evt!r}"),
+        on_health_check=lambda evt: pytest.fail(f"unexpected {evt!r}"),
+    )
+
+    router(_table_changed_event())
+
+    assert [evt.table for evt in seen] == ["jobs_table"]
 
 
-def test_event_router_duplicate_registration_raises() -> None:
-    router = EventRouter()
+def test_event_router_dispatches_each_type_once() -> None:
+    hits: list[str] = []
+    router = EventRouter(
+        on_table_changed=lambda evt: hits.append(evt.type),
+        on_cancellation=lambda evt: hits.append(evt.type),
+        on_health_check=lambda evt: hits.append(evt.type),
+    )
+    sent_at = datetime.now(tz=timezone.utc)
 
-    @router.register("table_changed_event")
-    def _handler(evt: TableChangedEvent) -> None:
-        pass
-
-    with pytest.raises(ValueError):
-
-        @router.register("table_changed_event")
-        def _another(evt: TableChangedEvent) -> None:
-            pass
-
-
-def test_event_router_missing_handler_raises() -> None:
-    router = EventRouter()
-
-    event = AnyEvent(
-        root=TableChangedEvent(
-            channel="chan",
-            sent_at=datetime.now(tz=timezone.utc),
-            type="table_changed_event",
-            operation="insert",
-            table="jobs_table",
+    router(_table_changed_event())
+    router(
+        AnyEvent(
+            root=CancellationEvent(
+                channel=Channel("chan"), sent_at=sent_at, type="cancellation_event", ids=[]
+            )
+        )
+    )
+    router(
+        AnyEvent(
+            root=HealthCheckEvent(
+                channel=Channel("chan"),
+                sent_at=sent_at,
+                type="health_check_event",
+                id=HealthCheckId(uuid.uuid4()),
+            )
         )
     )
 
-    with pytest.raises(NotImplementedError):
-        router(event)
+    assert hits == ["table_changed_event", "cancellation_event", "health_check_event"]


### PR DESCRIPTION
Part 7/9 of the strict-mypy series. Stacked on #794; merge in order, I rebase the rest after each merge.

EventRouter takes one typed handler per event type and dispatches
with an exhaustive isinstance chain, so each handler receives the
concrete event class and mypy proves every event type is handled. The
string-keyed register() decorator is gone; it could only be typed as
Callable[..., None]. default_event_router() wires the same three
handlers as before.
