### PR TITLE
docs: correct the stale mypy flag reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ When deprecating dataclass fields, use a module-level `_SENTINEL = object()` def
 
 ### Type Annotations
 
-- **Always annotate** all function/method signatures (`mypy: disallow_untyped_defs = true`)
+- **Always annotate** all function/method signatures (`strict = true` implies `disallow_untyped_defs`)
 - Use **native Python types**: `list[int]`, `dict[str, object]`, `int | None` (not `Optional`)
 - Use `NewType` for domain primitives: `JobId = NewType("JobId", int)`
 - Use `Literal` for string unions: `Literal["queued", "picked", "successful"]`


### PR DESCRIPTION
Tail-end cleanup from the strict-mypy series (#789–#799).

The **Type Annotations** rule cited `mypy: disallow_untyped_defs = true` as the enforcing setting. That flag is no longer written in `pyproject.toml` — `strict = true` subsumes it — so a reader grepping for it finds nothing. Reworded to say `strict = true` implies it.

Docs only; no code or config change.