### PR TITLE
chore(typing): move mypy to strict and ban Any inside pgqueuer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ When deprecating dataclass fields, use a module-level `_SENTINEL = object()` def
 - **Formatter/linter**: ruff (line-length=100)
 - **Lint rules**: C, E, F, I, PIE, Q, RET, RSE, SIM, W, C90 (max-complexity=15)
 - **isort**: combined-as-imports, furthest-to-closest relative imports
-- **Mypy** strict mode with Pydantic plugin, targets Python 3.10.
+- **Mypy** `strict = true` plus `warn_unreachable` and the error codes `truthy-bool`, `truthy-iterable`, `redundant-expr`, `unused-awaitable`, `possibly-undefined`, `ignore-without-code`; Pydantic plugin with `init_typed`; targets Python 3.10. Inside `pgqueuer/` the override adds `disallow_any_explicit` and `disallow_any_unimported`. Run it as `uv run mypy . --no-incremental`; the incremental cache has reported green on stale signatures.
 
 ### Import Rules
 
@@ -156,13 +156,14 @@ When deprecating dataclass fields, use a module-level `_SENTINEL = object()` def
 ### Type Annotations
 
 - **Always annotate** all function/method signatures (`mypy: disallow_untyped_defs = true`)
-- Use **native Python types**: `list[int]`, `dict[str, Any]`, `int | None` (not `Optional`)
+- Use **native Python types**: `list[int]`, `dict[str, object]`, `int | None` (not `Optional`)
 - Use `NewType` for domain primitives: `JobId = NewType("JobId", int)`
 - Use `Literal` for string unions: `Literal["queued", "picked", "successful"]`
 - **Exhaustive dispatch.** When branching on a `Literal` or `Enum` value, handle every member in an explicit `if`/`elif` chain and terminate with `else: assert_never(value)` (`typing_extensions.assert_never`) so mypy proves totality. No bare fallthroughs, no catch-all `else` doing real work — adding a new member must produce a type error at every dispatch site.
 - Use `Protocol` for structural subtyping (port interfaces)
 - Use `TypeAlias` for complex callable types
-- **Avoid `Any`** at nearly all cost. The codebase only uses it on driver protocol boundaries for variadic `*args` in SQL query methods -- nowhere else. Use proper types, generics, protocols, or `object` instead.
+- **`Any` is banned in `pgqueuer/`** (`disallow_any_explicit`). Use `object` and narrow with `isinstance`. Driver `*args` are `object`; rows come back as `dict[str, object]` and scalars are read through `query_helpers.cell(row, key, kind)`, multi-column rows through a pydantic model. User-owned bags (`Context.resources`) are `MutableMapping[str, object]`. `Callable[..., X]` counts as `Any`; declare a `Protocol` with `__call__(self, *args: object)` instead. Untyped third-party values are assigned to an `object`-annotated name before an `isinstance` check. Test code may use `Any`.
+- **Import domain types from `pgqueuer.domain.types`**, never via `models.JobId`; `no_implicit_reexport` is on and only the top-level shims re-export.
 - **Generic constructors over type-annotated assignments** for typed stdlib objects: `fut = asyncio.Future[MyType]()` not `fut: asyncio.Future[MyType] = asyncio.Future()`.
 - **No `# type: ignore` in production code.** `type: ignore` comments are forbidden in `pgqueuer/`. Fix the underlying type issue instead (use `dataclasses.KW_ONLY`, protocols, generics, overloads, etc.). `# type: ignore` is acceptable in test code only.
 
@@ -189,7 +190,7 @@ if isinstance(exc, SqlStateError) and isinstance(exc.sqlstate, str):
     return exc.sqlstate
 ```
 
-Two grandfathered call sites remain: `domain/settings.py` iterating declared dataclass fields, and `core/executors.py` probing `__call__`. Add no more; replace them when the code is next touched.
+Three grandfathered call sites remain: `domain/settings.py` iterating declared dataclass fields, `core/executors.py` probing `__call__`, and `adapters/cli/factories.py` resolving a `module:attr` path. Add no more; replace them when the code is next touched.
 
 Test code may use reflection where the test is *about* reflection. `monkeypatch.setattr` is pytest's API, not the builtin, and is unaffected.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -84,6 +84,22 @@ wins; nothing validates or rejects the mismatch.
   bare `uuid.uuid4()` needs `QueueManagerId(uuid.uuid4())` to pass mypy.
 - Type annotations only, no runtime change: `notify_health_check()` takes
   `HealthCheckId` instead of `uuid.UUID`.
+- mypy now runs in `strict` mode with `Any` banned inside `pgqueuer/`. Public
+  signatures tightened as a result: `Driver.fetch()`/`execute()` take
+  `*args: object` and rows are `list[dict[str, object]]`; `Job.headers` and
+  `TracebackRecord.additional_context` are `dict[str, object]`;
+  `Context.resources` / `ScheduleContext.resources` are
+  `MutableMapping[str, object]`, so readers narrow with `isinstance`;
+  `TracingProtocol.trace_publish()` yields `dict[str, object]`;
+  `load_factory()` returns a `Factory` protocol; `EventRouter` takes three typed
+  handlers instead of a `register()` decorator; `ScheduleExecutorFactoryParameters`
+  uses `CronEntrypoint`/`CronExpression`.
+- `Job.headers` also accepts an already-parsed dict on construction, not only
+  JSON text.
+- `load_factory()` raises `TypeError` when the `module:attr` path is not
+  callable, and `pgq` commands raise `TypeError` when a factory yields
+  something other than `Queries`, instead of failing later with an
+  `AttributeError`.
 - `QueryQueueBuilder.build_dequeue_query()` and `build_log_statistics_query()`
   take keyword-only arguments and return a `ComposedQuery` (`.sql`, `.args`)
   instead of a SQL string. Both are internal but reachable via `Queries.qbq`.

--- a/pgqueuer/core/tm.py
+++ b/pgqueuer/core/tm.py
@@ -51,10 +51,11 @@ class TaskManager:
 
     async def gather_tasks(self, return_exceptions: bool = True) -> list[object]:
         """Await every tracked task and return per-task results/exceptions."""
-        return await asyncio.gather(
+        results: list[object] = await asyncio.gather(
             *self.tasks,
             return_exceptions=return_exceptions,
         )
+        return results
 
     async def __aenter__(self) -> TaskManager:
         return self

--- a/pgqueuer/domain/settings.py
+++ b/pgqueuer/domain/settings.py
@@ -160,6 +160,7 @@ class DBSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="PGQUEUER_",
         extra="ignore",
+        populate_by_name=True,
     )
 
     # Prepended to every object name not explicitly overridden; lets multiple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,17 +146,30 @@ relative-imports-order = "furthest-to-closest"
 force-single-line = false
 
 [tool.mypy]
-disallow_untyped_defs = true
-exclude = "^(build)"
-extra_checks = true
-ignore_missing_imports = true
+strict = true
 plugins = ["pydantic.mypy"]
 python_version = "3.10"
-strict_equality = true
-warn_redundant_casts = true
-warn_unused_configs = true
-warn_unused_ignores = true
+exclude = "^(build)"
+ignore_missing_imports = true
 explicit_package_bases = true
+warn_unreachable = true
+enable_error_code = [
+    "truthy-bool",
+    "truthy-iterable",
+    "redundant-expr",
+    "unused-awaitable",
+    "possibly-undefined",
+    "ignore-without-code",
+]
+
+[tool.pydantic-mypy]
+init_typed = true
+init_forbid_extra = true
+
+[[tool.mypy.overrides]]
+module = "pgqueuer.*"
+disallow_any_explicit = true
+disallow_any_unimported = true
 
 [[tool.mypy.overrides]]
 module = "test.*"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,7 +63,7 @@ def queries(driver: InMemoryDriver) -> InMemoryQueries:
     return InMemoryQueries(driver=driver)
 
 
-class PgQueuerPostgresContainer(DockerContainer):
+class PgQueuerPostgresContainer(DockerContainer):  # type: ignore[misc]
     """Postgres container with modern wait strategy support
     (libpq env defaults: PGUSER, PGPASSWORD, PGDATABASE, PGPORT)."""
 

--- a/test/integration/test_persistence_queries_sql.py
+++ b/test/integration/test_persistence_queries_sql.py
@@ -19,7 +19,13 @@ import pytest
 from pgqueuer.adapters.persistence.queries import Queries
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.models import CronExpressionEntrypoint, TracebackRecord
-from pgqueuer.domain.types import CronEntrypoint, CronExpression, QueueEntrypoint, QueueManagerId
+from pgqueuer.domain.types import (
+    CronEntrypoint,
+    CronExpression,
+    JobId,
+    QueueEntrypoint,
+    QueueManagerId,
+)
 from pgqueuer.ports.repository import EntrypointExecutionParameter
 
 
@@ -274,7 +280,7 @@ async def test_traceback_jsonb_roundtrip(
     job = jobs[0]
 
     tb_record = TracebackRecord(
-        job_id=int(jids[0]),
+        job_id=JobId(int(jids[0])),
         timestamp=datetime.now(timezone.utc),
         exception_type="ValueError",
         exception_message="test error",

--- a/test/test_factory_supervisor_chain.py
+++ b/test/test_factory_supervisor_chain.py
@@ -315,7 +315,7 @@ async def test_asynccm_factory_setup_raises_propagates() -> None:
     @asynccontextmanager
     async def factory() -> AsyncGenerator[PgQueuer, None]:
         raise RuntimeError("setup failed")
-        yield  # unreachable, needed for generator
+        yield  # type: ignore[unreachable]  # keeps this a generator
 
     with pytest.raises(RuntimeError, match="setup failed"):
         await supervisor.runit(
@@ -361,7 +361,7 @@ async def test_factory_raises_restart_on_failure_retries() -> None:
         nonlocal call_count
         call_count += 1
         raise RuntimeError("transient error")
-        yield  # unreachable, needed for generator
+        yield  # type: ignore[unreachable]  # keeps this a generator
 
     shutdown = asyncio.Event()
     task = asyncio.create_task(

--- a/test/test_future_guards.py
+++ b/test/test_future_guards.py
@@ -11,7 +11,7 @@ from pgqueuer.core.listeners import (
     PGNoticeEventListener,
     default_event_router,
 )
-from pgqueuer.domain.types import HealthCheckId
+from pgqueuer.domain.types import Channel, HealthCheckId
 from pgqueuer.models import (
     AnyEvent,
     Context,
@@ -32,10 +32,10 @@ async def test_health_check_callback_ignores_done_future() -> None:
 
     event = AnyEvent(
         root=HealthCheckEvent(
-            channel="ch",
+            channel=Channel("ch"),
             sent_at=datetime.now(timezone.utc),
             type="health_check_event",
-            id=uuid.uuid4(),
+            id=HealthCheckId(uuid.uuid4()),
         )
     )
     assert isinstance(event.root, HealthCheckEvent)
@@ -61,10 +61,10 @@ async def test_health_check_callback_ignores_cancelled_future() -> None:
 
     event = AnyEvent(
         root=HealthCheckEvent(
-            channel="ch",
+            channel=Channel("ch"),
             sent_at=datetime.now(timezone.utc),
             type="health_check_event",
-            id=uuid.uuid4(),
+            id=HealthCheckId(uuid.uuid4()),
         )
     )
     assert isinstance(event.root, HealthCheckEvent)

--- a/test/test_insights_service.py
+++ b/test/test_insights_service.py
@@ -172,14 +172,18 @@ class TestSparklineBuckets:
     def test_counts_are_conserved(self) -> None:
         now = models.utc_now()
         series = [
-            models.ThroughputBucket(bucket=now, entrypoint="ep", status="successful", count=3),
+            models.ThroughputBucket(
+                bucket=now, entrypoint=QueueEntrypoint("ep"), status="successful", count=3
+            ),
             models.ThroughputBucket(
                 bucket=now - timedelta(minutes=30),
-                entrypoint="ep",
+                entrypoint=QueueEntrypoint("ep"),
                 status="exception",
                 count=2,
             ),
-            models.ThroughputBucket(bucket=now, entrypoint="other", status="successful", count=9),
+            models.ThroughputBucket(
+                bucket=now, entrypoint=QueueEntrypoint("other"), status="successful", count=9
+            ),
         ]
         buckets = sparkline_buckets(series, "ep", timedelta(hours=1))
         assert sum(buckets) == 5

--- a/test/test_listeners.py
+++ b/test/test_listeners.py
@@ -15,11 +15,10 @@ from pgqueuer.core.listeners import (
     initialize_notice_event_listener,
 )
 from pgqueuer.domain.settings import DBSettings
-from pgqueuer.domain.types import HealthCheckId, QueueEntrypoint, QueueManagerId
+from pgqueuer.domain.types import Channel, HealthCheckId, QueueEntrypoint, QueueManagerId
 from pgqueuer.models import (
     AnyEvent,
     CancellationEvent,
-    Channel,
     Context,
     HealthCheckEvent,
     JobId,
@@ -35,7 +34,7 @@ async def test_handle_table_changed_event() -> None:
 
     event = AnyEvent(
         root=TableChangedEvent(
-            channel="channel_1",
+            channel=Channel("channel_1"),
             sent_at=datetime.now(tz=timezone.utc),
             type="table_changed_event",
             operation="insert",
@@ -65,7 +64,7 @@ async def test_handle_cancellation_event() -> None:
 
     event = AnyEvent(
         root=CancellationEvent(
-            channel="channel_1",
+            channel=Channel("channel_1"),
             sent_at=datetime.now(tz=timezone.utc),
             type="cancellation_event",
             ids=[job_id],
@@ -88,10 +87,10 @@ async def test_handle_health_check_event_event() -> None:
 
     event = AnyEvent(
         root=HealthCheckEvent(
-            channel="channel_1",
+            channel=Channel("channel_1"),
             sent_at=datetime.now(timezone.utc),
             type="health_check_event",
-            id=uuid.uuid4(),
+            id=HealthCheckId(uuid.uuid4()),
         )
     )
     assert isinstance(event.root, HealthCheckEvent)

--- a/test/test_metrics_prometheus.py
+++ b/test/test_metrics_prometheus.py
@@ -6,6 +6,7 @@ from typing import cast
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from pgqueuer.domain.types import QueueEntrypoint
 from pgqueuer.metrics import prometheus as metrics
 from pgqueuer.metrics.fastapi import create_metrics_router
 from pgqueuer.models import LogStatistics, QueueStatistics
@@ -52,10 +53,12 @@ def test_custom_metric_names_are_used() -> None:
         queue_count="custom_queue_count",
         log_count="custom_log_count",
     )
-    queue_stats = [QueueStatistics(entrypoint="main", status="queued", count=2, priority=0)]
+    queue_stats = [
+        QueueStatistics(entrypoint=QueueEntrypoint("main"), status="queued", count=2, priority=0)
+    ]
     log_stats = [
         LogStatistics(
-            entrypoint="main",
+            entrypoint=QueueEntrypoint("main"),
             status="successful",
             count=5,
             priority=0,
@@ -84,11 +87,13 @@ async def test_collect_metrics_returns_payload() -> None:
 
 async def test_collect_metrics_with_statistics() -> None:
     queue_stats = [
-        QueueStatistics(entrypoint="worker", status="queued", count=10, priority=0),
+        QueueStatistics(
+            entrypoint=QueueEntrypoint("worker"), status="queued", count=10, priority=0
+        ),
     ]
     log_stats = [
         LogStatistics(
-            entrypoint="worker",
+            entrypoint=QueueEntrypoint("worker"),
             status="successful",
             count=25,
             priority=0,

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -543,7 +543,7 @@ async def test_queue_log_fetches_inserted_rows(apgdriver: db.Driver) -> None:
     logs = await q.queue_log()
 
     assert sorted(logs, key=lambda log: log.job_id) == sorted(
-        [models.Log(**entry) for entry in entries], key=lambda log: log.job_id
+        [models.Log.model_validate(entry) for entry in entries], key=lambda log: log.job_id
     )
 
 

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -8,6 +8,7 @@ import pytest
 from pgqueuer.adapters.inmemory import InMemoryQueries
 from pgqueuer.db import AsyncpgDriver
 from pgqueuer.domain.settings import DBSettings
+from pgqueuer.domain.types import ScheduleId
 from pgqueuer.executors import (
     ScheduleExecutor,
     ScheduleExecutorFactoryParameters,
@@ -420,7 +421,7 @@ async def test_schedule_executor_without_context() -> None:
     executor = ScheduleExecutor(parameters=params)
 
     fake_schedule = Schedule(
-        id=1,
+        id=ScheduleId(1),
         expression=CronExpression("* * * * *"),
         heartbeat=datetime.now(timezone.utc),
         created=datetime.now(timezone.utc),
@@ -453,7 +454,7 @@ async def test_schedule_executor_with_context() -> None:
     executor = ScheduleExecutor(parameters=params)
 
     fake_schedule = Schedule(
-        id=1,
+        id=ScheduleId(1),
         expression=CronExpression("* * * * *"),
         heartbeat=datetime.now(timezone.utc),
         created=datetime.now(timezone.utc),

--- a/test/test_sqlstate.py
+++ b/test/test_sqlstate.py
@@ -113,7 +113,7 @@ class _FetchBoom:
     def __init__(self, exc: Exception) -> None:
         self.exc = exc
 
-    async def fetch(self, query: str, *args: object) -> list[dict]:
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
         raise self.exc
 
 

--- a/test/test_tracing_sentry_status.py
+++ b/test/test_tracing_sentry_status.py
@@ -60,7 +60,9 @@ def transactions() -> Iterator[list[dict[str, Any]]]:
 def _status(transactions: list[dict[str, Any]]) -> str:
     consumer = [t for t in transactions if t.get("transaction") == "queue_consumer_transaction"]
     assert len(consumer) == 1, [t.get("transaction") for t in transactions]
-    return consumer[0]["contexts"]["trace"]["status"]
+    status = consumer[0]["contexts"]["trace"]["status"]
+    assert isinstance(status, str)
+    return status
 
 
 async def test_status_ok_on_success(transactions: list[dict[str, Any]]) -> None:

--- a/test/test_web_routes.py
+++ b/test/test_web_routes.py
@@ -399,7 +399,7 @@ class TestChartSlots:
     ) -> models.ThroughputBucket:
         return models.ThroughputBucket(
             bucket=self.now() - timedelta(minutes=minutes_ago),
-            entrypoint="ep",
+            entrypoint=QueueEntrypoint("ep"),
             status=status,
             count=count,
         )


### PR DESCRIPTION
Part 9/9 of the strict-mypy series. Stacked on #796; merge in order, I rebase the rest after each merge.

Turn on `strict = true`, `warn_unreachable` and the bug-finding error
codes (truthy-bool, truthy-iterable, redundant-expr, unused-awaitable,
possibly-undefined, ignore-without-code). Inside pgqueuer/ an override
adds `disallow_any_explicit` and `disallow_any_unimported`; tests stay
strict but may use Any. The pydantic plugin runs with `init_typed` and
`init_forbid_extra`, so model constructors are checked like any other
signature; DBSettings needs `populate_by_name` for the plugin to type
its AliasChoices fields.

Tests that built models from bare literals now wrap them in the domain
NewTypes or go through model_validate(). AGENTS.md documents the new
rules and RELEASE.md lists every public signature that moved across
the typing series.
